### PR TITLE
v0.4.2f4 fixes

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -2945,7 +2945,6 @@ namespace S1API.Entities
                     "NPCSignal_WaitForDelivery",
                     "NPCSignal_UseVendingMachine",
                     "NPCSignal_UseATM",
-                    "NPCSignal_HandleDeal",
                     "NPCSignal_DriveToCarPark",
                     "NPCEvent_StayInBuilding",
                     "NPCEvent_Sit",

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -4,6 +4,7 @@ using S1Quests = Il2CppScheduleOne.Quests;
 using S1Economy = Il2CppScheduleOne.Economy;
 using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1NPCsSchedules = Il2CppScheduleOne.NPCs.Schedules;
+using S1NPCsBehaviour = Il2CppScheduleOne.NPCs.Behaviour;
 using S1Items = Il2CppScheduleOne.ItemFramework;
 using S1Messaging = Il2CppScheduleOne.Messaging;
 using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
@@ -14,6 +15,7 @@ using S1Quests = ScheduleOne.Quests;
 using S1NPCs = ScheduleOne.NPCs;
 using S1Economy = ScheduleOne.Economy;
 using S1NPCsSchedules = ScheduleOne.NPCs.Schedules;
+using S1NPCsBehaviour = ScheduleOne.NPCs.Behaviour;
 using S1Items = ScheduleOne.ItemFramework;
 using S1Messaging = ScheduleOne.Messaging;
 using S1DevUtilities = ScheduleOne.DevUtilities;
@@ -821,34 +823,31 @@ namespace S1API.Entities
                 }
 #endif
 
-                // Ensure DealSignal exists for dealer schedule
+                // Ensure DealerAttendDealBehaviour exists (replaced NPCSignal_HandleDeal in v0.4.2f4)
                 try
                 {
-#if MONOMELON
-                    var dealSignalField = typeof(S1Economy.Dealer).GetField("DealSignal", BindingFlags.Public | BindingFlags.Instance);
-#else
-                    var dealSignalField = typeof(S1Economy.Dealer).GetProperty("DealSignal", BindingFlags.Public | BindingFlags.Instance);
-#endif
-                    var existingSignal = dealSignalField?.GetValue(dealer) as S1NPCsSchedules.NPCSignal_HandleDeal;
-                    if (existingSignal == null)
+                    var attendDealField = typeof(S1Economy.Dealer).GetField("_attendDealBehaviour", BindingFlags.NonPublic | BindingFlags.Instance);
+                    var existingBehaviour = attendDealField?.GetValue(dealer) as S1NPCsBehaviour.DealerAttendDealBehaviour;
+                    if (existingBehaviour == null)
                     {
-                        var sched = NPC.gameObject.GetComponentInChildren<S1NPCs.NPCScheduleManager>(true);
-                        if (sched == null)
+                        // Get or create NPCBehaviour manager
+                        var npcBehaviour = NPC.gameObject.GetComponentInChildren<S1NPCsBehaviour.NPCBehaviour>(true);
+                        if (npcBehaviour == null)
                         {
-                            var schedGo = new GameObject("NPCScheduleManager");
-                            schedGo.transform.SetParent(NPC.gameObject.transform, false);
-                            sched = schedGo.AddComponent<S1NPCs.NPCScheduleManager>();
+                            var behGo = new GameObject("NPCBehaviour");
+                            behGo.transform.SetParent(NPC.gameObject.transform, false);
+                            npcBehaviour = behGo.AddComponent<S1NPCsBehaviour.NPCBehaviour>();
                         }
 
-                        var signal = NPC.gameObject.GetComponentInChildren<S1NPCsSchedules.NPCSignal_HandleDeal>(true);
-                        if (signal == null)
+                        var behaviour = NPC.gameObject.GetComponentInChildren<S1NPCsBehaviour.DealerAttendDealBehaviour>(true);
+                        if (behaviour == null)
                         {
-                            var go = new GameObject("DealSignal");
-                            go.transform.SetParent(sched.transform, false);
-                            signal = go.AddComponent<S1NPCsSchedules.NPCSignal_HandleDeal>();
+                            var go = new GameObject("DealerAttendDealBehaviour");
+                            go.transform.SetParent(npcBehaviour.transform, false);
+                            behaviour = go.AddComponent<S1NPCsBehaviour.DealerAttendDealBehaviour>();
                             go.SetActive(false);
                         }
-                        dealSignalField?.SetValue(dealer, signal);
+                        attendDealField?.SetValue(dealer, behaviour);
                     }
                 }
                 catch { /* ignore */ }

