### PR TITLE
Add Name property to StorageEntity

### DIFF
--- a/S1API/Storage/StorageEntity.cs
+++ b/S1API/Storage/StorageEntity.cs
@@ -54,6 +54,15 @@ namespace S1API.Storage
         // ====== Properties ======
 
         /// <summary>
+        /// The display name of this storage container shown in the UI.
+        /// </summary>
+        public string Name
+        {
+            get => S1StorageEntity.StorageEntityName;
+            set => S1StorageEntity.StorageEntityName = value;
+        }
+
+        /// <summary>
         /// Current number of slots in this storage container.
         /// Setting this value will add or remove slots as needed.
         /// </summary>


### PR DESCRIPTION
Introduces a Name property to StorageEntity for managing the display name of the storage container in the UI. The property gets and sets the StorageEntityName field in S1StorageEntity.

<img width="560" height="413" alt="image" src="https://github.com/user-attachments/assets/bf742843-5136-4b13-a9d3-93de5bb8398d" />
