### PR TITLE
Project destinations to NavMesh height

### DIFF
--- a/S1API/Entities/Schedule/ActionSpecs/LocationDialogueSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/LocationDialogueSpec.cs
@@ -15,6 +15,7 @@ using S1VehiclesAI = ScheduleOne.Vehicles.AI;
 using S1ObjectScripts = ScheduleOne.ObjectScripts;
 #endif
 using UnityEngine;
+using UnityEngine.AI;
 using S1API.Map;
 using S1API.Vehicles;
 
@@ -112,11 +113,20 @@ namespace S1API.Entities.Schedule
             if (action == null)
                 return;
 
+            // Project destination to navmesh height so the game's 3D distance checks
+            // use a position consistent with where the NPC actually walks.
+            Vector3 markerPosition = Destination;
+            NavMeshHit navHit;
+            if (NavMesh.SamplePosition(Destination, out navHit, 5f, NavMesh.AllAreas))
+            {
+                markerPosition = new Vector3(Destination.x, navHit.position.y, Destination.z);
+            }
+
             // Create destination marker in NPC's dedicated container
             var destinationTransform = NPCDestinationContainer.CreateDestinationMarker(
                 schedule.NPC.gameObject.name,
                 "Marker",
-                Destination,
+                markerPosition,
                 Forward);
 
             if (destinationTransform != null)

--- a/S1API/Entities/Schedule/ActionSpecs/WalkToSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/WalkToSpec.cs
@@ -15,6 +15,7 @@ using S1VehiclesAI = ScheduleOne.Vehicles.AI;
 using S1ObjectScripts = ScheduleOne.ObjectScripts;
 #endif
 using UnityEngine;
+using UnityEngine.AI;
 using S1API.Map;
 using S1API.Vehicles;
 
@@ -111,11 +112,23 @@ namespace S1API.Entities.Schedule
                 }
             }
 
+            // Project destination to navmesh height so the game's 3D distance checks
+            // (WalkResult.Success threshold and IsAtDestination) use a position consistent
+            // with where the NPC actually walks. Without this, a Y-coordinate mismatch > 1 unit
+            // causes WalkResult.Partial instead of Success, and ReachedDestination() never fires,
+            // so FaceDirection is never called.
+            Vector3 markerPosition = Destination;
+            NavMeshHit navHit;
+            if (NavMesh.SamplePosition(Destination, out navHit, 5f, NavMesh.AllAreas))
+            {
+                markerPosition = new Vector3(Destination.x, navHit.position.y, Destination.z);
+            }
+
             // Create destination marker in NPC's dedicated container
             var destinationTransform = NPCDestinationContainer.CreateDestinationMarker(
-                schedule.NPC.gameObject.name, 
-                "Destination", 
-                Destination, 
+                schedule.NPC.gameObject.name,
+                "Destination",
+                markerPosition,
                 forwardDirection);
 
             if (destinationTransform != null)

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -65,6 +65,7 @@
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.ImageConversionModule.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.PhysicsModule.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\Unity.TextMeshPro.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.AIModule.dll" />
 
         <Reference Include="$(Il2CppAssembliesPath)\Il2CppFishNet.Runtime.dll" Condition="'$(Configuration)' == 'Il2CppMelon'" />
         <Reference Include="$(Il2CppAssembliesPath)\FishNet.Runtime.dll" Condition="'$(Configuration)' == 'Il2CppBepInEx'" />
@@ -110,6 +111,9 @@
         </Reference>
         <Reference Include="UnityEngine.PhysicsModule">
             <HintPath>$(MonoAssembliesPath)/UnityEngine.PhysicsModule.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.AIModule">
+            <HintPath>$(MonoAssembliesPath)/UnityEngine.AIModule.dll</HintPath>
         </Reference>
         <Reference Include="Unity.TextMeshPro">
             <HintPath>$(MonoAssembliesPath)/Unity.TextMeshPro.dll</HintPath>


### PR DESCRIPTION
Sample NavMesh height for destination markers in LocationDialogueSpec and WalkToSpec so destination markers use the navmesh Y coordinate when creating NPC markers. This makes distance checks and walk completion logic consistent with where NPCs actually walk (fixes WalkResult.Partial / unreachable ReachedDestination and FaceDirection not being called).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Project destination markers to NavMesh height in LocationDialogueSpec to align marker positioning with actual walking surfaces
- Project destination markers to NavMesh height in WalkToSpec to ensure distance checks and walk completion logic reflect actual NPC walking height
- Add UnityEngine.AIModule.dll references to project dependencies for NavMesh sampling functionality

## Contributor Statistics

| Author | Insertions | Deletions |
|--------|------------|-----------|
| HazDS | 35 | 4 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->