--- a/S1API/Entities/NPCPrefabBuilder.cs
+++ b/S1API/Entities/NPCPrefabBuilder.cs
@@ -1,6 +1,7 @@
 #if (IL2CPPMELON)
 using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1NPCsSchedules = Il2CppScheduleOne.NPCs.Schedules;
+using S1NPCsBehaviour = Il2CppScheduleOne.NPCs.Behaviour;
 using S1Economy = Il2CppScheduleOne.Economy;
 using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
 using S1Items = Il2CppScheduleOne.ItemFramework;
@@ -8,6 +9,7 @@ using S1Registry = Il2CppScheduleOne.Registry;
 #elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
 using S1NPCs = ScheduleOne.NPCs;
 using S1NPCsSchedules = ScheduleOne.NPCs.Schedules;
+using S1NPCsBehaviour = ScheduleOne.NPCs.Behaviour;
 using S1Economy = ScheduleOne.Economy;
 using S1AvatarFramework = ScheduleOne.AvatarFramework;
 using S1Items = ScheduleOne.ItemFramework;
@@ -310,17 +312,25 @@ namespace S1API.Entities
             
             // Ensure required schedule components exist
             var mgr = EnsureScheduleManager();
-            
-            // Ensure NPCSignal_HandleDeal exists for dealer contract fulfillment
-            var handleDeal = prefabRoot.GetComponentInChildren<S1NPCsSchedules.NPCSignal_HandleDeal>(true);
-            if (handleDeal == null)
+
+            // Ensure DealerAttendDealBehaviour exists for dealer contract fulfillment (v0.4.2f4+)
+            var npcBehaviour = prefabRoot.GetComponentInChildren<S1NPCsBehaviour.NPCBehaviour>(true);
+            if (npcBehaviour == null)
             {
-                var go = new GameObject("HandleDeal");
-                go.transform.SetParent(mgr.transform, false);
-                handleDeal = go.AddComponent<S1NPCsSchedules.NPCSignal_HandleDeal>();
+                var behGo = new GameObject("NPCBehaviour");
+                behGo.transform.SetParent(mgr.transform, false);
+                npcBehaviour = behGo.AddComponent<S1NPCsBehaviour.NPCBehaviour>();
+            }
+
+            var attendDeal = prefabRoot.GetComponentInChildren<S1NPCsBehaviour.DealerAttendDealBehaviour>(true);
+            if (attendDeal == null)
+            {
+                var go = new GameObject("DealerAttendDealBehaviour");
+                go.transform.SetParent(npcBehaviour.transform, false);
+                attendDeal = go.AddComponent<S1NPCsBehaviour.DealerAttendDealBehaviour>();
                 go.SetActive(false);
             }
-            
+
             // Ensure NPCEvent_StayInBuilding exists for home behavior
             var stayInBuilding = prefabRoot.GetComponentInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true);
             if (stayInBuilding == null)
@@ -529,7 +539,7 @@ namespace S1API.Entities
 
             var mgr = EnsureScheduleManager();
 
-            int walkTo = 0, stayInBuilding = 0, locationDialogue = 0, useVending = 0, driveToCarPark = 0, dealSignal = 0, useATM = 0, handleDeal = 0;
+            int walkTo = 0, stayInBuilding = 0, locationDialogue = 0, useVending = 0, driveToCarPark = 0, dealSignal = 0, useATM = 0;
             for (int i = 0; i < specs.Count; i++)
             {
                 var s = specs[i];
@@ -540,7 +550,6 @@ namespace S1API.Entities
                 else if (s is DriveToCarParkSpec) driveToCarPark++;
                 else if (s is EnsureDealSignalSpec) dealSignal = Math.Max(dealSignal, 1);
                 else if (s is UseATMSpec) useATM++;
-                else if (s is HandleDealSpec) handleDeal++;
             }
 
             if (dealSignal > 0)
@@ -570,7 +579,6 @@ namespace S1API.Entities
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_UseVendingMachine>(useVending, "UseVending");
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_DriveToCarPark>(driveToCarPark, "DriveToCarPark");
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_UseATM>(useATM, "UseATM");
-            EnsurePrefabAction<S1NPCsSchedules.NPCSignal_HandleDeal>(handleDeal, "HandleDeal");
         }
 
         private void EnsurePrefabAction<T>(int count, string namePrefix) where T : S1NPCsSchedules.NPCAction

