### PR TITLE
Switch lock type on BeforeBaseGame saveables

### DIFF
--- a/S1API/Internal/Patches/GenericSaveables.Patches.cs
+++ b/S1API/Internal/Patches/GenericSaveables.Patches.cs
@@ -76,8 +76,9 @@ namespace S1API.Internal.Patches
 		/// <summary>
 		/// Loads saveables marked with BeforeBaseGame load order BEFORE base game loaders run.
 		/// This runs as a prefix to LoadManager.QueueLoadRequest on the first LoadRequest creation,
-		/// which happens right before base game loaders start processing.
-		/// Uses a session flag cleared by onLoadComplete to detect new load cycles.
+		/// before base game loaders start processing.
+		/// Uses an internal sameSession flag to detect new load cycles. sameSession is reset by
+		/// onLoadComplete so subsequent load cycles can be detected.
 		/// </summary>
 		[HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.QueueLoadRequest))]
 		[HarmonyPrefix]

--- a/S1API/Internal/Patches/GenericSaveables.Patches.cs
+++ b/S1API/Internal/Patches/GenericSaveables.Patches.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using HarmonyLib;
+using MelonLoader;
 using Newtonsoft.Json;
 using S1API.Internal.Abstraction;
 using S1API.Saveables;
@@ -71,7 +72,7 @@ namespace S1API.Internal.Patches
 			}
 		}
 
-		private static string lastLoadedGameFolderPath = null;
+		private static bool sameSession = false;
 
 		/// <summary>
 		/// Loads saveables marked with BeforeBaseGame load order BEFORE base game loaders run.
@@ -89,12 +90,9 @@ namespace S1API.Internal.Patches
 				if (lm == null || string.IsNullOrEmpty(lm.LoadedGameFolderPath))
 					return;
 
-				// Only run once per load cycle by checking if the folder path has changed
-				if (lastLoadedGameFolderPath == lm.LoadedGameFolderPath)
-					return;
-
-				lastLoadedGameFolderPath = lm.LoadedGameFolderPath;
-
+				// QueueLoadRequest may be called multiple times before loading into a save
+				// this flag makes sure we only load once - it's cleared by onLoadComplete
+				if (sameSession) return;
 				string basePath = Path.Combine(lm.LoadedGameFolderPath, "Modded", "Saveables");
 				
 				foreach (var saveable in SaveableAutoRegistry.GetRegisteredSaveables())
@@ -129,6 +127,23 @@ namespace S1API.Internal.Patches
 						EventHelper.AddListener(InitializeOnLoadComplete, lm.onLoadComplete);
 					}
 				}
+				
+				// Lock subsequent calls to this prefix until load completes to avoid loading multiple times in the same session
+				sameSession = true;
+				// Clear the lock once the game is loaded to allow loading again in future sessions without restarting the game
+				void ClearLockOnLoadComplete()
+				{
+				    try
+				    {
+					    EventHelper.RemoveListener(ClearLockOnLoadComplete, lm.onLoadComplete);
+					    sameSession = false;
+				    }
+				    catch (Exception e)
+				    {
+					    try { MelonLoader.MelonLogger.Warning($"[Saveables] ClearLockOnLoadComplete failed: {e.Message}\n{e.StackTrace}"); } catch { }
+				    }
+				}
+				EventHelper.AddListener(ClearLockOnLoadComplete, lm.onLoadComplete);
 			}
 			catch (Exception e)
 			{

--- a/S1API/Internal/Patches/GenericSaveables.Patches.cs
+++ b/S1API/Internal/Patches/GenericSaveables.Patches.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using HarmonyLib;
-using MelonLoader;
 using Newtonsoft.Json;
 using S1API.Internal.Abstraction;
 using S1API.Saveables;
@@ -78,7 +77,7 @@ namespace S1API.Internal.Patches
 		/// Loads saveables marked with BeforeBaseGame load order BEFORE base game loaders run.
 		/// This runs as a prefix to LoadManager.QueueLoadRequest on the first LoadRequest creation,
 		/// which happens right before base game loaders start processing.
-		/// Uses the LoadedGameFolderPath to detect new load cycles.
+		/// Uses a session flag cleared by onLoadComplete to detect new load cycles.
 		/// </summary>
 		[HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.QueueLoadRequest))]
 		[HarmonyPrefix]


### PR DESCRIPTION
Switches the lock on `BeforeBaseGame` saveable loader from save path check to a flag-based system, where the lock is set on first load of all eligible saveables and released when game invokes `onLoadComplete`.

This allows for these saveables to be correctly reloaded on another load cycle (e.g. load save1 -> exit to menu -> load save1). Previous system blocked this exact example.

Tested on Mono with MoreNPCs and MultiDelivery (regression testing and testing the fix) and on IL2CPP with the same + BigWillyMod (regression testing for custom items).
Let me know if I missed anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Replace save-path-based lock mechanism with a flag-based lock for BeforeBaseGame saveables to allow correct reloads across load cycles
- Introduce `sameSession` boolean flag to prevent repeated execution within the same load session
- `sameSession` is cleared by an `onLoadComplete` listener so saveables can be reloaded after exiting to menu and reloading the same save
- Keeps existing filtering for `LoadOrder == BeforeBaseGame` and missing-save initialization-on-load-complete behavior
- Minor cleanup: updated docstrings and removal of an unused MelonLoader import; clarified before-base load cycle detection

## Contributions by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| k073l  | 24          | 9             |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->