### PR TITLE
Add Sit schedule action and duration support

### DIFF
--- a/S1API/Entities/NPCPrefabBuilder.cs
+++ b/S1API/Entities/NPCPrefabBuilder.cs
@@ -867,7 +867,7 @@ namespace S1API.Entities
 
             var mgr = EnsureScheduleManager();
 
-            int walkTo = 0, stayInBuilding = 0, locationDialogue = 0, locationBasedAction = 0, useVending = 0, driveToCarPark = 0, dealSignal = 0, useATM = 0;
+            int walkTo = 0, stayInBuilding = 0, locationDialogue = 0, locationBasedAction = 0, useVending = 0, driveToCarPark = 0, dealSignal = 0, useATM = 0, sit = 0;
             bool requiresSmokeBreak = false, requiresGraffiti = false, requiresDrinking = false, requiresHoldItem = false;
             for (int i = 0; i < specs.Count; i++)
             {
@@ -898,6 +898,7 @@ namespace S1API.Entities
                 else if (s is DriveToCarParkSpec) driveToCarPark++;
                 else if (s is EnsureDealSignalSpec) dealSignal = Math.Max(dealSignal, 1);
                 else if (s is UseATMSpec) useATM++;
+                else if (s is SitSpec) sit++;
             }
 
             if (requiresSmokeBreak)
@@ -937,6 +938,7 @@ namespace S1API.Entities
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_UseVendingMachine>(useVending, "UseVending");
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_DriveToCarPark>(driveToCarPark, "DriveToCarPark");
             EnsurePrefabAction<S1NPCsSchedules.NPCSignal_UseATM>(useATM, "UseATM");
+            EnsurePrefabAction<S1NPCsSchedules.NPCEvent_Sit>(sit, "Sit");
         }
 
         private void EnsurePrefabAction<T>(int count, string namePrefix) where T : S1NPCsSchedules.NPCAction

--- a/S1API/Entities/Schedule/ActionSpecs/SitSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/SitSpec.cs
@@ -26,9 +26,15 @@ namespace S1API.Entities.Schedule
     public sealed class SitSpec : IScheduleActionSpec
     {
         /// <summary>
-        /// Gets or sets the start time for this action, in minutes from midnight.
+        /// Gets or sets the start time for this action, in 24-hour time (e.g. 830 for 8:30 AM).
         /// </summary>
         public int StartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the duration of the sit action in minutes.
+        /// If not set (0 or negative), defaults to the time remaining until the next scheduled action.
+        /// </summary>
+        public int DurationMinutes { get; set; }
 
         /// <summary>
         /// Gets or sets the optional display name for this action. Defaults to "Sit".
@@ -98,6 +104,7 @@ namespace S1API.Entities.Schedule
             }
 
             action.WarpIfSkipped = WarpIfSkipped;
+            action.Duration = DurationMinutes > 0 ? DurationMinutes : 60;
         }
 
         private S1AvatarAnimation.AvatarSeatSet ResolveSeatSet(NPCSchedule schedule)

--- a/S1API/Entities/Schedule/NPCScheduleBuilder.cs
+++ b/S1API/Entities/Schedule/NPCScheduleBuilder.cs
@@ -64,7 +64,8 @@ namespace S1API.Entities.Schedule
         /// Adds a seating action that moves the NPC to an available seat within the specified seat set.
         /// </summary>
         /// <param name="seatSetName">The GameObject name of the <c>AvatarSeatSet</c> to use.</param>
-        /// <param name="startTime">The time when this action should start, in minutes from midnight (0-1439).</param>
+        /// <param name="startTime">The time when this action should start, in 24-hour time (e.g. 830 for 8:30 AM).</param>
+        /// <param name="durationMinutes">Duration of the sit action in minutes. Defaults to 60.</param>
         /// <param name="warpIfSkipped">Whether the NPC should be warped to the seat if the action is skipped. Default is <c>false</c>.</param>
         /// <param name="name">Optional custom name for this action; defaults to "Sit".</param>
         /// <returns>This builder instance for method chaining.</returns>
@@ -73,7 +74,7 @@ namespace S1API.Entities.Schedule
         /// lookup scenarios (GUIDs, transform paths, direct references) instantiate <see cref="SitSpec"/> manually and
         /// add it via <see cref="Add(IScheduleActionSpec)"/>.
         /// </remarks>
-        public PrefabScheduleBuilder SitAtSeatSet(string seatSetName, int startTime, bool warpIfSkipped = false, string name = null)
+        public PrefabScheduleBuilder SitAtSeatSet(string seatSetName, int startTime, int durationMinutes = 60, bool warpIfSkipped = false, string name = null)
         {
             if (!string.IsNullOrEmpty(seatSetName))
             {
@@ -81,6 +82,7 @@ namespace S1API.Entities.Schedule
                 {
                     SeatSetName = seatSetName,
                     StartTime = startTime,
+                    DurationMinutes = durationMinutes,
                     WarpIfSkipped = warpIfSkipped,
                     Name = name
                 });


### PR DESCRIPTION
Track and emit sit actions for NPC prefabs and add configurable duration to Sit specs. NPCPrefabBuilder now counts SitSpec instances and ensures a corresponding prefab action (NPCEvent_Sit). SitSpec gained a DurationMinutes property and sets action.Duration (defaulting to 60 minutes when not positive); StartTime doc was clarified to 24-hour format. PrefabScheduleBuilder.SitAtSeatSet was updated to accept a durationMinutes parameter and pass it into the SitSpec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added sit action tracking for NPC prefabs by counting `SitSpec` instances and ensuring a corresponding `NPCEvent_Sit` prefab action is created
- Introduced configurable duration support for sit actions via the new `DurationMinutes` property on `SitSpec`, with a default duration of 60 minutes when a non-positive value is provided
- Updated `PrefabScheduleBuilder.SitAtSeatSet()` method signature to accept a `durationMinutes` parameter (defaults to 60)
- Clarified `SitSpec.StartTime` documentation to specify 24-hour format input

| Author | Files Changed | Lines Added | Lines Removed |
|--------|---------------|-------------|---------------|
| HazDS | 3 | 15 | 4 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->