--- a/S1API/Entities/Schedule/ActionSpecs/HandleDealSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/HandleDealSpec.cs
@@ -1,20 +1,4 @@
-#if (IL2CPPMELON)
-using Il2Cpp;
-using S1NPCs = Il2CppScheduleOne.NPCs;
-using S1NPCsSchedules = Il2CppScheduleOne.NPCs.Schedules;
-using S1Map = Il2CppScheduleOne.Map;
-using S1Vehicles = Il2CppScheduleOne.Vehicles;
-using S1VehiclesAI = Il2CppScheduleOne.Vehicles.AI;
-using S1ObjectScripts = Il2CppScheduleOne.ObjectScripts;
-#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
-using S1NPCs = ScheduleOne.NPCs;
-using S1NPCsSchedules = ScheduleOne.NPCs.Schedules;
-using S1Map = ScheduleOne.Map;
-using S1Vehicles = ScheduleOne.Vehicles;
-using S1VehiclesAI = ScheduleOne.Vehicles.AI;
-using S1ObjectScripts = ScheduleOne.ObjectScripts;
-#endif
-using UnityEngine;
+using System;
 
 namespace S1API.Entities.Schedule
 {
@@ -22,9 +6,11 @@ namespace S1API.Entities.Schedule
     /// Specifies an action that handles a customer deal handover at the active contract location.
     /// </summary>
     /// <remarks>
-    /// Creates a <see cref="S1NPCsSchedules.NPCSignal_HandleDeal"/>. This action expects the owning NPC
-    /// to be a Dealer and for gameplay systems to assign the active contract at runtime.
+    /// As of v0.4.2f4, deal handling is now automatic through the DealerAttendDealBehaviour system.
+    /// This spec is kept for backwards compatibility but is a no-op. Dealer NPCs set up with
+    /// EnsureDealer() will automatically handle deals when contracts are assigned.
     /// </remarks>
+    [Obsolete("HandleDealSpec is no longer needed as of game version 0.4.2f4. Deal handling is now automatic through DealerAttendDealBehaviour.")]
     public sealed class HandleDealSpec : IScheduleActionSpec
     {
         /// <summary>
@@ -39,7 +25,9 @@ namespace S1API.Entities.Schedule
 
         void IScheduleActionSpec.ApplyTo(NPCSchedule schedule)
         {
-            schedule.AddActionInternal<S1NPCsSchedules.NPCSignal_HandleDeal>(StartTime, string.IsNullOrEmpty(Name) ? "HandleDeal" : Name);
+            // No-op: Deal handling is now automatic through DealerAttendDealBehaviour.
+            // Dealers set up with EnsureDealer() will automatically handle deals when contracts are assigned.
+            // This method intentionally does nothing to maintain backwards compatibility.
         }
     }
 }

--- a/S1API/Entities/Schedule/NPCScheduleBuilder.cs
+++ b/S1API/Entities/Schedule/NPCScheduleBuilder.cs
@@ -196,10 +196,11 @@ namespace S1API.Entities.Schedule
         /// <param name="name">Optional custom name for this action; defaults to "HandleDeal".</param>
         /// <returns>This builder instance for method chaining.</returns>
         /// <remarks>
-        /// Creates a <see cref="HandleDealSpec"/> that, when applied, configures a
-        /// <see cref="S1NPCsSchedules.NPCSignal_HandleDeal"/>. The owning NPC is expected to be a dealer
-        /// with contract assignment handled by gameplay systems.
+        /// As of v0.4.2f4, deal handling is now automatic through the DealerAttendDealBehaviour system.
+        /// This method is kept for backwards compatibility but is a no-op. Dealer NPCs set up with
+        /// EnsureDealer() will automatically handle deals when contracts are assigned.
         /// </remarks>
