### PR TITLE
Add QualityItemDefinition wrappers, StorableItemDefinition clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ obj/
 bin/
 *.user
 .vs/
+smoke
 
 # Build props
 local.*

--- a/S1API/Items/ClothingItemInstance.cs
+++ b/S1API/Items/ClothingItemInstance.cs
@@ -3,6 +3,7 @@ using S1Clothing = Il2CppScheduleOne.Clothing;
 #elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
 using S1Clothing = ScheduleOne.Clothing;
 #endif
+using S1API.Internal.Utils;
 
 namespace S1API.Items
 {
@@ -40,7 +41,8 @@ namespace S1API.Items
         /// The clothing definition (template) this instance was created from.
         /// </summary>
         public new ClothingItemDefinition Definition =>
-            new ClothingItemDefinition((S1Clothing.ClothingDefinition)S1ClothingInstance.Definition);
+            new ClothingItemDefinition(
+                CrossType.As<S1Clothing.ClothingDefinition>(S1ClothingInstance.Definition));
     }
 }
 

--- a/S1API/Items/ItemCreator.cs
+++ b/S1API/Items/ItemCreator.cs
@@ -1,4 +1,14 @@
+using System;
+using S1API.Internal.Utils;
+using S1API.Leveling;
 using UnityEngine;
+#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Registry = Il2CppScheduleOne.Registry;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Registry = ScheduleOne.Registry;
+#endif
 
 namespace S1API.Items
 {
@@ -31,6 +41,44 @@ namespace S1API.Items
         }
 
         /// <summary>
+        /// Creates a new storable item builder by cloning an existing item by ID.
+        /// </summary>
+        /// <param name="sourceItemId">The ID of the item to clone.</param>
+        /// <returns>A builder pre-configured with the source item properties.</returns>
+        /// <exception cref="ArgumentException">Thrown if the source item ID is not found or is not a storable item.</exception>
+        public static StorableItemDefinitionBuilder CloneFrom(string sourceItemId)
+        {
+            var sourceDefinition = S1Registry.GetItem(sourceItemId);
+            if (sourceDefinition == null)
+            {
+                throw new ArgumentException($"Source item with ID '{sourceItemId}' not found in registry", nameof(sourceItemId));
+            }
+
+            if (!CrossType.Is(sourceDefinition, out S1ItemFramework.StorableItemDefinition storableDef))
+            {
+                throw new ArgumentException($"Item '{sourceItemId}' is not an StorableItemDefinition", nameof(sourceItemId));
+            }
+
+            return new StorableItemDefinitionBuilder(storableDef);
+        }
+
+        /// <summary>
+        /// Creates a new storable item builder by cloning an existing storable item wrapper.
+        /// </summary>
+        /// <param name="source">The storable item definition to clone.</param>
+        /// <returns>A builder pre-configured with the source item properties.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the source definition is null.</exception>
+        public static StorableItemDefinitionBuilder CloneFrom(StorableItemDefinition source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source), "Source storable item definition cannot be null");
+            }
+
+            return new StorableItemDefinitionBuilder(source.S1StorableItemDefinition);
+        }
+
+        /// <summary>
         /// Creates an item with common parameters in a single call.
         /// The item is automatically registered with the game's registry.
         /// </summary>
@@ -42,6 +90,8 @@ namespace S1API.Items
         /// <param name="basePurchasePrice">Base price when buying from shops (default: 10).</param>
         /// <param name="resellMultiplier">Fraction of purchase price recovered when selling (default: 0.5).</param>
         /// <param name="legalStatus">Whether the item is legal or illegal (default: Legal).</param>
+        /// <param name="requiresLevelToPurchase">Whether purchasing the item requires a certain player rank (default: false).</param>
+        /// <param name="requiredRank">The player rank required to purchase the item, if applicable (default: null).</param>
         /// <param name="icon">Optional sprite to use as the item icon.</param>
         /// <param name="equippable">Optional equippable component to attach.</param>
         /// <returns>A wrapper around the created item definition.</returns>
@@ -66,6 +116,8 @@ namespace S1API.Items
             float basePurchasePrice = 10f,
             float resellMultiplier = 0.5f,
             LegalStatus legalStatus = LegalStatus.Legal,
