### PR TITLE
Bug fixes

### DIFF
--- a/S1API/Dialogues/DialogueChoiceListener.cs
+++ b/S1API/Dialogues/DialogueChoiceListener.cs
@@ -30,6 +30,15 @@ namespace S1API.Dialogues
         /// </summary>
         private static Action? _callback;
 
+        /// <summary>
+        /// Resets static state so the listener works correctly across save loads.
+        /// </summary>
+        internal static void ResetState()
+        {
+            _expectedChoiceLabel = null;
+            _callback = null;
+        }
+
         /// Registers a specific dialogue choice with a callback to be invoked when the choice is selected.
         /// <param name="handlerRef">The reference to the DialogueHandler that manages dialogue choices.</param>
         /// <param name="label">The label identifying the specific dialogue choice to be registered.</param>

--- a/S1API/Dialogues/DialogueInjector.cs
+++ b/S1API/Dialogues/DialogueInjector.cs
@@ -59,6 +59,15 @@ namespace S1API.Dialogues
         /// This method prevents multiple hookups by checking if the injection system is already active using an internal flag.
         /// If not already hooked, the method initializes a coroutine that processes and injects queued dialogue data into the corresponding NPCs.
         /// </remarks>
+        /// <summary>
+        /// Resets static state so the injector works correctly across save loads.
+        /// </summary>
+        internal static void ResetState()
+        {
+            _pendingInjections.Clear();
+            _isHooked = false;
+        }
+
         private static void HookUpdateLoop()
         {
             if (_isHooked)

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -75,6 +75,20 @@ namespace S1API.Entities
         }
 
         /// <summary>
+        /// Clears stale delegates from the static Dealer.onDealerRecruited field.
+        /// Must be called on scene change to prevent dead wrapper delegates from accumulating.
+        /// </summary>
+        internal static void ClearStaticDelegates()
+        {
+            try
+            {
+                if (DealerRecruitedField != null)
+                    DealerRecruitedField.SetValue(null, null);
+            }
+            catch { }
+        }
+
+        /// <summary>
         /// Returns whether this NPC currently has dealer functionality.
         /// </summary>
         public bool IsDealer => Component != null;

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -659,6 +659,23 @@ namespace S1API.Entities
 
                     // Set the Home field/property on the Dealer component
                     Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(Component, "Home", homeBuilding);