+        [System.Obsolete("HandleDeal is no longer needed as of game version 0.4.2f4. Deal handling is now automatic through DealerAttendDealBehaviour.")]
         public PrefabScheduleBuilder HandleDeal(int startTime, string name = null)
         {
             _specs.Add(new HandleDealSpec { StartTime = startTime, Name = name });

--- a/S1API/Growing/PlantInstance.cs
+++ b/S1API/Growing/PlantInstance.cs
@@ -1,7 +1,11 @@
 #if (IL2CPPMELON)
 using S1Growing = Il2CppScheduleOne.Growing;
+using S1Trash = Il2CppScheduleOne.Trash;
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
 #elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
 using S1Growing = ScheduleOne.Growing;
+using S1Trash = ScheduleOne.Trash;
+using S1DevUtilities = ScheduleOne.DevUtilities;
 #endif
 
 using S1API.Internal.Utils;
@@ -68,10 +72,33 @@ namespace S1API.Growing
         /// <summary>
         /// Destroys this plant in-game.
         /// </summary>
-        /// <param name="dropScraps">Whether to drop trash scraps.</param>
+        /// <param name="dropScraps">Whether to drop plant scraps (trash) at the plant's location.</param>
         public void Destroy(bool dropScraps = false)
         {
-            S1Plant.Destroy(dropScraps);
+            if (dropScraps && S1Plant.PlantScrapPrefab != null)
+            {
+                try
+                {
+                    // Spawn the plant scrap at the plant's position
+                    var trashManager = S1DevUtilities.NetworkSingleton<S1Trash.TrashManager>.Instance;
+                    if (trashManager != null)
+                    {
+                        var position = S1Plant.transform.position;
+                        var rotation = Quaternion.identity;
+                        trashManager.CreateTrashItem(
+                            S1Plant.PlantScrapPrefab.ID,
+                            position,
+                            rotation
+                        );
+                    }
+                }
+                catch
+                {
+                    // Silently fail if trash spawning fails - still destroy the plant
+                }
+            }
+
+            Object.Destroy(S1Plant.gameObject);
         }
     }
 }

--- a/S1API/Internal/Patches/BuildingPatches.cs
+++ b/S1API/Internal/Patches/BuildingPatches.cs
@@ -92,7 +92,7 @@ namespace S1API.Internal.Patches
         /// <summary>
         /// Patch for BuildableItem.InitializeBuildableItem - raises OnBuildableItemInitialized event.
         /// </summary>
-        [HarmonyPatch(typeof(S1EntityFramework.BuildableItem), nameof(S1EntityFramework.BuildableItem.InitializeBuildableItem))]
+        [HarmonyPatch(typeof(S1EntityFramework.BuildableItem), "InitializeBuildableItem")]
         [HarmonyPostfix]
         private static void InitializeBuildableItem_Postfix(S1EntityFramework.BuildableItem __instance, S1ItemFramework.ItemInstance instance)
         {

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -121,7 +121,11 @@ namespace S1API.Internal.Patches
         /// </summary>
         private static IEnumerator WaitForNPCs(S1ContactsApp.ContactsApp contactsApp)
         {
-            yield return new WaitWhile((Func<bool>)(() => NPCPatches.CustomNpcsReady == false));
+            // Wait for custom NPCs to be ready - use polling for Il2Cpp compatibility
+            while (!NPCPatches.CustomNpcsReady)
+            {
+                yield return null;
+            }
 
             // Check for physical custom NPCs immediately after CustomNpcsReady
             // If there are no physical NPCs, we can skip all the waiting and proceed immediately

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -1469,8 +1469,14 @@ namespace S1API.Internal.Patches
                     }
                 }
 
-                // Respect minimal fill
-                if (__instance.GetItemCount() >= 3)
+                // Respect minimal fill - count non-empty slots (GetItemCount was removed in v0.4.2f4)
+                int itemCount = 0;
+                for (int j = 0; j < __instance.ItemSlots.Count; j++)
+                {
+                    if (__instance.ItemSlots[j]?.ItemInstance != null)
+                        itemCount++;
+                }
+                if (itemCount >= 3)
                     return false;
 
                 // Random cash (local-only)
@@ -1484,22 +1490,13 @@ namespace S1API.Internal.Patches
                     }
                 }
 