+            bool requiresLevelToPurchase = false,
+            FullRank? requiredRank = null,
             Sprite icon = null,
             Equippable equippable = null)
         {
@@ -73,6 +125,7 @@ namespace S1API.Items
                 .WithBasicInfo(id, name, description, category)
                 .WithStackLimit(stackLimit)
                 .WithPricing(basePurchasePrice, resellMultiplier)
+                .WithRequiredRank(requiredRank)
                 .WithLegalStatus(legalStatus);
 
             if (icon != null)

--- a/S1API/Items/ItemManager.cs
+++ b/S1API/Items/ItemManager.cs
@@ -64,6 +64,10 @@ namespace S1API.Items
                 return new AdditiveDefinition(additiveDefinition);
 
             if (CrossType.Is(itemDefinition,
+                    out S1ItemFramework.QualityItemDefinition qualityItemDefinition))
+                return new QualityItemDefinition(qualityItemDefinition);
+
+            if (CrossType.Is(itemDefinition,
                     out S1ItemFramework.StorableItemDefinition storableItemDefinition))
                 return new StorableItemDefinition(storableItemDefinition);
 

--- a/S1API/Items/QualityItemCreator.cs
+++ b/S1API/Items/QualityItemCreator.cs
@@ -1,0 +1,67 @@
+﻿#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Registry = Il2CppScheduleOne.Registry;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Registry = ScheduleOne.Registry;
+#endif
+using System;
+using S1API.Internal.Utils;
+
+namespace S1API.Items
+{
+    /// <summary>
+    /// Provides convenient static methods for creating custom quality items.
+    /// Use <see cref="CreateBuilder"/> for flexible configuration
+    /// or <see cref="CloneFrom"/> for quick variants based on existing items.
+    /// </summary>
+    public class QualityItemCreator
+    {
+        /// <summary>
+        /// Creates a new builder for composing a quality item definition with full flexibility.
+        /// Use fluent methods to configure the definition, then call Build() to register it.
+        /// </summary>
+        public static QualityItemDefinitionBuilder CreateBuilder()
+        {
+            return new QualityItemDefinitionBuilder();
+        }
+        
+        /// <summary>
+        /// Creates a new quality item builder by cloning an existing quality item by ID.
+        /// </summary>
+        /// <param name="sourceItemId">The ID of the item to clone.</param>
+        /// <returns>A builder pre-configured with the source item properties.</returns>
+        /// <exception cref="ArgumentException">Thrown if the source item ID is not found or is not a quality item.</exception>
+        public static QualityItemDefinitionBuilder CloneFrom(string sourceItemId)
+        {
+            var sourceDefinition = S1Registry.GetItem(sourceItemId);
+            if (sourceDefinition == null)
+            {
+                throw new ArgumentException($"Source item with ID '{sourceItemId}' not found in registry", nameof(sourceItemId));
+            }
+
+            if (!CrossType.Is(sourceDefinition, out S1ItemFramework.QualityItemDefinition qualityDef))
+            {
+                throw new ArgumentException($"Item '{sourceItemId}' is not an QualityItemDefinition", nameof(sourceItemId));
+            }
+
+            return new QualityItemDefinitionBuilder(qualityDef);
+        }
+        
+        /// <summary>
+        /// Creates a new quality item builder by cloning an existing quality item wrapper.
+        /// </summary>
+        /// <param name="source">The quality item definition to clone.</param>
+        /// <returns>A builder pre-configured with the source item properties.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the source definition is null.</exception>
+        public static QualityItemDefinitionBuilder CloneFrom(QualityItemDefinition source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source), "Source storable item definition cannot be null");
+            }
+
+            return new QualityItemDefinitionBuilder(source.S1QualityDefinition);
+        }
+    }
+}