+
+                    // Sync HomeEvent.Building — Dealer.Awake() does this but runs before
+                    // Home is set for S1API NPCs, so we must do it here too.
+                    try
+                    {
+#if MONOMELON
+                        var homeEventField = typeof(S1Economy.Dealer).GetField("HomeEvent", BindingFlags.Public | BindingFlags.Instance);
+#else
+                        var homeEventField = typeof(S1Economy.Dealer).GetProperty("HomeEvent", BindingFlags.Public | BindingFlags.Instance);
+#endif
+                        var homeEvent = homeEventField?.GetValue(Component);
+                        if (homeEvent != null)
+                        {
+                            Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(homeEvent, "Building", homeBuilding);
+                        }
+                    }
+                    catch { }
                 }
                 catch (Exception ex)
                 {

--- a/S1API/Entities/Schedule/ActionSpecs/DriveToCarParkSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/DriveToCarParkSpec.cs
@@ -20,6 +20,7 @@ using System.Reflection;
 using UnityEngine;
 using S1API.Map;
 using S1API.Vehicles;
+using S1API.Logging;
 using S1API.Internal.Utils;
 
 namespace S1API.Entities.Schedule
@@ -34,6 +35,8 @@ namespace S1API.Entities.Schedule
     /// </remarks>
     public sealed class DriveToCarParkSpec : IScheduleActionSpec
     {
+        private static readonly Log Logger = new Log("DriveToCarParkSpec");
+
         /// <summary>
         /// Gets or sets the time when this action should start, in minutes from midnight.
         /// </summary>
@@ -177,22 +180,40 @@ namespace S1API.Entities.Schedule
             {
                 // Resolve lot
                 object lotObj = null;
+                S1Map.ParkingLot gameLot = null;
                 if (ParkingLot != null)
                 {
-                    lotObj = ParkingLot.ResolveGameLot();
+                    gameLot = ParkingLot.ResolveGameLot();
+                    lotObj = gameLot;
                 }
                 else if (!string.IsNullOrEmpty(ParkingLotName))
                 {
                     var lotWrap = ParkingLotRegistry.GetByName(ParkingLotName);
-                    lotObj = lotWrap?.ResolveGameLot();
+                    gameLot = lotWrap?.ResolveGameLot();
+                    lotObj = gameLot;
                 }
                 else if (!string.IsNullOrEmpty(ParkingLotGUID))
                 {
                     var lotWrap = ParkingLotRegistry.GetByGUID(ParkingLotGUID);
-                    lotObj = lotWrap?.ResolveGameLot();
+                    gameLot = lotWrap?.ResolveGameLot();
+                    lotObj = gameLot;
                 }
-                if (lotObj != null)
+
+                if (lotObj == null)
+                {
+                    Logger.Warning($"DriveToCarPark: Parking lot could not be resolved (Name='{ParkingLotName}', GUID='{ParkingLotGUID}'). Action will not function correctly.");
+                }
+                else
+                {
                     ReflectionUtils.TrySetFieldOrProperty(action, "ParkingLot", lotObj);
+
+                    // Warn if the lot has no parking spots - vehicles parked here will be hidden by the game
+                    if (gameLot != null && (gameLot.ParkingSpots == null || gameLot.ParkingSpots.Count == 0))
+                    {
+                        Logger.Warning($"DriveToCarPark: Parking lot '{gameLot.gameObject.name}' has no parking spots. " +
+                            "The game will hide (SetVisible=false) any vehicle parked here. Choose a lot with ParkingSpot children.");
+                    }
+                }
 
                 // Resolve vehicle
                 object vehObj = null;
@@ -213,8 +234,15 @@ namespace S1API.Entities.Schedule
                 else if (!string.IsNullOrEmpty(VehicleCode))
                 {
                     var v = VehicleRegistry.CreateVehicle(VehicleCode);
-                    vehObj = v?.S1LandVehicle;
-                    
+                    if (v == null)
+                    {
+                        Logger.Error($"DriveToCarPark: Failed to create vehicle with code '{VehicleCode}'. Verify the code is valid.");
+                    }
+                    else
+                    {
+                        vehObj = v.S1LandVehicle;
+                    }
+
                     // If we're on the server and the vehicle needs spawning, spawn it now
                     if (vehObj != null)
                     {
@@ -228,23 +256,38 @@ namespace S1API.Entities.Schedule
                                 #else
                                 var nm = Il2CppFishNet.InstanceFinder.NetworkManager;
                                 #endif
-                                
+
                                 if (nm != null && nm.IsServer)
                                 {
-                                    // Spawn the vehicle at the specified location and rotation
                                     var spawnRot = VehicleSpawnRotation ?? Quaternion.identity;
                                     wrapper.Spawn(VehicleSpawnPosition, spawnRot);
                                 }
                             }
                             catch (Exception ex)
                             {
-                                UnityEngine.Debug.LogWarning($"[S1API] Failed to spawn created vehicle: {ex.Message}");
+                                Logger.Error($"DriveToCarPark: Failed to spawn created vehicle '{VehicleCode}': {ex.Message}");
+                                Logger.Error($"DriveToCarPark: Stack trace: {ex.StackTrace}");
                             }
                         }
                     }
                 }
-                if (vehObj != null)
+
+                if (vehObj == null)
+                {
+                    Logger.Warning("DriveToCarPark: Vehicle could not be resolved. The NPC will not be able to drive.");
+                }
+                else
+                {
                     ReflectionUtils.TrySetFieldOrProperty(action, "Vehicle", vehObj);
+
+                    // Track vehicles created for lots with no spots so the patch can prevent hiding
+                    if (gameLot != null && (gameLot.ParkingSpots == null || gameLot.ParkingSpots.Count == 0))
+                    {
+                        var gameVeh = vehObj as S1Vehicles.LandVehicle;
+                        if (gameVeh != null)
+                            VehiclesAtNoSpotLots.Add(gameVeh);
+                    }
+                }
 
                 // Flags
                 if (OverrideParkingType.HasValue)
@@ -261,7 +304,18 @@ namespace S1API.Entities.Schedule
                     ReflectionUtils.TrySetFieldOrProperty(action, "ParkingType", boxed);
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Logger.Error($"DriveToCarPark: Unexpected error during ApplyTo: {ex.Message}");
+                Logger.Error($"DriveToCarPark: Stack trace: {ex.StackTrace}");
+            }
         }
