### PR TITLE
Issues backlog: PhoneApp onDestroyed, custom commands enhancement, employee appearances, more checks in CombatBehaviour

### DIFF
--- a/S1API/Console/CustomConsoleRegistry.cs
+++ b/S1API/Console/CustomConsoleRegistry.cs
@@ -11,7 +11,9 @@ namespace S1API.Console
     {
         private static readonly Logging.Log Logger = new Logging.Log("Console");
 
-        internal static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
+
+        internal static IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands => registry;
 
         internal static void Register(BaseConsoleCommand command)
         {

--- a/S1API/Console/CustomConsoleRegistry.cs
+++ b/S1API/Console/CustomConsoleRegistry.cs
@@ -11,7 +11,7 @@ namespace S1API.Console
     {
         private static readonly Logging.Log Logger = new Logging.Log("Console");
 
-        private static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
+        internal static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
 
         internal static void Register(BaseConsoleCommand command)
         {

--- a/S1API/Entities/Behaviour/CombatBehaviour.cs
+++ b/S1API/Entities/Behaviour/CombatBehaviour.cs
@@ -13,6 +13,7 @@ using S1API.Items;
 using UnityEngine;
 using MelonLoader;
 using S1API.Entities.Equippables;
+using S1API.Internal.Utils;
 using Object = UnityEngine.Object;
 
 namespace S1API.Entities.Behaviour;
@@ -22,6 +23,8 @@ namespace S1API.Entities.Behaviour;
 /// </summary>
 public class CombatBehaviour
 {
+    private static readonly Logging.Log Logger = new("CombatBehaviour");
+
     /// <summary>
     /// INTERNAL: NPC reference
     /// </summary>
@@ -57,8 +60,13 @@ public class CombatBehaviour
     /// <summary>
     /// Gets or sets the default weapon asset path for the NPC's combat behaviour.
     /// This property allows you to specify the weapon that the NPC will use by default.
-    /// <see cref="Weapon"/> for convenience when setting this property.
+    /// Use <see cref="Weapon"/> or <see cref="AvatarEquippablePaths"/> for convenience when setting this property.
+    /// Set to an empty string to clear the default weapon.
     /// </summary>
+    /// <remarks>
+    /// Using type-safe <see cref="SetDefaultWeapon(Equippable)"/>
+    /// or <see cref="SetDefaultWeapon(EquippableBuilder)"/> is generally preferred and advised.
+    /// </remarks>
     public string DefaultWeaponAssetPath
     {
         get
@@ -74,21 +82,27 @@ public class CombatBehaviour
                 return;
             }
 
-            var go = Resources.Load(value) as GameObject;
-            if (go == null)
+            var go = Resources.Load(value);
+            if (!CrossType.Is<GameObject>(go, out var gameObject) || gameObject == null)
             {
-                Debug.LogError("Could not find weapon at path: " + value);
+                Logger.Error("Could not find weapon at path: " + value);
                 return;
             }
 
-            var equippable = Object.Instantiate(go).GetComponent<AvatarEquippable>();
+            var equippable = Object.Instantiate(gameObject).GetComponent<AvatarEquippable>();
             if (equippable == null)
             {
-                Debug.LogError("Could not get AvatarEquippable from weapon at path: " + value);
+                Logger.Error("Could not get AvatarEquippable from weapon at path: " + value);
                 return;
             }
 
-            NPC.S1NPC.Behaviour.CombatBehaviour.DefaultWeapon = equippable as AvatarWeapon;
+            if (!CrossType.Is<AvatarWeapon>(equippable, out var avatarWeapon))
+            {
+                Logger.Error("AvatarEquippable at path is not an AvatarWeapon: " + value);
+                return;
+            }
+
+            NPC.S1NPC.Behaviour.CombatBehaviour.DefaultWeapon = avatarWeapon;
         }
     }
 

--- a/S1API/Entities/Behaviour/CombatBehaviour.cs
+++ b/S1API/Entities/Behaviour/CombatBehaviour.cs
@@ -89,7 +89,8 @@ public class CombatBehaviour
                 return;
             }
 
-            var equippable = Object.Instantiate(gameObject).GetComponent<AvatarEquippable>();
+            var equippable = gameObject.GetComponent<AvatarEquippable>() ??
+                             gameObject.GetComponentInChildren<AvatarEquippable>(true);
             if (equippable == null)
             {
                 Logger.Error("Could not get AvatarEquippable from weapon at path: " + value);

--- a/S1API/Entities/Employees/EmployeeManager.cs
+++ b/S1API/Entities/Employees/EmployeeManager.cs
@@ -1,0 +1,88 @@
+﻿#if IL2CPPMELON
+using S1Employees = Il2CppScheduleOne.Employees;
+#elif MONOMELON
+using S1Employees = ScheduleOne.Employees;
+#endif
+using System.Collections.Generic;
+using S1API.Avatar;
+using UnityEngine;
+
+namespace S1API.Entities.Employees
+{
+    /// <summary>
+    /// Provides methods for managing employee appearances and related data.
+    /// </summary>
+    public static class EmployeeManager
+    {
+        private static readonly Logging.Log Logger = new("EmployeeManager");
+
+        /// <summary>
+        /// Gets an employee appearance by index.
+        /// </summary>
+        /// <param name="male">Whether to choose from male employee appearance pool</param>
+        /// <param name="index">The index of the appearance to retrieve</param>
+        /// <returns>An <see cref="EmployeeAppearance"/> representing the employee appearance at the specified index if successful; otherwise, null.</returns>
+        public static EmployeeAppearance? GetAppearance(bool male, int index)
+        {
+            if (!S1Employees.EmployeeManager.InstanceExists)
+            {
+                Logger.Error("EmployeeManager instance does not exist; cannot get appearance");
+                return null;
+            }
+
+            return new EmployeeAppearance(S1Employees.EmployeeManager.Instance.GetAppearance(male, index));
+        }
+
+        /// <summary>
+        /// Gets a random employee appearance.
+        /// </summary>
+        /// <param name="male">Whether to choose from male employee appearance pool</param>
+        /// <param name="index">The index of the appearance that was retrieved</param>
+        /// <param name="settings">The avatar settings of the appearance that was retrieved</param>
+        /// <returns>True if an appearance was successfully retrieved; otherwise, false.</returns>
+        public static bool GetRandomAppearance(bool male, out int index, out AvatarSettings? settings)
+        {
+            if (!S1Employees.EmployeeManager.InstanceExists)
+            {
+                settings = null;
+                index = -1;
+                Logger.Error("EmployeeManager instance does not exist; cannot get random appearance");
+                return false;
+            }
+
+            S1Employees.EmployeeManager.Instance.GetRandomAppearance(male, out var i, out var avatarSettings);
+            index = i;
+            settings = new AvatarSettings(avatarSettings);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Represents an employee appearance, including avatar settings and mugshot sprite.
+    /// </summary>
+    public class EmployeeAppearance
+    {
+        /// <summary>
+        /// INTERNAL: The underlying employee appearance from the base game.
+        /// </summary>
+        internal S1Employees.EmployeeManager.EmployeeAppearance S1EmployeeAppearance;
+
+        /// <summary>
+        /// Gets the avatar settings associated with this employee appearance.
+        /// </summary>
+        public AvatarSettings Settings => new(S1EmployeeAppearance.Settings);
+
+        /// <summary>
+        /// Gets the mugshot sprite associated with this employee appearance.
+        /// </summary>
+        public Sprite Mugshot => S1EmployeeAppearance.Mugshot;
+
+        /// <summary>
+        /// INTERNAL: Initializes a new instance of the EmployeeAppearance class with the specified base game type appearance.
+        /// </summary>
+        internal EmployeeAppearance(S1Employees.EmployeeManager.EmployeeAppearance s1EmployeeAppearance)
+        {
+            S1EmployeeAppearance = s1EmployeeAppearance;
+        }
+    }
+}

--- a/S1API/Entities/Employees/EmployeeManager.cs
+++ b/S1API/Entities/Employees/EmployeeManager.cs
@@ -30,7 +30,8 @@ namespace S1API.Entities.Employees
                 return null;
             }
 
-            return new EmployeeAppearance(S1Employees.EmployeeManager.Instance.GetAppearance(male, index));
+            var appearance = S1Employees.EmployeeManager.Instance.GetAppearance(male, index);
+            return appearance == null ? null : new EmployeeAppearance(appearance);
         }
 
         /// <summary>
@@ -51,6 +52,13 @@ namespace S1API.Entities.Employees
             }
 
             S1Employees.EmployeeManager.Instance.GetRandomAppearance(male, out var i, out var avatarSettings);
+            if (avatarSettings == null)
+            {
+                settings = null;
+                index = -1;
+                return false;
+            }
+
             index = i;
             settings = new AvatarSettings(avatarSettings);
             return true;

--- a/S1API/Internal/Patches/ConsolePatches.cs
+++ b/S1API/Internal/Patches/ConsolePatches.cs
@@ -4,11 +4,16 @@ using System.Reflection;
 using HarmonyLib;
 using S1API.Console;
 using S1API.Internal.Utils;
+using UnityEngine;
+using Object = UnityEngine.Object;
 #if (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
 using S1Console = ScheduleOne.Console;
-
+using S1CommandListScreen = ScheduleOne.CommandListScreen;
+using TMPro;
 #elif (IL2CPPMELON)
 using S1Console = Il2CppScheduleOne.Console;
+using S1CommandListScreen = Il2CppScheduleOne.CommandListScreen;
+using Il2CppTMPro;
 #endif
 
 #if (IL2CPPMELON || IL2CPPBEPINEX)
@@ -35,6 +40,7 @@ namespace S1API.Internal.Patches
             if (__instance == null)
                 return;
 
+            _addedCommandsToList.Clear();
             var commandTypes = ReflectionUtils.GetDerivedClasses<BaseConsoleCommand>();
             foreach (var type in commandTypes)
             {
@@ -134,5 +140,64 @@ namespace S1API.Internal.Patches
             }
         }
 #endif
+
+#if (MONOMELON || MONOBEPINEX)
+        private static FieldInfo? _commandEntriesField;
+#endif
+
+        /// <summary>
+        /// Custom commands that were added to command list screen, stored here to prevent duplicate additions.
+        /// </summary>
+        private static HashSet<string> _addedCommandsToList = new();
+
+        /// <summary>
+        /// Adds custom commands to command list screen.
+        /// </summary>
+        [HarmonyPatch(typeof(S1CommandListScreen), "Start")]
+        [HarmonyPostfix]
+        private static void AddCustomCommandEntries(S1CommandListScreen __instance)
+        {
+            try
+            {
+                if (__instance == null || __instance.CommandEntryPrefab == null ||
+                    __instance.CommandEntryContainer == null)
+                    return;
+#if (MONOMELON || MONOBEPINEX)
+                _commandEntriesField ??= 
+                    typeof(S1CommandListScreen)
+                        .GetField("commandEntries", BindingFlags.NonPublic | BindingFlags.Instance);
+                var commandEntries = _commandEntriesField?.GetValue(__instance) as List<RectTransform>;
+#elif (IL2CPPMELON || IL2CPPBEPINEX)
+                var commandEntries = __instance?.commandEntries;
+#endif
+
+                foreach (var commandKey in CustomConsoleRegistry.registry.Keys)
+                {
+                    try
+                    {
+                        if (_addedCommandsToList.Contains(commandKey))
+                            continue;
+                        var rt = Object.Instantiate(__instance.CommandEntryPrefab, __instance.CommandEntryContainer);
+                        rt.Find("Command").GetComponent<TextMeshProUGUI>().text =
+                            CustomConsoleRegistry.registry[commandKey].CommandWord;
+                        rt.Find("Description").GetComponent<TextMeshProUGUI>().text =
+                            CustomConsoleRegistry.registry[commandKey].CommandDescription;
+                        rt.Find("Example").GetComponent<TextMeshProUGUI>().text =
+                            CustomConsoleRegistry.registry[commandKey].ExampleUsage;
+
+                        commandEntries?.Add(rt);
+                        _addedCommandsToList.Add(commandKey);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Warning($"[Console] Failed to add command '{commandKey}' to command list screen: {e.Message}");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Warning($"[Console] Failed to add custom commands to command list screen: {e.Message}");
+            }
+        }
     }
 }

--- a/S1API/Internal/Patches/ConsolePatches.cs
+++ b/S1API/Internal/Patches/ConsolePatches.cs
@@ -40,7 +40,6 @@ namespace S1API.Internal.Patches
             if (__instance == null)
                 return;
 
-            _addedCommandsToList.Clear();
             var commandTypes = ReflectionUtils.GetDerivedClasses<BaseConsoleCommand>();
             foreach (var type in commandTypes)
             {
@@ -162,6 +161,8 @@ namespace S1API.Internal.Patches
                 if (__instance == null || __instance.CommandEntryPrefab == null ||
                     __instance.CommandEntryContainer == null)
                     return;
+
+                _addedCommandsToList.Clear();
 #if (MONOMELON || MONOBEPINEX)
                 _commandEntriesField ??= 
                     typeof(S1CommandListScreen)
@@ -171,19 +172,23 @@ namespace S1API.Internal.Patches
                 var commandEntries = __instance?.commandEntries;
 #endif
 
-                foreach (var commandKey in CustomConsoleRegistry.registry.Keys)
+                foreach (var command in CustomConsoleRegistry.RegisteredCommands)
                 {
+                    var commandKey = command.Key;
                     try
                     {
                         if (_addedCommandsToList.Contains(commandKey))
                             continue;
+                        if (IsNativeCommand(commandKey))
+                            continue;
+
                         var rt = Object.Instantiate(__instance.CommandEntryPrefab, __instance.CommandEntryContainer);
                         rt.Find("Command").GetComponent<TextMeshProUGUI>().text =
-                            CustomConsoleRegistry.registry[commandKey].CommandWord;
+                            command.Value.CommandWord;
                         rt.Find("Description").GetComponent<TextMeshProUGUI>().text =
-                            CustomConsoleRegistry.registry[commandKey].CommandDescription;
+                            command.Value.CommandDescription;
                         rt.Find("Example").GetComponent<TextMeshProUGUI>().text =
-                            CustomConsoleRegistry.registry[commandKey].ExampleUsage;
+                            command.Value.ExampleUsage;
 
                         commandEntries?.Add(rt);
                         _addedCommandsToList.Add(commandKey);
@@ -198,6 +203,23 @@ namespace S1API.Internal.Patches
             {
                 Logger.Warning($"[Console] Failed to add custom commands to command list screen: {e.Message}");
             }
+        }
+
+        private static bool IsNativeCommand(string commandKey)
+        {
+            if (string.IsNullOrWhiteSpace(commandKey))
+                return false;
+
+#if (MONOMELON || MONOBEPINEX)
+            _monoCommandsField ??= typeof(S1Console).GetField("commands", BindingFlags.NonPublic | BindingFlags.Static);
+            var dict = _monoCommandsField?.GetValue(null) as IDictionary<string, S1Console.ConsoleCommand>;
+            return dict != null && dict.ContainsKey(commandKey);
+#elif (IL2CPPMELON || IL2CPPBEPINEX)
+            var dict = S1Console.commands;
+            return dict != null && dict.ContainsKey(commandKey);
+#else
+            return false;
+#endif
         }
     }
 }

--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -648,6 +648,12 @@ namespace S1API.PhoneApp
             }
         }
 
