### PR TITLE
Hotfix for 0.4.1f3

### DIFF
--- a/S1API/Internal/Patches/CallManagerPatches.cs
+++ b/S1API/Internal/Patches/CallManagerPatches.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using HarmonyLib;
 using MelonLoader;
 using S1API.PhoneCalls;
@@ -23,6 +24,11 @@ namespace S1API.Internal.Patches
     internal static class CallManagerPatches
     {
         /// <summary>
+        /// Cached reflection FieldInfo for CallManager.QueuedCallData
+        /// </summary>
+        private static FieldInfo? _queuedCallDataField;
+
+        /// <summary>
         /// Intercept game QueueCall and route to S1API queue unless we're currently
         /// dispatching to the game (to avoid recursion).
         /// </summary>
@@ -41,9 +47,18 @@ namespace S1API.Internal.Patches
                 return true; // no game manager yet; let original handle or no-op safely
             }
 
+            if (_queuedCallDataField == null)
+            {
+                _queuedCallDataField = typeof(S1Calling.CallManager).GetField("QueuedCallData", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (_queuedCallDataField == null)
+                {
+                    try { MelonLogger.Warning("[CallManagerPatches] Failed to find QueuedCallData field via reflection."); } catch { }
+                    return true;
+                }
+            }
             // If the game already has a call queued, route additional calls through S1API
             // so ordering is preserved without re-entering the game's QueueCall here.
-            if (gameCallManager.QueuedCallData != null)
+            if (_queuedCallDataField.GetValue(gameCallManager) != null)
             {
                 CallManager.QueueCall(data);
                 return false; // skip original to avoid clobbering and recursion

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -150,16 +150,16 @@ namespace S1API.Internal.Patches
             if (__instance.StartupItems == null)
                 __instance.StartupItems =
  new Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<Il2CppScheduleOne.ItemFramework.ItemDefinition>(0);
-            if (__instance.RandomItemDefinitions == null)
-                __instance.RandomItemDefinitions =
- new Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<Il2CppScheduleOne.ItemFramework.StorableItemDefinition>(0);
+            if (__instance.RandomInventoryItems == null)
+                __instance.RandomInventoryItems =
+ new Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<S1NPCs.NPCInventory.RandomInventoryItem>(0);
 #else
             if (__instance.TestItems == null)
                 __instance.TestItems = Array.Empty<ScheduleOne.ItemFramework.ItemDefinition>();
             if (__instance.StartupItems == null)
                 __instance.StartupItems = Array.Empty<ScheduleOne.ItemFramework.ItemDefinition>();
-            if (__instance.RandomItemDefinitions == null)
-                __instance.RandomItemDefinitions = Array.Empty<ScheduleOne.ItemFramework.StorableItemDefinition>();
+            if (__instance.RandomInventoryItems == null)
+                __instance.RandomInventoryItems = Array.Empty<S1NPCs.NPCInventory.RandomInventoryItem>();
 #endif
         }
 
@@ -831,14 +831,14 @@ namespace S1API.Internal.Patches
                 }
 
                 // Random items (local-only)
-                if (__instance.RandomItems && __instance.RandomItemDefinitions != null &&
-                    __instance.RandomItemDefinitions.Length > 0)
+                if (__instance.RandomItems && __instance.RandomInventoryItems != null &&
+                    __instance.RandomInventoryItems.Length > 0)
                 {
                     int count = UnityEngine.Random.Range(__instance.RandomItemMin, __instance.RandomItemMax + 1);
                     for (int i = 0; i < count; i++)
                     {
-                        var def = __instance.RandomItemDefinitions[
-                            UnityEngine.Random.Range(0, __instance.RandomItemDefinitions.Length)];
+                        var def = __instance.RandomInventoryItems[
+                            UnityEngine.Random.Range(0, __instance.RandomInventoryItems.Length)].ItemDefinition;
                         var inst = def.GetDefaultInstance();
                         __instance.InsertItem(inst, network: false);
                     }

--- a/S1API/PhoneCalls/CallManager.cs
+++ b/S1API/PhoneCalls/CallManager.cs
@@ -12,6 +12,7 @@ using ActionPhoneCall = System.Action<ScheduleOne.ScriptableObjects.PhoneCallDat
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using MelonLoader;
 
 namespace S1API.PhoneCalls
 {
@@ -22,6 +23,7 @@ namespace S1API.PhoneCalls
     public static class CallManager
     {
         private static readonly Queue<S1ScriptableObjects.PhoneCallData> PendingCalls = new();
+        private static FieldInfo? _queuedCallDataField;
         internal static bool IsDispatchingToGameQueue;
 
         /// <summary>
@@ -76,8 +78,17 @@ namespace S1API.PhoneCalls
 
             if (S1UIPhone.CallInterface.Instance == null) return;
 
+            if (_queuedCallDataField == null)
+            {
+                _queuedCallDataField = typeof(S1Calling.CallManager).GetField("QueuedCallData", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (_queuedCallDataField == null)
+                {
+                    try { MelonLogger.Warning("[CallManager] Failed to find QueuedCallData field via reflection."); } catch { }
+                    return;
+                }
+            }
             // If the game already has a queued call, wait until it is consumed/completed.
-            if (gameCallManager.QueuedCallData != null)
+            if (_queuedCallDataField.GetValue(gameCallManager) != null)
             {
                 return;
             }


### PR DESCRIPTION
On the latest beta S1API breaks functionalities of in-game NPCs ex. pickpocket intobj doesn't exist. Users also have reported issues with accessing NPC inventory in general, as in employees or dealers.

Changes summary:
- Changed `QueuedDataField` in CallManager classes to use reflection. This change is needed, as in 1f2 this field's visibility was changed to private.
- Changed `NPCInventory.RandomItemDefinitions` to `NPCInventory.RandomInventoryItems`, as the former does no longer exist in 1f3.

Since this game version (at the time of writing) is exclusive to beta branches and less than 24hrs old, I'm putting those changes as a PR - as to not pollute stable with beta changes.