### PR TITLE
Removed Contacts connections patch and bump version

### DIFF
--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -925,58 +925,5 @@ namespace S1API.Internal.Patches
             indicator.gameObject.SetActive(isDealer);
         }
 
-        [HarmonyPatch(typeof(S1ContactsApp.ContactsDetailPanel), "Open")]
-        [HarmonyPostfix]
-        private static void ContactsDetailPanel_Open_Postfix(S1ContactsApp.ContactsDetailPanel __instance)
-        {
-            if (__instance == null) return;
-            if (__instance.transform == null) return;
-            if (__instance.TypeLabel.font == null) return;
-            var gameObject = __instance.transform.Find("Connections")?.gameObject;
-            if (gameObject == null)
-            {
-                gameObject = new GameObject("Connections");
-                gameObject.transform.SetParent(__instance.transform, false);
-                var text = gameObject.AddComponent<Text>();
-                text.font = __instance.TypeLabel.font;
-            }
-
-            var textComp = gameObject.GetComponent<Text>();
-            if (textComp == null)
-            {
-                Debug.LogWarning("Connections Text Component not found!");
-                return;
-            }
-
-            var npcConnections = __instance.SelectedNPC?.RelationData?.Connections;
-            if (npcConnections == null || npcConnections.Count == 0)
-            {
-                textComp.text = "Connections: None";
-                return;
-            }
-#if MONOMELON
-            var connsText = string.Join(", ", npcConnections.Where(c => c != null).Select(c =>
-#elif IL2CPPMELON
-            var connsText = string.Join(", ", npcConnections._items.Where(c => c != null).Select(c =>
-#endif
-            {
-                if (c.RelationData == null)
-                    return "???";
-                var isCustomer = NPC.IsCustomerType(c.GetType());
-
-                // Dealers/Suppliers have to be unlocked to see the name
-                if (!isCustomer)
-                {
-                    return c.RelationData.Unlocked
-                        ? c.fullName
-                        : "???";
-                }
-                // Customers can be known via mutual connections
-                return c.RelationData.IsKnown()
-                    ? c.fullName
-                    : "???";
-            }));
-            textComp.text = $"Connections: {connsText}";
-        }
     }
 }

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -5,7 +5,7 @@ using S1API.Internal.Lifecycle;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "2.9.8", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "2.9.9", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API


### PR DESCRIPTION
Remove the Harmony postfix for S1ContactsApp.ContactsDetailPanel.Open that created a "Connections" UI element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Removed Harmony postfix patch for S1ContactsApp.ContactsDetailPanel.Open that was creating a "Connections" UI element
- Bumped version to 2.9.9

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| HazDS  | 1           | 54            |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->