+        private void OnDestroy()
+        {
+            // Destroy phone app when button handler is destroyed
+            phoneApp?.DestroyInternal();
+        }
+
         private bool IsHoveringButton()
         {
             // This is the same logic as native App<T>.IsHoveringButton()

--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -51,6 +51,9 @@ namespace S1API.PhoneApp
         /// app canvas structure in the game's Unity hierarchy.
         /// </summary>
         private GameObject? _appPanel;
+        private bool _isDestroying;
+
+        internal bool IsDestroying => _isDestroying;
 
         /// <summary>
         /// Indicates whether the application UI has been successfully created and initialized.
@@ -187,6 +190,11 @@ namespace S1API.PhoneApp
         /// </summary>
         protected override void OnDestroyed()
         {
+            if (_isDestroying)
+                return;
+
+            _isDestroying = true;
+
             if (_appPanel != null)
             {
                 Object.Destroy(_appPanel);
@@ -651,7 +659,8 @@ namespace S1API.PhoneApp
         private void OnDestroy()
         {
             // Destroy phone app when button handler is destroyed
-            phoneApp?.DestroyInternal();
+            if (phoneApp != null && !phoneApp.IsDestroying)
+                phoneApp.DestroyInternal();
         }
 
         private bool IsHoveringButton()


### PR DESCRIPTION
Closes a bunch of issues: #74, #76, #83.

Also closes one issue from Trello - custom commands now appear in the command list screen, just like native commands do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **PhoneApp lifecycle management**: Implemented `OnDestroy()` wiring for `PhoneAppButtonHandler` to properly tear down the associated `PhoneApp` when the button handler component is destroyed
- **Custom commands UI integration**: Custom commands now appear in the command list screen alongside native commands via updated console patches
- **Employee appearance API**: Exposed employee appearance data through new `EmployeeManager` and `EmployeeAppearance` wrapper classes with access to appearance settings and mugshots
- **Combat behavior improvements**: Refactored `CombatBehaviour.DefaultWeaponAssetPath` setter with safer type casting using `CrossType.Is` checks, switched to melonlogger for error reporting, and updated XML documentation
- **Internal registry accessibility**: Made `CustomConsoleRegistry.registry` internal to support assembly-level access for custom command integration

## Contributions by Author

| Author | Lines Added | Lines Removed | Net Change |
|--------|-------------|---------------|------------|
| k0 | 93 | 8 | +85 |
| ifBars | 89 | 1 | +88 |
| **Total** | **182** | **9** | **+173** |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->