--- a/S1API/Items/QualityItemDefinition.cs
+++ b/S1API/Items/QualityItemDefinition.cs
@@ -1,0 +1,67 @@
+﻿#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1ItemFramework = ScheduleOne.ItemFramework;
+#endif
+using S1API.Products;
+
+namespace S1API.Items
+{
+    /// <summary>
+    /// Represents a quality item definition that can be consumed or used in recipes
+    /// Extends <see cref="StorableItemDefinition"/> with quality-specific properties.
+    /// </summary>
+    /// <remarks>
+    /// Use <see cref="QualityItemCreator"/>
+    /// </remarks>
+    public class QualityItemDefinition : StorableItemDefinition
+    {
+        /// <summary>
+        /// INTERNAL: Wraps an existing native quality item definition.
+        /// </summary>
+        internal QualityItemDefinition(S1ItemFramework.QualityItemDefinition definition) : base(definition)
+        {
+            S1QualityDefinition = definition;
+        }
+        
+        /// <summary>
+        /// INTERNAL: The underlying S1 quality item definition instance.
+        /// </summary>
+        internal S1ItemFramework.QualityItemDefinition S1QualityDefinition { get; }
+
+        /// <summary>
+        /// Creates a quality item instance from this definition using the default quality.
+        /// </summary>
+        /// <param name="quantity">The quantity to apply to the created instance.</param>
+        /// <returns>A quality item instance using this definition's default quality.</returns>
+        public override ItemInstance CreateInstance(int quantity = 1) => CreateInstance(quantity, DefaultQuality);
+        
+        /// <summary>
+        /// Creates a quality item instance from this definition with the specified quality.
+        /// </summary>
+        /// <param name="quality">The quality to apply to the created instance.</param>
+        /// <returns>A quality item instance using the specified quality.</returns>
+        public QualityItemInstance CreateInstance(Quality quality) => CreateInstance(1, quality);
+        
+        /// <summary>
+        /// Creates a quality item instance from this definition with the specified quantity and quality.
+        /// </summary>
+        /// <param name="quantity">The quantity to apply to the created instance.</param>
+        /// <param name="quality">The quality to apply to the created instance.</param>
+        /// <returns>A quality item instance using the specified quantity and quality.</returns>
+        public QualityItemInstance CreateInstance(int quantity, Quality quality) =>
+            new QualityItemInstance(new S1ItemFramework.QualityItemInstance(
+                S1QualityDefinition,
+                quantity,
+                (S1ItemFramework.EQuality)quality));
+
+        /// <summary>
+        /// The default quality for this item.
+        /// </summary>
+        public Quality DefaultQuality
+        {
+            get => (Quality)S1QualityDefinition.DefaultQuality;
+            set => S1QualityDefinition.DefaultQuality = (S1ItemFramework.EQuality)value;
+        }
+    }
+}

--- a/S1API/Items/QualityItemDefinitionBuilder.cs
+++ b/S1API/Items/QualityItemDefinitionBuilder.cs
@@ -1,4 +1,4 @@
-#if (IL2CPPMELON)
+﻿#if (IL2CPPMELON)
 using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using S1CoreItemFramework = Il2CppScheduleOne.Core.Items.Framework;
 using S1Levelling = Il2CppScheduleOne.Levelling;
@@ -17,39 +17,36 @@ using S1Storage = ScheduleOne.Storage;
 using System;
 using System.Collections.Generic;
 using S1API.Logging;
