### PR TITLE
Add LoadImageRaw to ImageUtils as a way of loading a Sprite from byte array

### DIFF
--- a/S1API/Internal/Utils/ImageUtils.cs
+++ b/S1API/Internal/Utils/ImageUtils.cs
@@ -31,6 +31,27 @@ namespace S1API.Internal.Utils
             try
             {
                 byte[] data = File.ReadAllBytes(fullPath);
+                return LoadImageRaw(data);
+            }
+            catch (System.Exception ex)
+            {
+                _loggerInstance.Error("❌ Failed to load sprite: " + ex);
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Loads an image from a byte array and converts it into a Sprite object.
+        /// <param name="data">The byte array containing the image data to load.</param>
+        /// <returns>
+        /// A Sprite object representing the loaded image, or null if the image could not be loaded.
+        /// </returns>
+        /// </summary>
+        public static Sprite? LoadImageRaw(byte[] data)
+        {
+            try
+            {
                 Texture2D tex = new Texture2D(2, 2);
                 if (tex.LoadImage(data))
                 {
@@ -41,7 +62,6 @@ namespace S1API.Internal.Utils
             {
                 _loggerInstance.Error("❌ Failed to load sprite: " + ex);
             }
-
             return null;
         }
     }


### PR DESCRIPTION
IL2CPP breaks `Texture2DInst.LoadImage(byte[])` when not compiled against Unity IL2CPP assemblies.
```
 System.MissingMethodException: Method not found: 'Boolean UnityEngine.ImageConversion.LoadImage(UnityEngine.Texture2D, Byte[])'.
 ```
Allowing modders for loading a sprite from byte arrays can allow them to load a Sprite from embedded resources, while staying in Managed environment.

Usage example:
```cs
public static Sprite LoadEmbeddedPNG(string resourceName)
{
    var asm = Assembly.GetExecutingAssembly();

    using Stream stream = asm.GetManifestResourceStream(resourceName);
    if (stream == null) return null;

    var data = new byte[stream.Length];
    stream.Read(data, 0, data.Length);
    return ImageUtils.LoadImageRaw(data);
}
```