-                // Random items (local-only)
+                // Random items (local-only) - Use AddRandomItemsToInventory which handles the new API
                 if (__instance.RandomItems && __instance.RandomInventoryItems != null &&
                     __instance.RandomInventoryItems.Length > 0)
                 {
-                    int count = UnityEngine.Random.Range(__instance.RandomItemMin, __instance.RandomItemMax + 1);
-                    var getRandomMethod = typeof(S1NPCs.NPCInventory).GetMethod("GetRandomInventoryItem",
-                        BindingFlags.NonPublic | BindingFlags.Instance);
-                    for (int i = 0; i < count; i++)
-                    {
-                        var def = getRandomMethod?.Invoke(__instance, null) as S1Items.StorableItemDefinition;
-                        if (def != null)
-                        {
-                            var inst = def.GetDefaultInstance();
-                            __instance.InsertItem(inst, network: false);
-                        }
-                    }
+                    // v0.4.2f4 changed GetRandomInventoryItem to require excludeIDs parameter
+                    // and added AddRandomItemsToInventory() as a public method - use that instead
+                    __instance.AddRandomItemsToInventory();
                 }
             }
             catch (Exception ex)

--- a/S1API/Internal/Patches/StoragePatches.cs
+++ b/S1API/Internal/Patches/StoragePatches.cs
@@ -174,9 +174,9 @@ namespace S1API.Internal.Patches
         /// <summary>
         /// Hydrate expanded slots before loading contents so extra slots are restored from saves.
         /// </summary>
-        [HarmonyPatch(typeof(S1PersistenceLoaders.StorageRackLoader), "Load", new Type[] { typeof(S1Persistence.DynamicSaveData) })]
+        [HarmonyPatch(typeof(S1PersistenceLoaders.PlaceableStorageEntityLoader), "Load", new Type[] { typeof(S1Persistence.DynamicSaveData) })]
         [HarmonyPrefix]
-        private static bool StorageRackLoader_Load_Prefix(S1PersistenceLoaders.StorageRackLoader __instance, S1Persistence.DynamicSaveData data)
+        private static bool PlaceableStorageEntityLoader_Load_Prefix(S1PersistenceLoaders.PlaceableStorageEntityLoader __instance, S1Persistence.DynamicSaveData data)
         {
             try
             {
@@ -232,7 +232,7 @@ namespace S1API.Internal.Patches
             }
             catch (Exception ex)
             {
-                Logger.Error($"Error in StorageRackLoader_Load_Prefix: {ex.Message}");
+                Logger.Error($"Error in PlaceableStorageEntityLoader_Load_Prefix: {ex.Message}");
             }
 
             // Skip original loader to avoid double-loading

--- a/S1API/Items/BuildableItemDefinitionBuilder.cs
+++ b/S1API/Items/BuildableItemDefinitionBuilder.cs
@@ -64,7 +64,7 @@ namespace S1API.Items
             _definition.Icon = source.Icon;
             _definition.legalStatus = source.legalStatus;
             _definition.PickpocketDifficultyMultiplier = source.PickpocketDifficultyMultiplier;
-            _definition.CombatUtilityForNPCs = source.CombatUtilityForNPCs;
+            _definition.CombatUtility = source.CombatUtility;
 
             // StorableItemDefinition properties
             _definition.BasePurchasePrice = source.BasePurchasePrice;

--- a/S1API/Items/StorableItemDefinition.cs
+++ b/S1API/Items/StorableItemDefinition.cs
@@ -50,10 +50,10 @@ namespace S1API.Items
         }
 
         /// <summary>
-        /// Gets whether this item is currently purchasable based on level requirements.
+        /// Gets whether this item is currently unlocked (available for purchase/use).
         /// </summary>
-        public bool IsPurchasable =>
-            S1StorableItemDefinition.IsPurchasable;
+        public bool IsUnlocked =>
+            S1StorableItemDefinition.IsUnlocked;
     }
 }
 

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -4,7 +4,7 @@ using S1API.Internal.Lifecycle;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "2.8.5", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "2.8.6", "KaBooMa")]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API
 {

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -21,7 +21,7 @@
         <RootNamespace>S1API</RootNamespace>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>latest</LangVersion>
-		<Version>2.8.5</Version>
+		<Version>2.8.6</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon' or '$(Configuration)' == 'MonoBepInEx'">


### PR DESCRIPTION
Replaces NPCSignal_HandleDeal with DealerAttendDealBehaviour for dealer NPCs to match game version 0.4.2f4 changes. HandleDealSpec and related builder methods are now marked obsolete and are no-ops for backwards compatibility. Updates NPCPrefabBuilder and NPCDealer to use the new behaviour system. Also includes minor fixes for plant destruction (spawning trash), inventory randomization, storage loader patching, and item definition property updates.

Credits: @HazDS 