### PR TITLE
Add RemoveEventTrigger method to EventHelper

### DIFF
--- a/S1API/Internal/Abstraction/EventHelper.cs
+++ b/S1API/Internal/Abstraction/EventHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 
@@ -97,6 +98,28 @@ namespace S1API.Internal.Abstraction
             var entry = new EventTrigger.Entry { eventID = eventType };
             AddListener(listener, entry.callback);
             trigger.triggers.Add(entry);
+        }
+
+        /// <summary>
+        /// Removes an EventTrigger entry from the trigger.
+        /// </summary>
+        /// <param name="trigger">Target EventTrigger component</param>
+        /// <param name="eventType">The EventTriggerType to remove</param>
+        /// <param name="listener">BaseEventData callback to remove from the trigger</param>
+        public static void RemoveEventTrigger(EventTrigger trigger, EventTriggerType eventType,
+            Action<BaseEventData> listener)
+        {
+            if (trigger == null || listener == null || !SubscribedGenericActions.ContainsKey(listener)) 
+                return;
+            // We don't store the entry, so we need to find it
+            var entry = trigger.triggers.
+#if IL2CPPMELON
+                _items.
+#endif
+                FirstOrDefault(e => e.eventID == eventType);
+            if (entry == null) return;
+            RemoveListener(listener, entry.callback);
+            trigger.triggers.Remove(entry);
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a matching Remove method to already existing AddEventHelper.

This is useful in cross-backend setting, where direct removal via `RemoveListener(listener, trigger.triggers[0].callback)` is not possible, as Il2Cpp has issues resolving `UnityEngine.EventSystems.EventTrigger.get_triggers()'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added `RemoveEventTrigger` method to `EventHelper` class to enable programmatic removal of event triggers
- The method mirrors the existing `AddEventTrigger` functionality and addresses cross-backend scenarios where direct access to `EventTrigger.triggers` via Il2Cpp is unreliable
- Supports removal of event triggers by event type with proper validation and cleanup of both Unity listener callbacks and corresponding `EventTrigger` entries

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| k073l | 23 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->