### PR TITLE
Fix pick pocketing and vehicle cleanup issues

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -2242,6 +2242,32 @@ namespace S1API.Entities
                 S1NPC.Behaviour.ConsumeProductBehaviour = existing;
             }
 
+            // UnconsciousBehaviour and DeadBehaviour are required by NPC.IsConscious
+            // which is checked during pickpocketing and other interactions
+            if (S1NPC.Behaviour.UnconsciousBehaviour == null)
+            {
+                var existing = S1NPC.Behaviour.GetComponentInChildren<S1Behaviour.UnconsciousBehaviour>(true);
+                if (existing == null)
+                {
+                    GameObject go = new GameObject("UnconsciousBehaviour");
+                    go.transform.SetParent(S1NPC.Behaviour.transform, false);
+                    existing = go.AddComponent<S1Behaviour.UnconsciousBehaviour>();
+                }
+                S1NPC.Behaviour.UnconsciousBehaviour = existing;
+            }
+
+            if (S1NPC.Behaviour.DeadBehaviour == null)
+            {
+                var existing = S1NPC.Behaviour.GetComponentInChildren<S1Behaviour.DeadBehaviour>(true);
+                if (existing == null)
+                {
+                    GameObject go = new GameObject("DeadBehaviour");
+                    go.transform.SetParent(S1NPC.Behaviour.transform, false);
+                    existing = go.AddComponent<S1Behaviour.DeadBehaviour>();
+                }
+                S1NPC.Behaviour.DeadBehaviour = existing;
+            }
+
             TryRegisterBehaviourEventLinks();
         }
 

--- a/S1API/Entities/NPCInventory.cs
+++ b/S1API/Entities/NPCInventory.cs
@@ -223,21 +223,9 @@ namespace S1API.Entities
             {
                 ReflectionUtils.TrySetFieldOrProperty(inv, "npc", NPC.S1NPC);
 
-                if (inv.PickpocketIntObj != null)
-                {
-                    MethodInfo hoveredMi = typeof(S1NPCs.NPCInventory).GetMethod("Hovered", BindingFlags.Public | BindingFlags.Instance);
-                    MethodInfo interactedMi = typeof(S1NPCs.NPCInventory).GetMethod("Interacted", BindingFlags.Public | BindingFlags.Instance);
-                    if (hoveredMi != null)
-                    {
-                        UnityAction hovered = (UnityAction)Delegate.CreateDelegate(typeof(UnityAction), inv, hoveredMi);
-                        inv.PickpocketIntObj.onHovered?.AddListener(hovered);
-                    }
-                    if (interactedMi != null)
-                    {
-                        UnityAction interacted = (UnityAction)Delegate.CreateDelegate(typeof(UnityAction), inv, interactedMi);
-                        inv.PickpocketIntObj.onInteractStart?.AddListener(interacted);
-                    }
-                }
+                // NOTE: Do NOT add listeners here - the game's NPCInventory.Awake() already adds
+                // onHovered and onInteractStart listeners. Adding them again causes duplicate
+                // event firing which breaks the pickpocket screen.
             }
             catch { }
 

--- a/S1API/Internal/Patches/LandVehiclePatches.cs
+++ b/S1API/Internal/Patches/LandVehiclePatches.cs
@@ -15,7 +15,15 @@ namespace S1API.Internal.Patches
         [HarmonyPatch("OnDestroy")]
         [HarmonyPostfix]
         public static void OnDestroy(S1Vehicles.LandVehicle __instance) {
-            VehicleRegistry.RemoveVehicle(__instance.GUID.ToString());
+            try
+            {
+                if (__instance != null)
+                    VehicleRegistry.RemoveVehicle(__instance.GUID.ToString());
+            }
+            catch
+            {
+                // Ignore errors during cleanup - VehicleManager may be destroyed during scene unload
+            }
         }
 
     }

--- a/S1API/Vehicles/VehicleRegistry.cs
+++ b/S1API/Vehicles/VehicleRegistry.cs
@@ -154,39 +154,55 @@ namespace S1API.Vehicles
         }
 
         /// <summary>
-        /// Removes a vehicle from the game's lists, for permenently destroying a vehicle. This will be called automatically in OnDestroy, so there's likely no need to call this manually
+        /// Removes a vehicle from the game's lists, for permanently destroying a vehicle. This will be called automatically in OnDestroy, so there's likely no need to call this manually.
         /// </summary>
-        /// <param name="guidString"></param>
+        /// <param name="guidString">The GUID string of the vehicle to remove.</param>
         public static void RemoveVehicle(string guidString) {
-            S1Guid guid = new S1Guid(guidString);
+            if (string.IsNullOrEmpty(guidString))
+                return;
+
             var registry = S1Vehicles.VehicleManager.Instance;
+            if (registry == null)
+                return;
+
+            S1Guid guid = new S1Guid(guidString);
 
             int? allIndex = null;
             S1Vehicles.LandVehicle? gameVehicle = null;
-            for (int i = 0; i < registry.AllVehicles.Count; ++i) {
-                if (registry.AllVehicles[i]?.GUID.Equals(guid) ?? false) {
-                    allIndex = i;
-                    gameVehicle = registry.AllVehicles[i];
-                    break;
-                }
-            }
-            int? playerIndex = null;
-            for (int i = 0; i < registry.PlayerOwnedVehicles.Count; ++i) {
-                if (registry.PlayerOwnedVehicles[i]?.GUID.Equals(guid) ?? false) {
-                    playerIndex = i;
-                    break;
-                }
-            }
-            if (allIndex != null) {
-                registry.AllVehicles.RemoveAt((int)allIndex);
-            }
-            if (playerIndex != null) {
-                registry.PlayerOwnedVehicles.RemoveAt((int)playerIndex);
-            }
-            
-            if(gameVehicle != null && _cache.ContainsKey(gameVehicle))
-                _cache.Remove(gameVehicle);
 
+            var allVehicles = registry.AllVehicles;
+            if (allVehicles != null)
+            {
+                for (int i = 0; i < allVehicles.Count; ++i) {
+                    if (allVehicles[i]?.GUID.Equals(guid) ?? false) {
+                        allIndex = i;
+                        gameVehicle = allVehicles[i];
+                        break;
+                    }
+                }
+            }
+
+            int? playerIndex = null;
+            var playerVehicles = registry.PlayerOwnedVehicles;
+            if (playerVehicles != null)
+            {
+                for (int i = 0; i < playerVehicles.Count; ++i) {
+                    if (playerVehicles[i]?.GUID.Equals(guid) ?? false) {
+                        playerIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            if (allIndex != null && allVehicles != null) {
+                allVehicles.RemoveAt((int)allIndex);
+            }
+            if (playerIndex != null && playerVehicles != null) {
+                playerVehicles.RemoveAt((int)playerIndex);
+            }
+
+            if (gameVehicle != null && _cache.ContainsKey(gameVehicle))
+                _cache.Remove(gameVehicle);
         }
 
         private static LandVehicle Wrap(S1Vehicles.LandVehicle veh)


### PR DESCRIPTION
Ensures UnconsciousBehaviour and DeadBehaviour are always present for NPCs to support correct interaction checks. Prevents duplicate event listeners in NPCInventory to avoid breaking the pickpocket screen. Improves LandVehicle cleanup by handling null references and exceptions during destruction. Makes VehicleRegistry.RemoveVehicle more robust by adding null checks and correcting vehicle removal logic.