+using S1API.Products;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace S1API.Items
 {
     /// <summary>
-    /// Builder for composing item definitions at runtime.
-    /// Use fluent methods to configure item properties before calling <see cref="Build"/>.
-    /// </summary>
-    /// <remarks>
-    /// All items in Schedule One are StorableItemDefinition (or subclasses thereof).
-    /// The base ItemDefinition class is never used directly in the game.
-    /// </remarks>
-    public sealed class StorableItemDefinitionBuilder
+    /// Builder for composing quality item definitions at runtime.
+    /// Use fluent methods to configure item properties before calling <see cref="Build"/>
+    /// </summary
+    public sealed class QualityItemDefinitionBuilder
     {
-        private static readonly Log Logger = new Log("StorableItemDefinitionBuilder");
+        private static readonly Log Logger = new Log("QualityItemDefinitionBuilder");
         private static readonly object StationItemGate = new object();
         private static readonly Dictionary<int, S1StationFramework.StationItem> StationItemCache = new Dictionary<int, S1StationFramework.StationItem>();
         private static readonly HashSet<int> WarnedStationItemModuleMissing = new HashSet<int>();
         private static GameObject _stationItemRoot;
 
-        private readonly S1ItemFramework.StorableItemDefinition _definition;
+        private readonly S1ItemFramework.QualityItemDefinition _definition;
         private readonly GameObject _storedItemPlaceholder;
         private bool _hasCustomStoredItem;
 
         /// <summary>
-        /// INTERNAL: Creates a new builder instance with a fresh StorableItemDefinition.
-        /// Only ItemCreator can instantiate this.
+        /// INTERNAL: Creates a new builder instance with a fresh QualityItemDefinition.
+        /// Only QualityItemCreator can instantiate this.
         /// </summary>
-        internal StorableItemDefinitionBuilder()
+        internal QualityItemDefinitionBuilder()
         {
-            _definition = ScriptableObject.CreateInstance<S1ItemFramework.StorableItemDefinition>();
-
+            _definition = ScriptableObject.CreateInstance<S1ItemFramework.QualityItemDefinition>();
+            
             // Set defaults
             _definition.StackLimit = 10;
             _definition.BasePurchasePrice = 10f;
@@ -60,6 +57,7 @@ namespace S1API.Items
             _definition.UsableInFilters = true;
             _definition.RequiresLevelToPurchase = false;
             _definition.RequiredRank = new S1Levelling.FullRank(S1Levelling.ERank.Street_Rat, 1);
+            _definition.DefaultQuality = S1ItemFramework.EQuality.Standard;
 
             // Provide a minimal StoredItem placeholder so the field is never null in tooling/inspectors.
             _storedItemPlaceholder = new GameObject("S1API_DefaultStoredItem");
@@ -71,14 +69,14 @@ namespace S1API.Items
         }
 
         /// <summary>
-        /// INTERNAL: Creates a builder instance initialized by cloning an existing storable item definition.
-        /// Only ItemCreator can instantiate this.
+        /// INTERNAL: Creates a builder instance initialized by cloning an existing quality item definition.
+        /// Only QualityItemCreator can instantiate this.
         /// </summary>
-        /// <param name="source">The source definition to clone properties from.</param>
-        internal StorableItemDefinitionBuilder(S1ItemFramework.StorableItemDefinition source)
+        /// <param name="source"></param>
+        internal QualityItemDefinitionBuilder(S1ItemFramework.QualityItemDefinition source)
         {
-            _definition = ScriptableObject.CreateInstance<S1ItemFramework.StorableItemDefinition>();
-
+            _definition = ScriptableObject.CreateInstance<S1ItemFramework.QualityItemDefinition>();
+            
             // Provide a minimal StoredItem placeholder so the field is never null in tooling/inspectors.
             _storedItemPlaceholder = new GameObject("S1API_DefaultStoredItem");
             _storedItemPlaceholder.SetActive(false);
@@ -86,19 +84,19 @@ namespace S1API.Items
             Object.DontDestroyOnLoad(_storedItemPlaceholder);
             var storedItemComponent = _storedItemPlaceholder.AddComponent<S1Storage.StoredItem>();
             _definition.StoredItem = storedItemComponent;
-
+            
             CopyPropertiesFrom(source);
         }
 
         /// <summary>
         /// Sets the basic information for the item.
         /// </summary>
-        /// <param name="id">Unique identifier for the item (e.g., "my_custom_tool").</param>
+        /// <param name="id">Unique identifier for the item (e.g., "my_custom_item").</param>
         /// <param name="name">Display name shown in UI.</param>
         /// <param name="description">Item description shown in tooltips.</param>
         /// <param name="category">Item category for inventory organization.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithBasicInfo(string id, string name, string description, ItemCategory category)
+        public QualityItemDefinitionBuilder WithBasicInfo(string id, string name, string description, ItemCategory category)
         {
             _definition.ID = id;
             _definition.Name = name;
@@ -123,7 +121,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="limit">Maximum quantity per inventory slot (1-999).</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithStackLimit(int limit)
+        public QualityItemDefinitionBuilder WithStackLimit(int limit)
         {
             _definition.StackLimit = Mathf.Clamp(limit, 1, 999);
             return this;
@@ -134,7 +132,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="icon">The sprite to use as the item icon.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithIcon(Sprite icon)
+        public QualityItemDefinitionBuilder WithIcon(Sprite icon)
         {
             _definition.Icon = icon;
             return this;
@@ -146,7 +144,7 @@ namespace S1API.Items
         /// <param name="basePurchasePrice">Base price when buying from shops.</param>
         /// <param name="resellMultiplier">Fraction of purchase price recovered when selling (0.0 to 1.0).</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithPricing(float basePurchasePrice, float resellMultiplier = 0.5f)
+        public QualityItemDefinitionBuilder WithPricing(float basePurchasePrice, float resellMultiplier = 0.5f)
         {
             _definition.BasePurchasePrice = Mathf.Max(0f, basePurchasePrice);
             _definition.ResellMultiplier = Mathf.Clamp01(resellMultiplier);
@@ -158,7 +156,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="status">Whether the item is legal or illegal.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithLegalStatus(LegalStatus status)
+        public QualityItemDefinitionBuilder WithLegalStatus(LegalStatus status)
         {
             _definition.legalStatus = (S1CoreItemFramework.ELegalStatus)status;
             return this;
@@ -169,7 +167,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="equippable">The equippable wrapper to attach.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithEquippable(Equippable equippable)
+        public QualityItemDefinitionBuilder WithEquippable(Equippable equippable)
         {
             if (equippable != null)
             {
@@ -183,7 +181,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="storedItemPrefab">Prefab containing a StoredItem component.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithStoredItem(GameObject storedItemPrefab)
+        public QualityItemDefinitionBuilder WithStoredItem(GameObject storedItemPrefab)
         {
             if (storedItemPrefab == null)
                 return this;
@@ -204,9 +202,9 @@ namespace S1API.Items
         /// </remarks>
         /// <param name="stationItemPrefab">A prefab GameObject that has a StationItem component.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="stationItemPrefab"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="stationItemPrefab"/> does not have a StationItem component.</exception>
-        public StorableItemDefinitionBuilder WithStationItem(GameObject stationItemPrefab)
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="stationItemPrefab"/> is null.</exception>
+        /// <exception cref="System.ArgumentException">Thrown if <paramref name="stationItemPrefab"/> does not have a StationItem component.</exception>
+        public QualityItemDefinitionBuilder WithStationItem(GameObject stationItemPrefab)
         {
             if (stationItemPrefab == null)
                 throw new ArgumentNullException(nameof(stationItemPrefab));
@@ -225,7 +223,7 @@ namespace S1API.Items
         /// <summary>
         /// Clears the StationItem reference for this definition.
         /// </summary>
-        public StorableItemDefinitionBuilder WithoutStationItem()
+        public QualityItemDefinitionBuilder WithoutStationItem()
         {
             _definition.StationItem = null;
             return this;
@@ -236,7 +234,7 @@ namespace S1API.Items
         /// </summary>
         /// <param name="available">True if available in demo, false otherwise.</param>
         /// <returns>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithDemoAvailability(bool available)
+        public QualityItemDefinitionBuilder WithDemoAvailability(bool available)
         {
             _definition.AvailableInDemo = available;
             return this;
@@ -247,16 +245,26 @@ namespace S1API.Items
         /// </summary>
         /// <param name="rank">The required rank to purchase this item, or null to remove level requirement.</param>
         /// <returns>>The builder instance for fluent chaining.</returns>
-        public StorableItemDefinitionBuilder WithRequiredRank(Leveling.FullRank? rank)
+        public QualityItemDefinitionBuilder WithRequiredRank(Leveling.FullRank? rank)
         {
             if (rank == null)
             {
                 _definition.RequiresLevelToPurchase = false;
                 return this;
             }
-
             _definition.RequiredRank = rank.Value.ToNative();
             _definition.RequiresLevelToPurchase = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Assigns a default quality for this definition.
+        /// </summary>
+        /// <param name="quality">The default quality to assign to items of this definition.</param>
+        /// <returns>>The builder instance for fluent chaining.</returns>
+        public QualityItemDefinitionBuilder WithDefaultQuality(Quality quality)
+        {
+            _definition.DefaultQuality = (S1ItemFramework.EQuality)quality;
             return this;
         }
 
@@ -264,7 +272,7 @@ namespace S1API.Items
         /// Builds the item definition, registers it with the game's registry, and returns a wrapper.
         /// </summary>
         /// <returns>A wrapper around the created storable item definition.</returns>
-        public StorableItemDefinition Build()
+        public QualityItemDefinition Build()
         {
             if (!_hasCustomStoredItem && _definition.StoredItem != null)
             {
@@ -279,14 +287,14 @@ namespace S1API.Items
             S1Registry.Instance.AddToRegistry(_definition);
 
             // Return wrapper
-            return new StorableItemDefinition(_definition);
+            return new QualityItemDefinition(_definition);
         }
 
         /// <summary>
         /// INTERNAL: Builds and returns the raw game item definition without registering.
         /// Used internally by S1API. Modders should use <see cref="Build"/> instead.
         /// </summary>
-        internal S1ItemFramework.StorableItemDefinition BuildInternal()
+        internal S1ItemFramework.QualityItemDefinition BuildInternal()
         {
             return _definition;
         }
@@ -295,10 +303,10 @@ namespace S1API.Items
         /// Copies all properties from a source StorableItemDefinition to the current definition.
         /// </summary>
         /// <param name="source">The source definition to copy properties from.</param>
-        private void CopyPropertiesFrom(S1ItemFramework.StorableItemDefinition source)
+        private void CopyPropertiesFrom(S1ItemFramework.QualityItemDefinition source)
         {
             if (source == null) return;
-
+            
             // Basic ItemDefinition properties
             _definition.Name = source.Name;
             _definition.Description = source.Description;
@@ -320,10 +328,11 @@ namespace S1API.Items
             _definition.StoredItem = source.StoredItem != null ? source.StoredItem : _definition.StoredItem;
             _definition.StationItem = source.StationItem;
             _definition.Equippable = source.Equippable;
+            _definition.DefaultQuality = source.DefaultQuality;
+            _definition.CustomItemUI = source.CustomItemUI;
         }
 
-        private static S1StationFramework.StationItem GetOrCreateStationItemPrefab(
-            S1StationFramework.StationItem stationItemPrefab)
+        private static S1StationFramework.StationItem GetOrCreateStationItemPrefab(S1StationFramework.StationItem stationItemPrefab)
         {
             var id = stationItemPrefab.GetInstanceID();
 

--- a/S1API/Items/QualityItemDefinitionBuilder.cs
+++ b/S1API/Items/QualityItemDefinitionBuilder.cs
@@ -26,7 +26,7 @@ namespace S1API.Items
     /// <summary>
     /// Builder for composing quality item definitions at runtime.
     /// Use fluent methods to configure item properties before calling <see cref="Build"/>
-    /// </summary
+    /// </summary>
     public sealed class QualityItemDefinitionBuilder
     {
         private static readonly Log Logger = new Log("QualityItemDefinitionBuilder");

--- a/S1API/Items/QualityItemInstance.cs
+++ b/S1API/Items/QualityItemInstance.cs
@@ -3,6 +3,7 @@ using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 #elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
 using S1ItemFramework = ScheduleOne.ItemFramework;
 #endif
+using S1API.Internal.Utils;
 using S1API.Products;
 
 namespace S1API.Items
@@ -40,6 +41,7 @@ namespace S1API.Items
         /// The quality item definition (template) this instance was created from.
         /// </summary>
         public new QualityItemDefinition Definition =>
-            new QualityItemDefinition((S1ItemFramework.QualityItemDefinition)S1QualityInstance.Definition);
+            new QualityItemDefinition(
+                CrossType.As<S1ItemFramework.QualityItemDefinition>(S1QualityInstance.Definition));
     }
 }

--- a/S1API/Items/QualityItemInstance.cs
+++ b/S1API/Items/QualityItemInstance.cs
@@ -1,0 +1,45 @@
+﻿#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1ItemFramework = ScheduleOne.ItemFramework;
+#endif
+using S1API.Products;
+
+namespace S1API.Items
+{
+    /// <summary>
+    /// Represents a quality item instance in the game world (usable item).
+    /// Extends <see cref="ItemInstance"/> with quality information.
+    /// </summary>
+    public class QualityItemInstance : ItemInstance
+    {
+        /// <summary>
+        /// INTERNAL: Reference to the in-game quality item instance.
+        /// </summary>
+        internal readonly S1ItemFramework.QualityItemInstance S1QualityInstance;
+        
+        /// <summary>
+        /// INTERNAL: Creates a QualityItemInstance wrapper.
+        /// </summary>
+        /// <param name="itemInstance">In-game quality item instance</param>
+        internal QualityItemInstance(S1ItemFramework.QualityItemInstance itemInstance) : base(itemInstance)
+        {
+            S1QualityInstance = itemInstance;
+        }
+        
+        /// <summary>
+        /// The quality of this item.
+        /// </summary>
+        public Quality Quality
+        {
+            get => (Quality)S1QualityInstance.Quality;
+            set => S1QualityInstance.Quality = (S1ItemFramework.EQuality)value;
+        }
+        
+        /// <summary>
+        /// The quality item definition (template) this instance was created from.
+        /// </summary>
+        public new QualityItemDefinition Definition =>
+            new QualityItemDefinition((S1ItemFramework.QualityItemDefinition)S1QualityInstance.Definition);
+    }
+}

--- a/S1API/Items/StorableItemDefinition.cs
+++ b/S1API/Items/StorableItemDefinition.cs
@@ -4,6 +4,7 @@ using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using S1ItemFramework = ScheduleOne.ItemFramework;
 #endif
 
+using S1API.Leveling;
 using UnityEngine;
 
 namespace S1API.Items
@@ -56,6 +57,24 @@ namespace S1API.Items
         /// </summary>
         public bool IsUnlocked =>
             S1StorableItemDefinition.IsUnlocked;
+
+        /// <summary>
+        /// Whether purchasing this item requires the player to be at or above a certain level.
+        /// </summary>
+        public bool RequiresLevelToPurchase
+        {
+            get => S1StorableItemDefinition.RequiresLevelToPurchase;
+            set => S1StorableItemDefinition.RequiresLevelToPurchase = value;
+        }
+
+        /// <summary>
+        /// The required player level to purchase this item, if <see cref="RequiresLevelToPurchase"/> is true.
+        /// </summary>
+        public FullRank RequiredRank
+        {
+            get => FullRank.FromNative(S1StorableItemDefinition.RequiredRank);
+            set => S1StorableItemDefinition.RequiredRank = value.ToNative();
+        }
 
         /// <summary>
         /// Gets whether this item has a StationItem assigned (used by station/minigame tasks, e.g., Chemistry Station).

--- a/S1API/Products/ProductInstance.cs
+++ b/S1API/Products/ProductInstance.cs
@@ -58,7 +58,8 @@ namespace S1API.Products
         /// <summary>
         /// Gets the definition of the product associated with this instance.
         /// </summary>
-        public ProductDefinition Definition => new ProductDefinition(S1ProductInstance.Definition);
+        public ProductDefinition Definition =>
+            new ProductDefinition(CrossType.As<S1Product.ProductDefinition>(S1ProductInstance.Definition));
 
         /// <summary>
         /// Gets the list of properties associated with the product definition.

--- a/S1API/Products/ShroomInstance.cs
+++ b/S1API/Products/ShroomInstance.cs
@@ -37,7 +37,7 @@ namespace S1API.Products
         /// Gets the shroom-specific definition for this instance.
         /// </summary>
         public new ShroomDefinition Definition =>
-            new ShroomDefinition(S1ShroomInstance.Definition as S1Product.ShroomDefinition);
+            new ShroomDefinition(CrossType.As<S1Product.ShroomDefinition>(S1ShroomInstance.Definition));
 
         /// <summary>
         /// Gets the display name of the shroom instance.


### PR DESCRIPTION
Adds `QualityItemDefinition` wrappers, allowing for creation of custom items of that type.

I also added methods for cloning an existing `StorableItemDefinition` to the builder and a missing `RequiredRank` method.


Since `QualityItemDefinition` is a subclass of `StorableItemDefinition`, much of the builder code is duplicated. That's not ideal, but other item creator builders also seem to follow this pattern.
I'm working on a [solution](https://github.com/k073l/S1API/tree/refactor/item-builders) to this, but that should be its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Added QualityItemDefinition wrapper class and builder for creating custom quality items at runtime
- Introduced QualityItemCreator utility with factory methods (CreateBuilder(), CloneFrom()) for quality item creation
- Added QualityItemInstance wrapper to expose quality property on item instances
- Implemented QualityItemDefinitionBuilder with fluent API for configuring quality items (ID, name, description, pricing, stacking, icons, default quality, station prefab handling, and more)
- Extended StorableItemDefinition with RequiresLevelToPurchase and RequiredRank properties for purchase-level gating
- Enhanced StorableItemDefinitionBuilder with WithRequiredRank() and CopyPropertiesFrom() to support rank-based purchase restrictions and cloning initialization
- Added CloneFrom() overloads to StorableItemDefinitionBuilder for cloning existing storable items by ID or reference
- Extended ItemCreator.CreateItem() signature with requiresLevelToPurchase and requiredRank parameters and added CloneFrom overloads
- Registered QualityItemDefinition type dispatch in ItemManager.GetItemDefinition()
- Note: Builder code contains duplicated logic between StorableItemDefinitionBuilder and QualityItemDefinitionBuilder; a refactor is planned in a separate branch

## Lines Added/Removed by Author

| Author | Added | Removed | Total |
|--------|-------:|--------:|------:|
| k073l  | 80425 | 0 | +80425 |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ifBars/S1API/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->