### PR TITLE
Add seatSetPath and make SitSpec fail-safe

### DIFF
--- a/S1API/Entities/Schedule/ActionSpecs/SitSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/SitSpec.cs
@@ -19,9 +19,21 @@ namespace S1API.Entities.Schedule
     /// Specifies an action that seats an NPC at an <see cref="S1AvatarAnimation.AvatarSeatSet"/>.
     /// </summary>
     /// <remarks>
-    /// The specification resolves an <see cref="S1AvatarAnimation.AvatarSeatSet"/> using one of the provided
+    /// <para>The specification resolves an <see cref="S1AvatarAnimation.AvatarSeatSet"/> using one of the provided
     /// lookup mechanisms and configures a <see cref="S1NPCsSchedules.NPCEvent_Sit"/> instance on the target
-    /// schedule. This allows mods to declaratively schedule seating behaviour through the S1API builder.
+    /// schedule. This allows mods to declaratively schedule seating behaviour through the S1API builder.</para>
+    ///
+    /// <para><strong>Important:</strong> When multiple seat sets share the same name (e.g. "outdoorbench"),
+    /// use <see cref="SeatSetPath"/> to target a specific one by its full hierarchy path
+    /// (e.g. "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)"). Name lookups return the first match found.</para>
+    ///
+    /// <para><strong>Duration:</strong> You must set <see cref="DurationMinutes"/> to a positive value.
+    /// The game's <c>NPCEvent_Sit</c> uses Duration to calculate its end time. With Duration=0 the action
+    /// has a zero-width time range and will never be matched by the schedule manager.</para>
+    ///
+    /// <para><strong>Seat set resolution failure:</strong> If the seat set cannot be resolved, the action
+    /// is disabled to prevent a NullReferenceException in <c>NPCEvent_Sit.Started()</c> which would
+    /// permanently break the NPC's schedule. A warning is logged to help diagnose the issue.</para>
     /// </remarks>
     public sealed class SitSpec : IScheduleActionSpec
     {
@@ -32,7 +44,7 @@ namespace S1API.Entities.Schedule
 
         /// <summary>
         /// Gets or sets the duration of the sit action in minutes.
-        /// If not set (0 or negative), defaults to the time remaining until the next scheduled action.
+        /// If not set (0 or negative), defaults to 60 minutes. Must be positive for the action to trigger.
         /// </summary>
         public int DurationMinutes { get; set; }
 
@@ -100,7 +112,10 @@ namespace S1API.Entities.Schedule
             else
             {
                 var npcName = schedule.NPC?.gameObject != null ? schedule.NPC.gameObject.name : "Unknown";
-                Debug.LogWarning($"[S1API] SitSpec could not resolve a seat set (Name={SeatSetName}, Path={SeatSetPath}) for NPC '{npcName}'.");
+                Debug.LogWarning($"[S1API] SitSpec could not resolve a seat set (Name={SeatSetName}, Path={SeatSetPath}) for NPC '{npcName}'. Disabling action to prevent crash.");
+                action.enabled = false;
+                action.gameObject.SetActive(false);
+                return;
             }
 
             action.WarpIfSkipped = WarpIfSkipped;

--- a/S1API/Entities/Schedule/NPCScheduleBuilder.cs
+++ b/S1API/Entities/Schedule/NPCScheduleBuilder.cs
@@ -63,24 +63,35 @@ namespace S1API.Entities.Schedule
         /// <summary>
         /// Adds a seating action that moves the NPC to an available seat within the specified seat set.
         /// </summary>
-        /// <param name="seatSetName">The GameObject name of the <c>AvatarSeatSet</c> to use.</param>
-        /// <param name="startTime">The time when this action should start, in 24-hour time (e.g. 830 for 8:30 AM).</param>
-        /// <param name="durationMinutes">Duration of the sit action in minutes. Defaults to 60.</param>
+        /// <param name="seatSetName">The GameObject name of the <c>AvatarSeatSet</c> to use. Can be <c>null</c> if <paramref name="seatSetPath"/> is provided.</param>
+        /// <param name="startTime">The time when this action should start, in 24-hour HHMM format (e.g. 830 for 8:30 AM, 1400 for 2:00 PM).</param>
+        /// <param name="durationMinutes">Duration of the sit action in minutes. Defaults to 60. Must be positive for the action to trigger.</param>
         /// <param name="warpIfSkipped">Whether the NPC should be warped to the seat if the action is skipped. Default is <c>false</c>.</param>
         /// <param name="name">Optional custom name for this action; defaults to "Sit".</param>
+        /// <param name="seatSetPath">Optional full hierarchy path to the seat set GameObject (e.g. "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)"). Use this when multiple seat sets share the same name to target a specific one.</param>
         /// <returns>This builder instance for method chaining.</returns>
         /// <remarks>
-        /// This convenience overload creates a <see cref="SitSpec"/> that resolves a seat set by name. For more advanced
-        /// lookup scenarios (GUIDs, transform paths, direct references) instantiate <see cref="SitSpec"/> manually and
-        /// add it via <see cref="Add(IScheduleActionSpec)"/>.
+        /// <para>This method creates a <see cref="SitSpec"/> that resolves a seat set by name, path, or both.
+        /// When multiple seat sets share the same name (e.g. "outdoorbench"), use <paramref name="seatSetPath"/>
+        /// to target a specific one. The path is matched case-insensitively against the full transform hierarchy.</para>
+        ///
+        /// <para><strong>Example — by name:</strong></para>
+        /// <code>plan.SitAtSeatSet("Fast Food Booth", 900, durationMinutes: 60)</code>
+        ///
+        /// <para><strong>Example — by path (when name is ambiguous):</strong></para>
+        /// <code>plan.SitAtSeatSet(null, 1650, durationMinutes: 130, seatSetPath: "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)")</code>
+        ///
+        /// <para>If the seat set cannot be resolved at runtime, the action is disabled and a warning is logged.
+        /// This prevents a NullReferenceException that would permanently break the NPC's schedule.</para>
         /// </remarks>
-        public PrefabScheduleBuilder SitAtSeatSet(string seatSetName, int startTime, int durationMinutes = 60, bool warpIfSkipped = false, string name = null)
+        public PrefabScheduleBuilder SitAtSeatSet(string seatSetName, int startTime, int durationMinutes = 60, bool warpIfSkipped = false, string name = null, string seatSetPath = null)
         {
-            if (!string.IsNullOrEmpty(seatSetName))
+            if (!string.IsNullOrEmpty(seatSetName) || !string.IsNullOrEmpty(seatSetPath))
             {
                 _specs.Add(new SitSpec
                 {
                     SeatSetName = seatSetName,
+                    SeatSetPath = seatSetPath,
                     StartTime = startTime,
                     DurationMinutes = durationMinutes,
                     WarpIfSkipped = warpIfSkipped,

--- a/S1API/docs/scheduling-system.md
+++ b/S1API/docs/scheduling-system.md
@@ -257,21 +257,30 @@ builder.EnsureSmokeBreak()
 
 ### SitAtSeatSet
 
-Seat the NPC at a configured seating area:
+Seat the NPC at a configured seating area. The NPC will walk to the seat and sit down for the specified duration.
 
 ```csharp
-plan.SitAtSeatSet("OutdoorBench", 900, warpIfSkipped: true);
+// By name — finds the first AvatarSeatSet with this GameObject name
+plan.SitAtSeatSet("Fast Food Booth", 900, durationMinutes: 60);
+
+// By path — use when multiple seat sets share the same name
+plan.SitAtSeatSet(null, 1650, durationMinutes: 130,
+    seatSetPath: "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)");
 ```
 
 **Parameters:**
-- `seatSetName`: GameObject name of the `AvatarSeatSet`
-- `startTime`: Time to begin the seating action (24h format)
-- `warpIfSkipped`: Whether to warp the NPC to the seat if missed (default: false)
+- `seatSetName`: GameObject name of the `AvatarSeatSet`. Can be `null` if `seatSetPath` is provided.
+- `startTime`: Time to begin the seating action (24h HHMM format)
+- `durationMinutes`: How long the NPC sits in minutes (default: 60). **Must be positive** — with duration 0 the action will never trigger.
+- `warpIfSkipped`: Whether to warp the NPC to the seat if the action is skipped (default: false)
 - `name`: Optional action name; defaults to "Sit"
+- `seatSetPath`: Optional full hierarchy path to the seat set GameObject (e.g. `"Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)"`). Use this when multiple seat sets share the same name.
 
-**Notes:**
-- Seat sets can be located in the Unity hierarchy (inactive objects are supported)
-- For complex lookups (path or direct reference), create a `SitSpec` manually and add it via `plan.Add`
+**Important notes:**
+- Name lookups are case-insensitive and return the first match. Use `seatSetPath` when you need a specific seat set among duplicates.
+- If the seat set cannot be resolved, the action is automatically disabled and a warning is logged. This prevents the NPC's schedule from breaking permanently.
+- The NPC must be able to reach the seat — ensure a preceding action (e.g. `LocationBased`) gets the NPC close enough before the sit starts, or give enough travel time in the duration of the previous action.
+- For complex lookups (direct object reference, custom search settings), create a `SitSpec` manually and add it via `plan.Add`
 
 ## Action Specs
 
@@ -375,26 +384,47 @@ plan.Add(new LocationDialogueSpec {
 
 ### SitSpec
 
-Seat an NPC using an existing `AvatarSeatSet`:
+Seat an NPC using an existing `AvatarSeatSet`. Use the spec directly when you need advanced lookup options beyond what `SitAtSeatSet()` provides.
 
 ```csharp
+// By name
 plan.Add(new SitSpec {
     StartTime = 900,
-    SeatSetName = "OutdoorBench",
-    WarpIfSkipped = true,
+    DurationMinutes = 60,
+    SeatSetName = "Fast Food Booth",
+    Name = "Breakfast"
+});
+
+// By path (for ambiguous names)
+plan.Add(new SitSpec {
+    StartTime = 1650,
+    DurationMinutes = 130,
+    SeatSetPath = "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)",
+    Name = "WatchSunset"
+});
+
+// By direct reference
+plan.Add(new SitSpec {
+    StartTime = 900,
+    DurationMinutes = 60,
+    SeatSetReference = mySeatSetGameObject,
     Name = "MorningCoffee"
 });
 ```
 
 **Properties:**
-- `StartTime`: Time to begin the action
-- `SeatSetName`: GameObject name of the target `AvatarSeatSet`
-- `SeatSetPath`: Optional transform path (supports inactive objects)
-- `SeatSetReference`: Optional direct reference to the seat set or any component within it
-- `WarpIfSkipped`: Whether to warp the NPC directly to the seat when skipped
+- `StartTime`: Time to begin the action (24h HHMM format)
+- `DurationMinutes`: How long the NPC sits in minutes. **Must be positive** — with duration 0 the action has a zero-width time range and will never be matched by the schedule manager. Defaults to 60 if not set.
+- `SeatSetName`: GameObject name of the target `AvatarSeatSet` (case-insensitive, returns first match)
+- `SeatSetPath`: Full hierarchy path to the seat set (e.g. `"Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)"`). Use when multiple seat sets share the same name. Supports suffix matching.
+- `SeatSetReference`: Direct Unity object reference — can be an `AvatarSeatSet`, `GameObject`, or any `Component` in the seat set hierarchy
+- `WarpIfSkipped`: Whether to warp the NPC directly to the seat when the action is skipped
 - `Name`: Optional custom name for the action
 - `IncludeInactiveSearch`: Include inactive seat sets during lookup (default: true)
-- Use the seating registry (`S1API.Avatar.Seat`) to gather scene-specific seat metadata when authoring schedules
+
+**Resolution order:** Direct reference → path lookup → name lookup → NPC child search.
+
+**Failure handling:** If no seat set can be resolved, the action is disabled and a warning is logged. This prevents `NPCEvent_Sit.Started()` from throwing a NullReferenceException which would permanently break the NPC's schedule.
 
 ### DriveToCarParkSpec
 

--- a/S1API/docs/seating-registry.md
+++ b/S1API/docs/seating-registry.md
@@ -36,6 +36,27 @@ These methods return `null` if the underlying GameObject has been destroyed.
 
 ## Schedule Integration
 
-`SitSpec` continues to target an `AvatarSeatSet`. For seats that are not part of a set, use the
-registry data to create your own `AvatarSeatSet` prefab or to place NPCs manually. The `Seat.Label`
-and `Seat.HierarchyPath` values make it straightforward to map scene seats to your configuration assets.
+`SitSpec` targets an `AvatarSeatSet` and can resolve it by name, hierarchy path, or direct reference.
+
+```csharp
+// By name — quick lookup, finds the first matching AvatarSeatSet
+plan.SitAtSeatSet("Fast Food Booth", 900, durationMinutes: 60);
+
+// By path — use when multiple seat sets share the same name (e.g. "outdoorbench")
+plan.SitAtSeatSet(null, 1650, durationMinutes: 130,
+    seatSetPath: "Map/Hyland Point/Region_Docks/WaterFront/OutdoorBench (1)");
+```
+
+Use the registry's `HierarchyPath` to discover the correct path for `seatSetPath`. The path is matched
+case-insensitively and supports suffix matching, so you can omit leading scene root segments.
+
+**Important:** `durationMinutes` must be positive. The game uses Duration to calculate when the sit
+action ends — with duration 0 the action has a zero-width time range and will never trigger.
+
+If the seat set cannot be resolved at runtime, the action is automatically disabled and a warning is
+logged. This prevents a NullReferenceException in `NPCEvent_Sit.Started()` that would permanently
+break the NPC's schedule.
+
+For seats that are not part of a set, use the registry data to create your own `AvatarSeatSet` prefab
+or to place NPCs manually. The `Seat.Label` and `Seat.HierarchyPath` values make it straightforward
+to map scene seats to your configuration assets.


### PR DESCRIPTION
Add support for resolving seat sets by full hierarchy path (seatSetPath) and expose it on SitAtSeatSet. Change SitSpec to require a positive DurationMinutes (defaults to 60) and to disable the action (and deactivate its GameObject) with a logged warning when a seat set cannot be resolved to prevent NullReferenceExceptions. Update NPCScheduleBuilder API docs and the scheduling/seating registry documentation with examples, resolution order, and failure-handling guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

### Changes
- **Seat Set Resolution by Path**: Added `seatSetPath` parameter to `SitAtSeatSet` method, enabling resolution of seat sets via full hierarchy path in addition to name-based lookup
- **Fail-Safe Behavior**: SitSpec now gracefully handles unresolved seat sets by disabling the action, deactivating its GameObject, and logging a warning instead of causing NullReferenceExceptions
- **Duration Validation**: DurationMinutes now defaults to 60 minutes and must be positive to trigger
- **API Documentation**: Updated NPCScheduleBuilder API docs and scheduling/seating registry documentation with detailed examples, resolution order (direct reference → path lookup → name lookup → NPC child search), and failure-handling guidance

### Lines Changed by Contributor

| Author | File | Added | Removed |
|--------|------|-------|---------|
| HazDS  | S1API/Entities/Schedule/ActionSpecs/SitSpec.cs | 19 | 4 |
| HazDS  | S1API/Entities/Schedule/NPCScheduleBuilder.cs | 19 | 8 |
| HazDS  | S1API/docs/scheduling-system.md | 47 | 17 |
| HazDS  | S1API/docs/seating-registry.md | 24 | 3 |
| **Total** | | **109** | **32** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->