### PR TITLE
growing: add GrowContainer allowed additives registry + injection patch

### DIFF
--- a/S1API/Growing/GrowContainerAdditives.cs
+++ b/S1API/Growing/GrowContainerAdditives.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using S1API.Logging;
+
+namespace S1API.Growing
+{
+    /// <summary>
+    /// Global registry for additive IDs that should be allowed on all grow containers.
+    /// These IDs are applied to <c>GrowContainer.AllowedAdditives</c> during <c>GrowContainer.InitializeGridItem</c>.
+    /// </summary>
+    public static class GrowContainerAdditives
+    {
+        private static readonly Log Logger = new Log("GrowContainerAdditives");
+        private static readonly object Gate = new object();
+        private static readonly HashSet<string> AllowedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private static readonly HashSet<string> WarnedMissingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Registers an additive item ID as allowed on all grow containers (idempotent).
+        /// </summary>
+        /// <remarks>
+        /// Recommended timing: call during <see cref="Lifecycle.GameLifecycle.OnPreLoad"/> (or earlier).
+        /// </remarks>
+        public static void AllowAdditive(string additiveItemId)
+        {
+            var id = (additiveItemId ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Additive item ID is required.", nameof(additiveItemId));
+
+            lock (Gate)
+            {
+                // Final decision: duplicates are a silent no-op.
+                AllowedIds.Add(id);
+            }
+        }
+
+        /// <summary>
+        /// Returns a snapshot of allowed additive IDs registered via S1API.
+        /// </summary>
+        public static IReadOnlyList<string> GetAllowedAdditiveIds()
+        {
+            lock (Gate)
+            {
+                var arr = new string[AllowedIds.Count];
+                AllowedIds.CopyTo(arr);
+                return arr;
+            }
+        }
+
+        internal static IReadOnlyList<string> GetAllowedAdditiveIdsInternal() => GetAllowedAdditiveIds();
+
+        internal static void WarnMissing(string additiveItemId, string message)
+        {
+            if (string.IsNullOrWhiteSpace(additiveItemId))
+                return;
+
+            lock (Gate)
+            {
+                // Keep missing-ID warnings one-per-ID per session to avoid log spam.
+                if (WarnedMissingIds.Add(additiveItemId))
+                    Logger.Warning(message);
+            }
+        }
+    }
+}

--- a/S1API/Internal/Patches/GrowContainerPatches.AllowedAdditives.cs
+++ b/S1API/Internal/Patches/GrowContainerPatches.AllowedAdditives.cs
@@ -1,0 +1,144 @@
+#if (IL2CPPMELON)
+using S1Growing = Il2CppScheduleOne.Growing;
+using S1Grid = Il2CppScheduleOne.Tiles.Grid;
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Registry = Il2CppScheduleOne.Registry;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Growing = ScheduleOne.Growing;
+using S1Grid = ScheduleOne.Tiles.Grid;
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Registry = ScheduleOne.Registry;
+#endif
+
+using System;
+using HarmonyLib;
+using S1API.Growing;
+using S1API.Internal.Utils;
+using S1API.Logging;
+using UnityEngine;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Injects S1API-registered allowed additives into <c>GrowContainer.AllowedAdditives</c>.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class GrowContainerPatches
+    {
+        private static readonly Log Logger = new Log("GrowContainerPatches");
+
+        [HarmonyPatch(typeof(S1Growing.GrowContainer), nameof(S1Growing.GrowContainer.InitializeGridItem),
+            new Type[] { typeof(S1ItemFramework.ItemInstance), typeof(S1Grid), typeof(Vector2), typeof(int), typeof(string) })]
+        [HarmonyPrefix]
+        private static void GrowContainer_InitializeGridItem_Prefix(S1Growing.GrowContainer __instance)
+        {
+            try
+            {
+                ApplyRegisteredAllowedAdditives(__instance);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"[S1API] Failed to apply registered allowed additives: {ex.Message}");
+            }
+        }
+
+        internal static void ApplyRegisteredAllowedAdditives(S1Growing.GrowContainer container)
+        {
+            if (container == null)
+                return;
+
+            var ids = GrowContainerAdditives.GetAllowedAdditiveIdsInternal();
+            if (ids == null || ids.Count == 0)
+                return;
+
+            for (int i = 0; i < ids.Count; i++)
+            {
+                var id = ids[i];
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
+                S1ItemFramework.AdditiveDefinition additive;
+                try
+                {
+                    var item = S1Registry.GetItem(id);
+                    if (item == null || !CrossType.Is(item, out S1ItemFramework.AdditiveDefinition add))
+                    {
+                        GrowContainerAdditives.WarnMissing(
+                            id,
+                            $"[S1API] GrowContainerAdditives: additive '{id}' was not found or is not an AdditiveDefinition; skipping.");
+                        continue;
+                    }
+
+                    additive = add;
+                }
+                catch (Exception ex)
+                {
+                    GrowContainerAdditives.WarnMissing(
+                        id,
+                        $"[S1API] GrowContainerAdditives: could not resolve additive '{id}' (registry unavailable yet?): {ex.Message}");
+                    continue;
+                }
+
+                if (ContainsAdditive(container, id))
+                    continue;
+
+                AppendAdditive(container, additive);
+            }
+        }
+
+        private static bool ContainsAdditive(S1Growing.GrowContainer container, string additiveId)
+        {
+#if (IL2CPPMELON)
+            var current = container.AllowedAdditives;
+            var len = current?.Length ?? 0;
+            for (int i = 0; i < len; i++)
+            {
+                var existing = current![i];
+                if (existing != null && string.Equals(existing.ID, additiveId, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+#else
+            var current = container.AllowedAdditives;
+            if (current == null)
+                return false;
+
+            for (int i = 0; i < current.Length; i++)
+            {
+                var existing = current[i];
+                if (existing != null && string.Equals(existing.ID, additiveId, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+#endif
+        }
+
+        private static void AppendAdditive(S1Growing.GrowContainer container, S1ItemFramework.AdditiveDefinition additive)
+        {
+            if (additive == null)
+                return;
+
+#if (IL2CPPMELON)
+            var current = container.AllowedAdditives;
+            var len = current?.Length ?? 0;
+
+            var managed = new S1ItemFramework.AdditiveDefinition[len + 1];
+            for (int i = 0; i < len; i++)
+            {
+                managed[i] = current![i];
+            }
+
+            managed[len] = additive;
+            container.AllowedAdditives = new Il2CppReferenceArray<S1ItemFramework.AdditiveDefinition>(managed);
+#else
+            var current = container.AllowedAdditives ?? Array.Empty<S1ItemFramework.AdditiveDefinition>();
+            var next = new S1ItemFramework.AdditiveDefinition[current.Length + 1];
+            current.CopyTo(next, 0);
+            next[next.Length - 1] = additive;
+            container.AllowedAdditives = next;
+#endif
+        }
+    }
+}
+

--- a/S1API/docs/items.md
+++ b/S1API/docs/items.md
@@ -137,6 +137,36 @@ var variant = AdditiveItemCreator.CloneFrom("pgr")
     .Build();
 ```
 
+### Allowing additives on Grow Containers
+
+Grow containers have a fixed allowlist of additives (`GrowContainer.AllowedAdditives`). S1API can extend that allowlist globally so mods don’t need to patch `GrowContainer.InitializeGridItem`.
+
+Notes:
+- Applies to **all** grow containers.
+- Duplicate `AllowAdditive(...)` calls are a no-op.
+- If the ID can’t be resolved to an `AdditiveDefinition` at runtime, S1API will **warn once** and **skip** it.
+
+```csharp
+using MelonLoader;
+using S1API.Growing;
+using S1API.Lifecycle;
+
+public class MyMod : MelonMod
+{
+    public override void OnSceneWasLoaded(int buildIndex, string sceneName)
+    {
+        if (sceneName != "Main")
+            return;
+
+        GameLifecycle.OnPreLoad += () =>
+        {
+            // Allow a runtime additive you registered earlier in OnPreLoad
+            GrowContainerAdditives.AllowAdditive("mymod_growth_booster");
+        };
+    }
+}
+```
+
 ## Item Categories
 
 Available item categories:


### PR DESCRIPTION
## Summary

This PR adds S1API support for allowing additional additives on grow containers at runtime, without each mod needing to patch `GrowContainer.InitializeGridItem`.

It introduces a small global registry of additive item IDs and a centralized Harmony patch that injects the corresponding `AdditiveDefinition` entries into `GrowContainer.AllowedAdditives` during container initialization.

## What’s included

- New API:
  - `S1API.Growing.GrowContainerAdditives`
    - `AllowAdditive(string additiveItemId)` (idempotent)
    - `GetAllowedAdditiveIds()`
- Internal injection (Harmony patch):
  - Patch target: `ScheduleOne.Growing.GrowContainer.InitializeGridItem(ItemInstance, Grid, Vector2, int, string)`
  - Injects resolved `AdditiveDefinition` entries into `GrowContainer.AllowedAdditives`
  - IL2CPP-safe array assignment (`Il2CppReferenceArray<AdditiveDefinition>`)
- Docs:
  - Added “Allowing additives on Grow Containers” section to `S1API/docs/items.md`

## Usage (recommended)

Register allowed additives during `GameLifecycle.OnPreLoad`:

```csharp
using MelonLoader;
using S1API.Growing;
using S1API.Lifecycle;

public class MyMod : MelonMod
{
    public override void OnSceneWasLoaded(int buildIndex, string sceneName)
    {
        if (sceneName != "Main")
            return;

        GameLifecycle.OnPreLoad += () =>
        {
            // Allow a runtime additive ID you registered earlier in OnPreLoad
            GrowContainerAdditives.AllowAdditive("mymod_growth_booster");
        };
    }
}
```

## Implementation

- Scope: **global only** (applies to all `GrowContainer` instances).
- Duplicate registrations: **silent no-op**.
- Missing/invalid IDs: **warn once + skip**.
- Model: **allow-only** (no remove/disallow API).

## Testing

### Find the smoke-test console command source file in the first comment under this PR!

- DEV-local smoke test command:
  - `s1api_dev_growcontainer_additives_smoke_test runtime`
  - `s1api_dev_growcontainer_additives_smoke_test basegame <additiveId>` (example: `pgr`)
  - `s1api_dev_growcontainer_additives_smoke_test arm runtime`
  - `s1api_dev_growcontainer_additives_smoke_test arm basegame <additiveId>`
- Validates:
  - Runtime mode: creates a runtime additive, registers it, allows it, injects it into `GrowContainer.AllowedAdditives`, and validates idempotency.
  - Base-game mode: resolves an existing additive ID from `Registry`, allows it, injects it into `GrowContainer.AllowedAdditives`, and validates idempotency.
  - Armed mode: waits for Main + a `GrowContainer` (skips if none appear) then runs the same validations once.
- Verified on **Mono** and **IL2CPP** (manual + arm; runtime + base-game modes).

## Notes / rationale

- Centralizing the injection avoids multiple mods patching the same method (`InitializeGridItem`) and fighting over ordering.
- The base game can remove runtime-added items from `Registry` on scene changes; therefore missing additive IDs are handled defensively (warn+skip) rather than breaking container initialization.
