### PR TITLE
Remove callback resetting in DialogueChoiceListener

### DIFF
--- a/S1API/Dialogues/DialogueChoiceListener.cs
+++ b/S1API/Dialogues/DialogueChoiceListener.cs
@@ -71,7 +71,6 @@ namespace S1API.Dialogues
         private static void OnChoice()
         {
             _callback?.Invoke();
-            _callback = null; // optional: remove if one-time use
         }
     }
 }


### PR DESCRIPTION
Callbacks set in `DialogueChoiceListener` are resetting after one use. 
This leads to issues, where an entry added by `DialogueInjection` can experience degraded usefulness or break completely, due to lack of attached listener.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Removed callback resetting behavior in `DialogueChoiceListener.OnChoice()` to preserve listener callbacks across subsequent dialogue choice selections
- Prevents loss of attached listeners on entries added by `DialogueInjection`, maintaining functionality across multiple uses

## Contributor Statistics

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| k0     | 0          | 1             |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->