+
+        /// <summary>
+        /// INTERNAL: Tracks vehicles assigned to parking lots with no spots.
+        /// Used by the LandVehicle.Park patch to prevent the game from hiding these vehicles.
+        /// </summary>
+        internal static readonly System.Collections.Generic.HashSet<S1Vehicles.LandVehicle> VehiclesAtNoSpotLots =
+            new System.Collections.Generic.HashSet<S1Vehicles.LandVehicle>();
     }
 }

--- a/S1API/Internal/Entities/NPCPrefabIdentity.cs
+++ b/S1API/Internal/Entities/NPCPrefabIdentity.cs
@@ -662,6 +662,29 @@ namespace S1API.Internal.Entities
                 {
                     Logger.Warning($"[Dealer Home] Failed to set Home property on Dealer component for NPC {npc?.ID ?? "<null>"}");
                 }
+                else
+                {
+                    // Dealer.Awake() runs HomeEvent.Building = Home, but for S1API NPCs
+                    // Home is null at Awake-time (resolved later). We must sync HomeEvent.Building
+                    // so the schedule system knows where to send the dealer.
+                    try
+                    {
+#if MONOMELON
+                        var homeEventField = typeof(S1Economy.Dealer).GetField("HomeEvent", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+#else
+                        var homeEventField = typeof(S1Economy.Dealer).GetProperty("HomeEvent", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+#endif
+                        var homeEvent = homeEventField?.GetValue(dealerComponent);
+                        if (homeEvent != null)
+                        {
+                            ReflectionUtils.TrySetFieldOrProperty(homeEvent, "Building", gameBuilding);
+                        }
+                    }
+                    catch (Exception homeEventEx)
+                    {
+                        Logger.Warning($"[Dealer Home] Failed to sync HomeEvent.Building for NPC {npc?.ID ?? "<null>"}: {homeEventEx.Message}");
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/S1API/Internal/Lifecycle/SceneStateCleaner.cs
+++ b/S1API/Internal/Lifecycle/SceneStateCleaner.cs
@@ -1,4 +1,5 @@
 using System;
+using S1API.Dialogues;
 using S1API.Entities;
 using S1API.Avatar;
 using S1API.Logging;
@@ -100,6 +101,22 @@ namespace S1API.Internal.Lifecycle
                     
                     // Reset loading screen patch state to prevent stuck flags
                     LoadingScreenPatches.ResetState();
+
+                    // Reset dialogue system static state to prevent stale injections/callbacks
+                    DialogueInjector.ResetState();
+                    DialogueChoiceListener.ResetState();
+
+                    // Reset contacts app state so it re-initializes properly on next load
+                    ContactsAppPatches.ResetState();
+
+                    // Clear stale NPC patch state (dangling Customer references, loading guards)
+                    NPCPatches.ResetState();
+
+                    // Clear stale delegates from Dealer.onDealerRecruited static field
+                    NPCDealer.ClearStaticDelegates();
+
+                    // Clear accumulated shim delegates to prevent stale references on next load
+                    TimeManagerShim.Instance.ResetDelegates();
                 }
                 else
                 {

--- a/S1API/Internal/Lifecycle/TimeManagerShim.cs
+++ b/S1API/Internal/Lifecycle/TimeManagerShim.cs
@@ -31,6 +31,21 @@ namespace S1API.Internal.Lifecycle
 
         private TimeManagerShim() { }
 
+        /// <summary>
+        /// Clears accumulated delegates so stale references from a previous load don't leak into the next session.
+        /// </summary>
+        internal void ResetDelegates()
+        {
+            onSleepStart = delegate { };
+            onHourPass = delegate { };
+#if IL2CPPMELON
+            il2cppOnSleepStart = null;
+            il2cppOnHourPass = null;
+            _addedSleepStart.Clear();
+            _addedHourPass.Clear();
+#endif
+        }
+
         internal void AddDelegatesToReal()
         {
             try

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -40,6 +40,15 @@ namespace S1API.Internal.Patches
         private static bool? _hasCustomNpcTypesCache;
 
         /// <summary>
+        /// Resets static state so the contacts app initializes correctly across save loads.
+        /// </summary>
+        internal static void ResetState()
+        {
+            _startCalled = false;
+            _hasCustomNpcTypesCache = null;
+        }
+
+        /// <summary>
         /// Checks if any custom NPC types exist (excluding S1API internal types).
         /// Caches the result to avoid repeated reflection calls.
         /// </summary>

--- a/S1API/Internal/Patches/DealerManagementAppPatches.cs
+++ b/S1API/Internal/Patches/DealerManagementAppPatches.cs
@@ -1,0 +1,134 @@
+#if (IL2CPPMELON)
+using S1DealerManagementApp = Il2CppScheduleOne.UI.Phone.Messages.DealerManagementApp;
+using S1Economy = Il2CppScheduleOne.Economy;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1DealerManagementApp = ScheduleOne.UI.Phone.Messages.DealerManagementApp;
+using S1Economy = ScheduleOne.Economy;
+#endif
+
+using System;
+using System.Reflection;
+using HarmonyLib;
+using S1API.Internal.Utils;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Patches DealerManagementApp to refresh the dropdown when opened.
+    /// Fixes stale mugshot sprites and region text for custom S1API dealers whose
+    /// properties are set in OnCreated (after the dropdown was initially populated).
+    /// </summary>
+    [HarmonyPatch]
+    internal static class DealerManagementAppPatches
+    {
+        private static readonly Logging.Log Logger = new Logging.Log("DealerManagementAppPatches");
+
+        #region Private Implementation
+
+        /// <summary>
+        /// Calls the private RefreshDropdown method and restores the selected dealer index.
+        /// </summary>
+        private static void RefreshAndSyncDropdown(S1DealerManagementApp instance)
+        {
+            var selectedDealer = instance.SelectedDealer;
+
+#if (IL2CPPMELON)
+            try
+            {
+                instance.RefreshDropdown();
+            }
+            catch
+            {
+                var method = typeof(S1DealerManagementApp).GetMethod("RefreshDropdown",
+                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                method?.Invoke(instance, null);
+            }
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+            var method = typeof(S1DealerManagementApp).GetMethod("RefreshDropdown",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            if (method == null)
+                return;
+            method.Invoke(instance, null);
+#endif
+
+            if (selectedDealer == null)
+                return;
+
+#if (IL2CPPMELON)
+            var dealers = instance.dealers;
+            if (dealers == null)
+                return;
+
+            int index = -1;
+            for (int i = 0; i < dealers.Count; i++)
+            {
+                if (dealers[i] == selectedDealer)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index >= 0)
+                instance._dropdown?.SetValueWithoutNotify(index);
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+            var dealersObj = ReflectionUtils.TryGetFieldOrProperty(instance, "dealers");
+            var dealers = dealersObj as System.Collections.Generic.List<S1Economy.Dealer>;
+            if (dealers == null)
+                return;
+
+            int index = dealers.IndexOf(selectedDealer);
+            if (index < 0)
+                return;
+
+            var dropdownObj = ReflectionUtils.TryGetFieldOrProperty(instance, "_dropdown");
+            var dropdown = dropdownObj as UnityEngine.UI.Dropdown;
+            if (dropdown != null)
+                dropdown.SetValueWithoutNotify(index);
+#endif
+        }
+
+        #endregion
+
+        #region Harmony Patches
+
+        /// <summary>
+        /// After SetOpen(true), rebuild the dropdown so it reflects current MugshotSprite and Region values.
+        /// </summary>
+        [HarmonyPatch(typeof(S1DealerManagementApp), nameof(S1DealerManagementApp.SetOpen))]
+        [HarmonyPostfix]
+        private static void SetOpen_Postfix(S1DealerManagementApp __instance, bool open)
+        {
+            if (!open)
+                return;
+
+            try
+            {
+                RefreshAndSyncDropdown(__instance);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to refresh dealer dropdown on open: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// After Refresh(), rebuild the dropdown so it reflects current values when the phone is reopened.
+        /// </summary>
+        [HarmonyPatch(typeof(S1DealerManagementApp), nameof(S1DealerManagementApp.Refresh))]
+        [HarmonyPostfix]
+        private static void Refresh_Postfix(S1DealerManagementApp __instance)
+        {
+            try
+            {
+                RefreshAndSyncDropdown(__instance);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Failed to refresh dealer dropdown on refresh: {ex.Message}");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/S1API/Internal/Patches/LandVehiclePatches.cs
+++ b/S1API/Internal/Patches/LandVehiclePatches.cs
@@ -1,7 +1,8 @@
 ﻿using HarmonyLib;
 using S1API.Vehicles;
+using S1API.Entities.Schedule;
 
-#if (IL2CPPMELON || Il2CppBepInEx)
+#if (IL2CPPMELON || IL2CPPBEPINEX)
 using S1Vehicles = Il2CppScheduleOne.Vehicles;
 #else
 using S1Vehicles = ScheduleOne.Vehicles;
@@ -18,7 +19,10 @@ namespace S1API.Internal.Patches
             try
             {
                 if (__instance != null)
+                {
                     VehicleRegistry.RemoveVehicle(__instance.GUID.ToString());
+                    DriveToCarParkSpec.VehiclesAtNoSpotLots.Remove(__instance);
+                }
             }
             catch
             {
@@ -26,5 +30,28 @@ namespace S1API.Internal.Patches
             }
         }
 
+        /// <summary>
+        /// Prevents the game from hiding vehicles that were assigned to parking lots with no
+        /// parking spots. When spotIndex is invalid, the game calls SetVisible(false). This
+        /// prefix intercepts that call and keeps the vehicle visible instead, leaving it
+        /// wherever it currently is (e.g. where the NPC drove it).
+        /// </summary>
+        [HarmonyPatch(nameof(S1Vehicles.LandVehicle.SetVisible))]
+        [HarmonyPrefix]
+        public static bool SetVisible_Prefix(S1Vehicles.LandVehicle __instance, ref bool vis)
+        {
+            try
+            {
+                if (!vis && __instance != null && DriveToCarParkSpec.VehiclesAtNoSpotLots.Contains(__instance))
+                {
+                    vis = true;
+                }
+            }
+            catch
+            {
+                // Don't break game visibility if our fix-up fails
+            }
+            return true;
+        }
     }
 }

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -75,6 +75,15 @@ namespace S1API.Internal.Patches
             = new System.Collections.Generic.Dictionary<S1Economy.Customer, float>();
 
         /// <summary>
+        /// Resets static state that can leak across save loads.
+        /// </summary>
+        internal static void ResetState()
+        {
+            _savedCurrentAddiction.Clear();
+            _loadingDealers.Clear();
+        }
+
+        /// <summary>
         /// Comparison function for sorting NPCAction by StartTime, with signals coming before non-signals when times are equal.
         /// </summary>
         private static int CompareNPCActions(S1NPCsSchedules.NPCAction a, S1NPCsSchedules.NPCAction b)

--- a/S1API/Internal/Patches/StoragePatches.cs
+++ b/S1API/Internal/Patches/StoragePatches.cs
@@ -50,6 +50,41 @@ namespace S1API.Internal.Patches
         }
 
         /// <summary>
+        /// Manually parse the custom name from RenamableConfigurationData JSON.
+        /// Handles both compact and pretty-printed formats.
+        /// </summary>
+        private static string ParseConfigurationName(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                return null;
+
+            try
+            {
+                int valueKeyIdx = json.IndexOf("\"Value\"");
+                if (valueKeyIdx < 0)
+                    return null;
+
+                int colonIdx = json.IndexOf(':', valueKeyIdx + 7);
+                if (colonIdx < 0)
+                    return null;
+
+                int openQuote = json.IndexOf('"', colonIdx + 1);
+                if (openQuote < 0)
+                    return null;
+
+                int closeQuote = json.IndexOf('"', openQuote + 1);
+                if (closeQuote < 0)
+                    return null;
+
+                return json.Substring(openQuote + 1, closeQuote - openQuote - 1);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Manually parse StorageSlotMeta from JSON to avoid IL2CPP generic method issues.
         /// </summary>
         private static StorageSlotMeta ParseStorageSlotMeta(string json)
@@ -335,6 +370,25 @@ namespace S1API.Internal.Patches
                 wrapper.SetSlotCount(targetSlots);
 
                 storageData.Contents.LoadTo(placeableStorage.StorageEntity.ItemSlots);
+
+                // Load the Configuration (custom name) from save data.
+                // The original loader does this deferred via onLoadComplete, but we apply it
+                // directly since Configuration is already initialized after LoadAndCreate.
+                if (data.TryGetData("Configuration", out string configJson) && !string.IsNullOrEmpty(configJson))
+                {
+                    try
+                    {
+                        var configName = ParseConfigurationName(configJson);
+                        if (!string.IsNullOrEmpty(configName) && placeableStorage.Configuration?.Name != null)
+                        {
+                            placeableStorage.Configuration.Name.SetValue(configName, true);
+                        }
+                    }
+                    catch (Exception configEx)
+                    {
+                        Logger.Warning($"Failed to load storage configuration name: {configEx.Message}");
+                    }
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Bug Fixes & Stability Improvements                                                                                                                                                                                                                                                                             
  ### Summary                                                                                                                                                                                                                                                                                                    
  - Fixed static state not being reset on scene save/reload, preventing stale data across sessions
  - Improved DriveToCarPark action with better logging and a vehicle visibility fix                                                                                                                                                                                                                                - Patched DealerManagementApp dropdown to work correctly with modded dealers                                                                                                                                                                                                                                   
  - Fixed dealers resolving to incorrect home locations
  - Restored storage configuration names being lost after loading a save

  ### Changes

  **Reset static state on scene save/reload**
  Adds `SceneStateCleaner` and `TimeManagerShim` to properly clear static caches (dialogue listeners, injectors, NPC dealers, contacts, NPC patches) when scenes are saved or reloaded.

  **Improve DriveToCarPark logging and visibility fix**
  Reworks `DriveToCarParkSpec` with improved debug logging and fixes a bug where land vehicles could become invisible via `LandVehiclePatches`.

  **Patch DealerManagementApp dropdown**
  Adds `DealerManagementAppPatches` to fix the dealer management dropdown not populating correctly for modded NPC dealers.

  **Fix dealers home location**
  Introduces `NPCPrefabIdentity` to correctly resolve dealer home locations, fixing misrouted NPCs.

  **Restore storage configuration name from save**
  Adds `StoragePatches` to restore the storage configuration name that was being lost when loading a saved game.

  ### Test plan
  - [ ] Load a save and verify storage names persist
  - [ ] Add a modded dealer and confirm the management app dropdown works
  - [ ] Verify NPC dealers navigate to correct home locations
  - [ ] Save/reload a scene and confirm no stale static state
  - [ ] Observe DriveToCarPark behavior and confirm vehicles remain visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Reset dialogue system state**: Added `ResetState()` methods to `DialogueChoiceListener` and `DialogueInjector` to clear static state across save/reload cycles, preventing stale listeners and pending injections
- **Clear dealer callbacks**: Introduced `ClearStaticDelegates()` in `NPCDealer` to prevent accumulation of dead wrapper delegates on scene changes
- **Synchronize dealer home locations**: Enhanced `NPCDealer.Home` setter to update `Dealer.HomeEvent.Building` field via reflection, ensuring correct NPC routing and preventing home location mismatches
- **Improved DriveToCarParkSpec robustness**: Added comprehensive logging, vehicle spawn failure handling, and introduced `VehiclesAtNoSpotLots` tracking to prevent in-game hiding of vehicles assigned to parking lots without spots
- **Prevent vehicle visibility override**: Added Harmony prefix patch to `LandVehicle.SetVisible` to keep tracked vehicles visible and preserve their state
- **Fixed dealer dropdown UI**: Introduced `DealerManagementAppPatches` to refresh and repopulate the dealer dropdown on open/refresh with proper selected index restoration, supporting modded NPC dealers
- **Restore storage custom names**: Added `StoragePatches` with JSON parsing to extract and reapply `RenamableConfigurationData` names that were lost on save load
- **Comprehensive scene cleanup**: Added `SceneStateCleaner` to reset all static caches on scene save/reload including dialogue, contacts, NPC patches, time manager, and dealer state
- **Reset time manager delegates**: Introduced `ResetDelegates()` method in `TimeManagerShim` to clear previously registered sleep and hour-pass callbacks
- **Reset contacts app state**: Added `ResetState()` to `ContactsAppPatches` to reinitialize on scene transitions

## Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| HazDS | 403 | 12 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->