### PR TITLE
Various fixed: PlaceableStorageEntity ID NRE, red eyes not applying, dealer inventory wipe

### DIFF
--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -74,6 +74,10 @@ namespace S1API.Internal.Patches
         private static readonly System.Collections.Generic.Dictionary<S1Economy.Customer, float> _savedCurrentAddiction
             = new System.Collections.Generic.Dictionary<S1Economy.Customer, float>();
 
+        // Pending inventory loads for custom dealers - stored until NPCInventory.Awake creates slots
+        private static readonly System.Collections.Generic.Dictionary<string, S1Datas.DeserializedItemSet> _pendingInventoryLoads
+            = new System.Collections.Generic.Dictionary<string, S1Datas.DeserializedItemSet>();
+
         /// <summary>
         /// Resets static state that can leak across save loads.
         /// </summary>
@@ -81,6 +85,7 @@ namespace S1API.Internal.Patches
         {
             _savedCurrentAddiction.Clear();
             _loadingDealers.Clear();
+            _pendingInventoryLoads.Clear();
         }
 
         /// <summary>
@@ -624,6 +629,13 @@ namespace S1API.Internal.Patches
                 {
                     var wrapperInventory = new NPCInventory(apiNpc);
                     wrapperInventory.EnsureInitialized();
+
+                    // Load pending inventory after slots are initialized
+                    if (baseNpc != null && _pendingInventoryLoads.TryGetValue(baseNpc.ID, out var pendingItemSet))
+                    {
+                        pendingItemSet.LoadTo(__instance.ItemSlots);
+                        _pendingInventoryLoads.Remove(baseNpc.ID);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -2248,6 +2260,17 @@ namespace S1API.Internal.Patches
                     {
                         Logger.Warning($"Failed to load overflow items for dealer '{baseNpc?.ID ?? "unknown"}': {ex.Message}");
                         Logger.Warning($"Stack trace: {ex.StackTrace}");
+                    }
+                }
+
+                if (isCustomNPC)
+                {
+                    if (dynamicData.TryGetData("Inventory", out var inventoryData))
+                    {
+                        if (S1Datas.ItemSet.TryDeserialize(inventoryData, out var itemSet))
+                            _pendingInventoryLoads[__instance.ID] = itemSet;
+                        else
+                            Logger.Warning($"Failed to deserialize inventory data for custom NPC dealer {__instance.ID}");
                     }
                 }
             }

--- a/S1API/Internal/Patches/ProductEffectPatches.cs
+++ b/S1API/Internal/Patches/ProductEffectPatches.cs
@@ -32,33 +32,33 @@ namespace S1API.Internal.Patches
         private static Dictionary<string, Type>? _npcWrapperTypeById;
 
         /// <summary>
-        /// Targets all concrete product instance ApplyEffectsToPlayer and ApplyEffectsToNPC implementations.
+        /// Targets only the base ProductItemInstance ApplyEffectsToPlayer and ApplyEffectsToNPC implementations.
+        /// Subclass overrides (e.g., WeedInstance) will run their custom logic and then call base,
+        /// which is intercepted here to route through callbacks.
         /// </summary>
         private static IEnumerable<MethodBase> TargetMethods()
         {
             var playerType = typeof(S1PlayerScripts.Player);
             var npcType = typeof(S1NPCs.NPC);
+            var baseType = typeof(S1Product.ProductItemInstance);
 
-            return typeof(S1Product.ProductItemInstance).Assembly
-                .GetTypes()
-                .Where(type => typeof(S1Product.ProductItemInstance).IsAssignableFrom(type))
-                .SelectMany(type => new[]
-                {
-                    type.GetMethod(
-                        "ApplyEffectsToPlayer",
-                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                        null,
-                        new[] { playerType },
-                        null),
-                    type.GetMethod(
-                        "ApplyEffectsToNPC",
-                        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                        null,
-                        new[] { npcType },
-                        null)
-                })
-                .Where(method => method != null)
-                .Cast<MethodBase>();
+            return new[]
+            {
+                baseType.GetMethod(
+                    "ApplyEffectsToPlayer",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { playerType },
+                    null),
+                baseType.GetMethod(
+                    "ApplyEffectsToNPC",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { npcType },
+                    null)
+            }
+            .Where(method => method != null)
+            .Cast<MethodBase>();
         }
 
         /// <summary>

--- a/S1API/Internal/Patches/StoragePatches.cs
+++ b/S1API/Internal/Patches/StoragePatches.cs
@@ -154,8 +154,16 @@ namespace S1API.Internal.Patches
         private static void PlaceableStorageEntity_Start_Postfix(S1ObjectScripts.PlaceableStorageEntity __instance)
         {
             // Skip if ItemInstance isn't ready yet - InitializeGridItem patch will handle it
-            if (__instance?.ItemInstance?.Definition == null)
+            try
+            {
+                if (__instance?.ItemInstance?.Definition == null)
+                    return;
+            }
+            catch (Exception)
+            {
+                // Accessing Definition accesses the ID, which can throw NRE
                 return;
+            }
 
             if (__instance.StorageEntity == null)
                 return;


### PR DESCRIPTION
Resolves #61, resolves #62, resolves #65.

I was unable to reproduce the issue in #62, but the error originated from that line - Definition property internally uses ID, which was mentioned in the stacktrace. Wrapping it in try-catch should be enough, especially given the comment above that we can exit early out of that patch.

For #65 I'd like to ask @JumbleBumble for review to determine if the fix I made wouldn't break anything that might be using this code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Fixed PlaceableStorageEntity NullReferenceException (#62)**: Wrapped Definition access in try-catch to prevent failures when ItemInstance lacks proper definition data
- **Fixed red eye effect not applying (#65)**: Narrowed patch target to only the base `ProductItemInstance.ApplyEffectsToPlayer/NPC` methods, preventing exceptions from subclass method interception
- **Fixed dealer inventory wipe (#61)**: Implemented pending inventory loads mechanism to preserve dealer NPC inventories across scene changes and player deaths

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| k073l  | 53          | 22            |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->