### PR TITLE
feat(items): add custom mixing ingredient, effect, and reaction API

### DIFF
--- a/S1API/Internal/Items/CustomIngredientRegistry.cs
+++ b/S1API/Internal/Items/CustomIngredientRegistry.cs
@@ -1,0 +1,159 @@
+#if (IL2CPPMELON)
+using S1Product = Il2CppScheduleOne.Product;
+using S1Registry = Il2CppScheduleOne.Registry;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Product = ScheduleOne.Product;
+using S1Registry = ScheduleOne.Registry;
+#endif
+using System;
+using System.Collections.Generic;
+using S1API.Lifecycle;
+using S1API.Logging;
+
+namespace S1API.Internal.Items
+{
+    /// <summary>
+    /// INTERNAL: Tracks mod-created mixing ingredients and re-applies them across scene changes.
+    /// The game's item registry is wiped on scene change, and the mixing-ingredient list lives on a
+    /// session-scoped singleton, so both must be re-populated on every load.
+    /// </summary>
+    internal static class CustomIngredientRegistry
+    {
+        private static readonly Log Logger = new Log("CustomIngredientRegistry");
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, S1Product.PropertyItemDefinition> Ingredients =
+            new Dictionary<string, S1Product.PropertyItemDefinition>(StringComparer.OrdinalIgnoreCase);
+        private static bool _hooked;
+
+        /// <summary>
+        /// Records an ingredient so it is re-applied on future loads, and applies it to the mixing-ingredient
+        /// list immediately if the game is already running.
+        /// </summary>
+        internal static void Register(S1Product.PropertyItemDefinition definition)
+        {
+            if (definition == null)
+                return;
+
+            var id = definition.ID;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                Logger.Warning("Ingredient has no ID; it will not be tracked as a mixing ingredient.");
+                return;
+            }
+
+            lock (Gate)
+            {
+                Ingredients[id] = definition;
+                EnsureHooked();
+            }
+
+            EnsureInMixIngredients(definition);
+        }
+
+        /// <summary>
+        /// Returns the ingredient already registered under the given ID, if any. Used to keep repeated
+        /// builds of the same ID idempotent instead of registering duplicate definitions.
+        /// </summary>
+        internal static bool TryGetExisting(string id, out S1Product.PropertyItemDefinition definition)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                definition = null;
+                return false;
+            }
+
+            lock (Gate)
+            {
+                return Ingredients.TryGetValue(id, out definition);
+            }
+        }
+
+        private static void EnsureHooked()
+        {
+            if (_hooked)
+                return;
+
+            GameLifecycle.OnPreLoad += OnPreLoad;
+            GameLifecycle.OnLoadComplete += OnLoadComplete;
+            _hooked = true;
+        }
+
+        private static void OnPreLoad()
+        {
+            ReapplyRegistry();
+        }
+
+        private static void OnLoadComplete()
+        {
+            ReapplyRegistry();
+            ReapplyMixIngredients();
+        }
+
+        private static S1Product.PropertyItemDefinition[] Snapshot()
+        {
+            lock (Gate)
+            {
+                var snapshot = new S1Product.PropertyItemDefinition[Ingredients.Count];
+                Ingredients.Values.CopyTo(snapshot, 0);
+                return snapshot;
+            }
+        }
+
+        private static void ReapplyRegistry()
+        {
+            if (S1Registry.Instance == null)
+                return;
+
+            foreach (var definition in Snapshot())
+            {
+                if (definition == null)
+                    continue;
+
+                try
+                {
+                    if (!S1Registry.ItemExists(definition.ID))
+                        S1Registry.Instance.AddToRegistry(definition);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to re-register ingredient '{definition.ID}': {ex}");
+                }
+            }
+        }
+
+        private static void ReapplyMixIngredients()
+        {
+            foreach (var definition in Snapshot())
+            {
+                if (definition == null)
+                    continue;
+
+                EnsureInMixIngredients(definition);
+            }
+        }
+
+        private static bool EnsureInMixIngredients(S1Product.PropertyItemDefinition definition)
+        {
+            try
+            {
+                var productManager = S1Product.ProductManager.Instance;
+                if (productManager == null)
+                    return false;
+
+                var validMixIngredients = productManager.ValidMixIngredients;
+                if (validMixIngredients == null)
+                    return false;
+
+                if (!validMixIngredients.Contains(definition))
+                    validMixIngredients.Add(definition);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to add ingredient '{definition?.ID}' to the mixing-ingredient list: {ex}");
+                return false;
+            }
+        }
+    }
+}

--- a/S1API/Internal/Patches/MixReactionPatches.cs
+++ b/S1API/Internal/Patches/MixReactionPatches.cs
@@ -1,0 +1,137 @@
+#if (IL2CPPMELON)
+using S1Effects = Il2CppScheduleOne.Effects;
+using S1Product = Il2CppScheduleOne.Product;
+using EffectList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Effects.Effect>;
+#elif (IL2CPPBEPINEX)
+using S1Effects = ScheduleOne.Effects;
+using S1Product = ScheduleOne.Product;
+using EffectList = Il2CppSystem.Collections.Generic.List<ScheduleOne.Effects.Effect>;
+#elif (MONOMELON || MONOBEPINEX)
+using S1Effects = ScheduleOne.Effects;
+using S1Product = ScheduleOne.Product;
+using EffectList = System.Collections.Generic.List<ScheduleOne.Effects.Effect>;
+#endif
+using System;
+using HarmonyLib;
+using S1API.Logging;
+using S1API.Products;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Applies mod-registered mixing reactions after the game's mixing calculation.
+    /// </summary>
+    [HarmonyPatch(typeof(S1Effects.EffectMixCalculator), "MixProperties")]
+    internal static class MixReactionPatches
+    {
+        private static readonly Log Logger = new Log("MixReactionPatches");
+
+        private const int MaxProperties = 8;
+
+        /// <summary>
+        /// Applies registered mixing reactions to the effect list the game produced for a mix.
+        /// </summary>
+        /// <param name="__result">The mix result (Harmony-injected); reassigned to a cloned, transformed list so the game's own list is never mutated.</param>
+        /// <param name="newProperty">The effect the mixed-in ingredient contributed.</param>
+        /// <param name="drugType">The drug being mixed.</param>
+        [HarmonyPostfix]
+        private static void MixProperties_Postfix(
+            ref EffectList __result,
+            S1Effects.Effect newProperty,
+            S1Product.EDrugType drugType)
+        {
+            try
+            {
+                if (__result == null || newProperty == null)
+                    return;
+
+                var rules = MixReactions.Snapshot();
+                if (rules.Length == 0)
+                    return;
+
+                var mixerId = newProperty.ID;
+
+                // The game can return a shared list (e.g. a product definition's Properties for a named recipe),
+                // so never mutate __result directly. Clone once, only if a rule actually fires.
+                EffectList working = null;
+
+                foreach (var rule in rules)
+                {
+                    if (rule.Drug.HasValue && (int)rule.Drug.Value != (int)drugType)
+                        continue;
+
+                    if (!string.Equals(rule.MixerEffectId, mixerId, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    var current = working ?? __result;
+                    if (IndexOfId(current, rule.WhenContainsId) < 0)
+                        continue;
+
+                    var addEffect = MixReactions.ResolveAddResult(rule);
+                    if (addEffect == null)
+                        continue;
+
+                    if (working == null)
+                        working = Clone(__result);
+
+                    var matchIndex = IndexOfId(working, rule.WhenContainsId);
+                    if (matchIndex < 0)
+                        continue;
+
+                    if (rule.Replace)
+                    {
+                        working[matchIndex] = addEffect;
+                        RemoveDuplicateIds(working, addEffect.ID);
+                    }
+                    else if (working.Count < MaxProperties && IndexOfId(working, addEffect.ID) < 0)
+                    {
+                        working.Add(addEffect);
+                    }
+                }
+
+                if (working != null)
+                    __result = working;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Mixing reaction postfix failed: {ex}");
+            }
+        }
+
+        private static EffectList Clone(EffectList source)
+        {
+            var copy = new EffectList();
+            if (source == null)
+                return copy;
+            for (int i = 0; i < source.Count; i++)
+                copy.Add(source[i]);
+            return copy;
+        }
+
+        private static int IndexOfId(EffectList list, string id)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                var effect = list[i];
+                if (effect != null && string.Equals(effect.ID, id, StringComparison.OrdinalIgnoreCase))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static void RemoveDuplicateIds(EffectList list, string id)
+        {
+            var first = IndexOfId(list, id);
+            if (first < 0)
+                return;
+
+            for (int i = list.Count - 1; i > first; i--)
+            {
+                var effect = list[i];
+                if (effect != null && string.Equals(effect.ID, id, StringComparison.OrdinalIgnoreCase))
+                    list.RemoveAt(i);
+            }
+        }
+    }
+}

--- a/S1API/Internal/Patches/PropertyUtilityPatches.cs
+++ b/S1API/Internal/Patches/PropertyUtilityPatches.cs
@@ -1,0 +1,138 @@
+#if (IL2CPPMELON)
+using S1Product = Il2CppScheduleOne.Product;
+using S1Properties = Il2CppScheduleOne.Effects;
+using StringList = Il2CppSystem.Collections.Generic.List<string>;
+using EffectList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Effects.Effect>;
+#elif (IL2CPPBEPINEX)
+using S1Product = ScheduleOne.Product;
+using S1Properties = ScheduleOne.Effects;
+using StringList = Il2CppSystem.Collections.Generic.List<string>;
+using EffectList = Il2CppSystem.Collections.Generic.List<ScheduleOne.Effects.Effect>;
+#elif (MONOMELON || MONOBEPINEX)
+using S1Product = ScheduleOne.Product;
+using S1Properties = ScheduleOne.Effects;
+using StringList = System.Collections.Generic.List<string>;
+using EffectList = System.Collections.Generic.List<ScheduleOne.Effects.Effect>;
+#endif
+using System;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using S1API.Logging;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Safety net so a mod-created effect is never lost when the game resolves effects by ID.
+    /// <c>PropertyUtility.GetProperties(List&lt;string&gt;)</c> silently drops any ID it cannot find in its lookup;
+    /// this recovers custom effects from the mixing maps and the mixing-ingredient list, which our registry
+    /// always populates, so a custom effect survives even if a load-order edge case leaves it out of the lookup.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class PropertyUtilityPatches
+    {
+        private static readonly Log Logger = new Log("PropertyUtilityPatches");
+
+        private static readonly S1Product.EDrugType[] MixDrugs =
+        {
+            S1Product.EDrugType.Marijuana,
+            S1Product.EDrugType.Methamphetamine,
+            S1Product.EDrugType.Cocaine,
+            S1Product.EDrugType.Shrooms
+        };
+
+        private static MethodBase TargetMethod()
+        {
+            // The GetProperties(List<string>) overload, distinguished from GetProperties(int tier).
+            return typeof(S1Product.PropertyUtility)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .FirstOrDefault(method => method.Name == "GetProperties"
+                    && method.GetParameters().Length == 1
+                    && method.GetParameters()[0].ParameterType != typeof(int));
+        }
+
+        [HarmonyPostfix]
+        private static void GetProperties_Postfix(StringList __0, EffectList __result)
+        {
+            try
+            {
+                if (__0 == null || __result == null || __result.Count == __0.Count)
+                    return;
+
+                var productManager = S1Product.ProductManager.Instance;
+                if (productManager == null)
+                    return;
+
+                for (int i = 0; i < __0.Count; i++)
+                {
+                    var id = __0[i];
+                    if (string.IsNullOrEmpty(id) || ContainsId(__result, id))
+                        continue;
+
+                    var effect = FindInMixMaps(productManager, id) ?? FindInIngredients(productManager, id);
+                    if (effect != null && !ContainsId(__result, id))
+                        __result.Add(effect);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"GetProperties recovery failed: {ex}");
+            }
+        }
+
+        private static bool ContainsId(EffectList list, string id)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                var effect = list[i];
+                if (effect != null && string.Equals(effect.ID, id, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static S1Properties.Effect FindInMixMaps(S1Product.ProductManager productManager, string id)
+        {
+            foreach (var drug in MixDrugs)
+            {
+                var map = productManager.GetMixerMap(drug);
+                if (map == null || map.Effects == null)
+                    continue;
+
+                for (int i = 0; i < map.Effects.Count; i++)
+                {
+                    var mixerMapEffect = map.Effects[i];
+                    if (mixerMapEffect?.Property != null &&
+                        string.Equals(mixerMapEffect.Property.ID, id, StringComparison.OrdinalIgnoreCase))
+                        return mixerMapEffect.Property;
+                }
+            }
+
+            return null;
+        }
+
+        private static S1Properties.Effect FindInIngredients(S1Product.ProductManager productManager, string id)
+        {
+            var validMixIngredients = productManager.ValidMixIngredients;
+            if (validMixIngredients == null)
+                return null;
+
+            for (int i = 0; i < validMixIngredients.Count; i++)
+            {
+                var properties = validMixIngredients[i]?.Properties;
+                if (properties == null)
+                    continue;
+
+                for (int j = 0; j < properties.Count; j++)
+                {
+                    var effect = properties[j];
+                    if (effect != null && string.Equals(effect.ID, id, StringComparison.OrdinalIgnoreCase))
+                        return effect;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/S1API/Internal/Properties/CustomEffectRegistry.cs
+++ b/S1API/Internal/Properties/CustomEffectRegistry.cs
@@ -1,0 +1,259 @@
+#if (IL2CPPMELON)
+using S1Properties = Il2CppScheduleOne.Effects;
+using S1MixMaps = Il2CppScheduleOne.Effects.MixMaps;
+using S1Product = Il2CppScheduleOne.Product;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Properties = ScheduleOne.Effects;
+using S1MixMaps = ScheduleOne.Effects.MixMaps;
+using S1Product = ScheduleOne.Product;
+#endif
+using System;
+using System.Collections.Generic;
+#if (MONOMELON || MONOBEPINEX)
+using S1API.Internal.Utils;
+#endif
+using S1API.Lifecycle;
+using S1API.Logging;
+using UnityEngine;
+
+namespace S1API.Internal.Properties
+{
+    /// <summary>
+    /// INTERNAL: Tracks mod-created effects so they can be (re)applied to the game each load.
+    /// Effects are injected into <c>PropertyUtility</c> (both its list and its ID lookup) and given a position
+    /// on each relevant per-drug MixerMap so they survive being mixed again without crashing the game.
+    /// </summary>
+    internal static class CustomEffectRegistry
+    {
+        private sealed class Entry
+        {
+            internal S1Properties.Effect S1Effect { get; set; } = null!;
+            internal S1Product.EDrugType[] S1Drugs { get; set; } = Array.Empty<S1Product.EDrugType>();
+            internal Vector2? MixMapPosition { get; set; }
+            internal float MixMapRadius { get; set; }
+        }
+
+        private static readonly Log Logger = new Log("CustomEffectRegistry");
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, Entry> Effects =
+            new Dictionary<string, Entry>(StringComparer.OrdinalIgnoreCase);
+        private static bool _hooked;
+
+        /// <summary>
+        /// Records a custom effect and its mixing placement, and applies it immediately if the game is running.
+        /// </summary>
+        internal static void Register(
+            S1Properties.Effect effect,
+            S1Product.EDrugType[] drugs,
+            Vector2? mixMapPosition,
+            float mixMapRadius)
+        {
+            if (effect == null)
+                return;
+
+            var id = effect.ID;
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                Logger.Warning("Custom effect has no ID; it will not be tracked.");
+                return;
+            }
+
+            var entry = new Entry
+            {
+                S1Effect = effect,
+                S1Drugs = drugs ?? Array.Empty<S1Product.EDrugType>(),
+                MixMapPosition = mixMapPosition,
+                MixMapRadius = mixMapRadius
+            };
+
+            lock (Gate)
+            {
+                Effects[id] = entry;
+                EnsureHooked();
+            }
+
+            Apply(entry);
+        }
+
+        /// <summary>
+        /// Returns the effect already registered under the given ID, if any. Used to keep repeated builds of
+        /// the same ID idempotent instead of injecting a second object the game's lookups would not resolve to.
+        /// </summary>
+        internal static bool TryGetExisting(string id, out S1Properties.Effect effect)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                effect = null!;
+                return false;
+            }
+
+            lock (Gate)
+            {
+                if (Effects.TryGetValue(id, out var entry))
+                {
+                    effect = entry.S1Effect;
+                    return true;
+                }
+            }
+
+            effect = null!;
+            return false;
+        }
+
+        private static void EnsureHooked()
+        {
+            if (_hooked)
+                return;
+
+            // Apply on pre-load so saved products that reference a custom effect can resolve its ID during load,
+            // and again on load-complete once the mixing systems (MixerMaps) are available.
+            GameLifecycle.OnPreLoad += ApplyAll;
+            GameLifecycle.OnLoadComplete += ApplyAll;
+            _hooked = true;
+        }
+
+        private static void ApplyAll()
+        {
+            foreach (var entry in Snapshot())
+                Apply(entry);
+        }
+
+        private static Entry[] Snapshot()
+        {
+            lock (Gate)
+            {
+                var snapshot = new Entry[Effects.Count];
+                Effects.Values.CopyTo(snapshot, 0);
+                return snapshot;
+            }
+        }
+
+        private static void Apply(Entry entry)
+        {
+            EnsureInPropertyUtility(entry);
+            EnsureInMixMaps(entry);
+        }
+
+        private static void EnsureInPropertyUtility(Entry entry)
+        {
+            if (entry?.S1Effect == null || string.IsNullOrWhiteSpace(entry.S1Effect.ID))
+                return;
+
+            try
+            {
+                var propertyUtility = S1Product.PropertyUtility.Instance;
+                if (propertyUtility == null)
+                    return;
+
+                var allProperties = propertyUtility.AllProperties;
+                if (allProperties == null)
+                    return;
+
+                var effect = entry.S1Effect;
+
+                // Always keep the ID lookup consistent with the list; the game's GetProperties(List<string>)
+                // reads the list to test membership and then indexes the dictionary, so both must contain the ID.
+                var inDictionary = EnsureInPropertiesDict(propertyUtility, effect);
+
+                var inList = false;
+                for (int i = 0; i < allProperties.Count; i++)
+                {
+                    var existing = allProperties[i];
+                    if (existing != null &&
+                        string.Equals(existing.ID, effect.ID, StringComparison.OrdinalIgnoreCase))
+                    {
+                        inList = true;
+                        break;
+                    }
+                }
+
+                if (!inList && inDictionary)
+                    allProperties.Add(effect);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to add custom effect '{entry.S1Effect?.ID}' to PropertyUtility: {ex}");
+            }
+        }
+
+        private static bool EnsureInPropertiesDict(S1Product.PropertyUtility propertyUtility, S1Properties.Effect effect)
+        {
+#if (IL2CPPMELON || IL2CPPBEPINEX)
+            var dict = propertyUtility.PropertiesDict;
+            if (dict == null)
+                return false;
+            if (!dict.ContainsKey(effect.ID))
+                dict.Add(effect.ID, effect);
+            return true;
+#else
+            var dictObject = ReflectionUtils.TryGetFieldOrProperty(propertyUtility, "PropertiesDict");
+            if (dictObject is System.Collections.Generic.Dictionary<string, S1Properties.Effect> dict)
+            {
+                if (!dict.ContainsKey(effect.ID))
+                    dict.Add(effect.ID, effect);
+                return true;
+            }
+            return false;
+#endif
+        }
+
+        private static void EnsureInMixMaps(Entry entry)
+        {
+            if (entry?.S1Effect == null || entry.S1Drugs == null)
+                return;
+
+            try
+            {
+                var productManager = S1Product.ProductManager.Instance;
+                if (productManager == null)
+                    return;
+
+                foreach (var drug in entry.S1Drugs)
+                {
+                    var map = productManager.GetMixerMap(drug);
+                    if (map == null || map.Effects == null)
+                        continue;
+
+                    if (ContainsEffect(map, entry.S1Effect.ID))
+                        continue;
+
+                    var mixerMapEffect = new S1MixMaps.MixerMapEffect();
+                    mixerMapEffect.Property = entry.S1Effect;
+                    mixerMapEffect.Position = entry.MixMapPosition ?? DefaultPosition(entry.S1Effect, map.MapRadius);
+                    mixerMapEffect.Radius = entry.MixMapRadius > 0f ? entry.MixMapRadius : 0.01f;
+
+                    map.Effects.Add(mixerMapEffect);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to place custom effect '{entry.S1Effect?.ID}' on a MixerMap: {ex}");
+            }
+        }
+
+        private static bool ContainsEffect(S1MixMaps.MixerMap map, string effectId)
+        {
+            for (int i = 0; i < map.Effects.Count; i++)
+            {
+                var existing = map.Effects[i];
+                if (existing?.Property != null &&
+                    string.Equals(existing.Property.ID, effectId, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Places the effect just outside the map so it never captures an incoming mix by default,
+        /// while still giving it a valid position so re-mixing does not throw.
+        /// </summary>
+        private static Vector2 DefaultPosition(S1Properties.Effect effect, float mapRadius)
+        {
+            var hash = (effect.ID ?? string.Empty).GetHashCode() & 0x7fffffff;
+            var angle = (hash % 360) * Mathf.Deg2Rad;
+            var radius = (mapRadius > 0f ? mapRadius : 5f) + 1f;
+            return new Vector2(Mathf.Cos(angle) * radius, Mathf.Sin(angle) * radius);
+        }
+    }
+}

--- a/S1API/Items/Ingredient/MixIngredientDefinition.cs
+++ b/S1API/Items/Ingredient/MixIngredientDefinition.cs
@@ -1,0 +1,59 @@
+#if (IL2CPPMELON)
+using S1Product = Il2CppScheduleOne.Product;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Product = ScheduleOne.Product;
+#endif
+using System.Collections.Generic;
+using S1API.Properties;
+using S1API.Properties.Interfaces;
+
+namespace S1API.Items.Ingredient
+{
+    /// <summary>
+    /// Represents a mixing ingredient item definition.
+    /// A mixing ingredient is a <see cref="Storable.StorableItemDefinition"/> that carries one or more
+    /// effects and can be dropped into the Mixing Station to imprint those effects onto a product.
+    /// </summary>
+    /// <remarks>
+    /// Builder-only: the effect list is intentionally read-only here to avoid runtime surprises from
+    /// mutating globally-registered ScriptableObject definitions mid-session. Use
+    /// <see cref="MixIngredientItemCreator"/> to create ingredients with configured effects.
+    /// </remarks>
+    public sealed class MixIngredientDefinition : Storable.StorableItemDefinition
+    {
+        /// <summary>
+        /// INTERNAL: Wraps an existing native property item definition used as a mixing ingredient.
+        /// </summary>
+        internal MixIngredientDefinition(S1Product.PropertyItemDefinition definition)
+            : base(definition)
+        {
+            S1IngredientDefinition = definition;
+        }
+
+        /// <summary>
+        /// INTERNAL: A reference to the native game property item definition.
+        /// </summary>
+        internal S1Product.PropertyItemDefinition S1IngredientDefinition { get; }
+
+        /// <summary>
+        /// The effects this ingredient imprints when mixed.
+        /// The first effect is the one applied to the product; further effects are carried on the item.
+        /// Returns runtime-agnostic wrappers that work on both Mono and IL2CPP.
+        /// </summary>
+        public IReadOnlyList<PropertyBase> Properties
+        {
+            get
+            {
+                var s1Properties = S1IngredientDefinition.Properties;
+                if (s1Properties == null)
+                    return new List<PropertyBase>().AsReadOnly();
+
+                var wrappers = new List<PropertyBase>(s1Properties.Count);
+                for (int i = 0; i < s1Properties.Count; i++)
+                    wrappers.Add(new ProductPropertyWrapper(s1Properties[i]));
+
+                return wrappers.AsReadOnly();
+            }
+        }
+    }
+}

--- a/S1API/Items/Ingredient/MixIngredientDefinitionBuilder.cs
+++ b/S1API/Items/Ingredient/MixIngredientDefinitionBuilder.cs
@@ -1,0 +1,228 @@
+#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1CoreItemFramework = Il2CppScheduleOne.Core.Items.Framework;
+using S1Product = Il2CppScheduleOne.Product;
+using S1Properties = Il2CppScheduleOne.Effects;
+using S1Registry = Il2CppScheduleOne.Registry;
+using S1Storage = Il2CppScheduleOne.Storage;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1CoreItemFramework = ScheduleOne.Core.Items.Framework;
+using S1Product = ScheduleOne.Product;
+using S1Properties = ScheduleOne.Effects;
+using S1Registry = ScheduleOne.Registry;
+using S1Storage = ScheduleOne.Storage;
+#endif
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Items;
+using S1API.Internal.Properties;
+using S1API.Internal.Utils;
+using S1API.Items.Storable;
+using S1API.Logging;
+using S1API.Properties.Interfaces;
+using UnityEngine;
+
+namespace S1API.Items.Ingredient
+{
+    /// <summary>
+    /// Builder for composing mixing ingredient definitions at runtime.
+    /// Use fluent methods to configure the ingredient and its imprinted effects before calling <see cref="Build"/>.
+    /// </summary>
+    public sealed class MixIngredientDefinitionBuilder
+        : StorableItemDefinitionBuilderBase<MixIngredientDefinitionBuilder>
+    {
+        private static readonly Log Logger = new Log("MixIngredientDefinitionBuilder");
+
+        private static readonly string[] MixerTemplateIds =
+        {
+            "iodine", "cuke", "banana", "donut", "chili", "paracetamol", "energydrink",
+            "motoroil", "mouthwash", "megabean", "battery", "addy", "flumedicine", "gasoline"
+        };
+
+        private S1Product.PropertyItemDefinition IngredientDefinition =>
+            CrossType.As<S1Product.PropertyItemDefinition>(Definition);
+
+        /// <summary>
+        /// INTERNAL: Creates a new builder instance with a fresh PropertyItemDefinition.
+        /// Only <see cref="MixIngredientItemCreator"/> can instantiate this.
+        /// </summary>
+        internal MixIngredientDefinitionBuilder()
+            : base(ScriptableObject.CreateInstance<S1Product.PropertyItemDefinition>)
+        {
+            Definition.Category = (S1CoreItemFramework.EItemCategory)ItemCategory.Ingredient;
+        }
+
+        /// <summary>
+        /// INTERNAL: Creates a builder instance initialized by cloning an existing ingredient.
+        /// </summary>
+        internal MixIngredientDefinitionBuilder(
+            S1Product.PropertyItemDefinition source)
+            : base(source,
+                ScriptableObject.CreateInstance<S1Product.PropertyItemDefinition>)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void CopyPropertiesFrom(
+            S1ItemFramework.StorableItemDefinition source)
+        {
+            base.CopyPropertiesFrom(source);
+
+            var ingredientSource = CrossType.As<S1Product.PropertyItemDefinition>(source);
+            if (ingredientSource == null)
+                return;
+
+            var copy = new List<S1Properties.Effect>();
+            var sourceProperties = ingredientSource.Properties;
+            if (sourceProperties != null)
+            {
+                for (int i = 0; i < sourceProperties.Count; i++)
+                    copy.Add(sourceProperties[i]);
+            }
+
+            IngredientDefinition.Properties = ToIl2CppList(copy);
+        }
+
+        /// <summary>
+        /// Sets the single effect this ingredient imprints when mixed.
+        /// </summary>
+        /// <param name="effect">The effect to imprint (a vanilla token from <c>S1API.Properties.Property</c> or a registered custom effect).</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public MixIngredientDefinitionBuilder WithEffect(PropertyBase effect)
+        {
+            return WithEffects(effect);
+        }
+
+        /// <summary>
+        /// Sets the effects this ingredient carries. The first effect is the one applied to the product when mixed.
+        /// </summary>
+        /// <param name="effects">The effects to carry (vanilla tokens or registered custom effects).</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public MixIngredientDefinitionBuilder WithEffects(params PropertyBase[] effects)
+        {
+            if (effects == null || effects.Length == 0)
+            {
+                Logger.Warning("WithEffects called with no effects; the ingredient will not imprint anything when mixed.");
+                return this;
+            }
+
+            var resolved = PropertyResolver.ResolveToGameProperties(effects);
+            if (resolved.Count == 0)
+            {
+                Logger.Warning(
+                    "None of the supplied effects resolved to a game effect. Use a vanilla token or a registered custom effect.");
+            }
+
+            IngredientDefinition.Properties = ToIl2CppList(resolved);
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the ingredient definition, registers it with the game's registry and the mixing-ingredient
+        /// list, and returns a wrapper. The ingredient is automatically re-applied on subsequent loads.
+        /// </summary>
+        /// <returns>A wrapper around the created ingredient definition.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the ingredient carries no resolved effects.</exception>
+        public new MixIngredientDefinition Build()
+        {
+            // Building the same ID again (e.g. from a per-load setup hook) reuses the first registration
+            // instead of adding a duplicate mixing ingredient.
+            var id = Definition.ID;
+            if (CustomIngredientRegistry.TryGetExisting(id, out var existing))
+            {
+                Logger.Warning($"Mixing ingredient '{id}' is already registered; returning the existing one.");
+                return new MixIngredientDefinition(existing);
+            }
+
+            var properties = IngredientDefinition.Properties;
+            if (properties == null || properties.Count == 0)
+            {
+                Logger.Error(
+                    "Cannot build mixing ingredient: it carries no effects. Use WithEffect(...) with a vanilla token or a registered custom effect.");
+                throw new InvalidOperationException("Cannot build mixing ingredient: at least one effect is required.");
+            }
+
+            EnsureStoredItem();
+            var built = (MixIngredientDefinition)base.Build();
+            CustomIngredientRegistry.Register(IngredientDefinition);
+            return built;
+        }
+
+        /// <summary>
+        /// Gives the ingredient a working StoredItem. The base builder only attaches a bare placeholder, which
+        /// has no footprint tiles, so the game throws when it places the ingredient into a slot. A real mixing
+        /// ingredient's StoredItem (e.g. Iodine's) has a valid footprint and model, so reuse one of those.
+        /// </summary>
+        private void EnsureStoredItem()
+        {
+            // Respect a StoredItem the modder supplied via WithStoredItem; only fill in a default otherwise.
+            if (HasCustomStoredItem)
+                return;
+
+            var template = FindMixerStoredItem();
+            if (template != null)
+            {
+                Definition.StoredItem = template;
+                return;
+            }
+
+            // Fallback if no vanilla mixer is available: give the placeholder a 1x1 footprint so it does not throw.
+            var storedItem = Definition.StoredItem;
+            if (storedItem == null)
+                return;
+
+            ReflectionUtils.TrySetFieldOrProperty(storedItem, "footprintX", 1);
+            ReflectionUtils.TrySetFieldOrProperty(storedItem, "footprintY", 1);
+        }
+
+        private static S1Storage.StoredItem FindMixerStoredItem()
+        {
+            foreach (var id in MixerTemplateIds)
+            {
+                var definition = S1Registry.GetItem(id);
+                if (definition == null)
+                    continue;
+
+                if (CrossType.Is(definition, out S1ItemFramework.StorableItemDefinition storable) &&
+                    storable.StoredItem != null)
+                    return storable.StoredItem;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// INTERNAL: Builds and returns the raw game item definition without registering.
+        /// Used internally by S1API. Modders should use <see cref="Build"/> instead.
+        /// </summary>
+        internal new S1Product.PropertyItemDefinition BuildInternal()
+        {
+            return IngredientDefinition;
+        }
+
+        /// <inheritdoc />
+        protected override Storable.StorableItemDefinition CreateWrapper(
+            S1ItemFramework.StorableItemDefinition definition)
+        {
+            return new MixIngredientDefinition(CrossType.As<S1Product.PropertyItemDefinition>(definition));
+        }
+
+#if (IL2CPPMELON || IL2CPPBEPINEX)
+        private static Il2CppSystem.Collections.Generic.List<T> ToIl2CppList<T>(List<T> source)
+        {
+            var list = new Il2CppSystem.Collections.Generic.List<T>();
+            if (source == null)
+                return list;
+            for (int i = 0; i < source.Count; i++)
+                list.Add(source[i]);
+            return list;
+        }
+#else
+        private static List<T> ToIl2CppList<T>(List<T> source)
+        {
+            return source;
+        }
+#endif
+    }
+}

--- a/S1API/Items/Ingredient/MixIngredientItemCreator.cs
+++ b/S1API/Items/Ingredient/MixIngredientItemCreator.cs
@@ -1,0 +1,72 @@
+#if (IL2CPPMELON)
+using S1Product = Il2CppScheduleOne.Product;
+using S1Registry = Il2CppScheduleOne.Registry;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Product = ScheduleOne.Product;
+using S1Registry = ScheduleOne.Registry;
+#endif
+using System;
+using S1API.Internal.Utils;
+
+namespace S1API.Items.Ingredient
+{
+    /// <summary>
+    /// Provides convenient static methods for creating custom mixing ingredients.
+    /// Use <see cref="CreateBuilder"/> for creating ingredients from scratch, or <see cref="CloneFrom(string)"/> for variants.
+    /// </summary>
+    public static class MixIngredientItemCreator
+    {
+        /// <summary>
+        /// Creates a new builder for composing a mixing ingredient definition with full flexibility.
+        /// Use fluent methods to configure the ingredient, then call Build() to register it.
+        /// </summary>
+        /// <returns>A new <see cref="MixIngredientDefinitionBuilder"/> instance for fluent configuration.</returns>
+        public static MixIngredientDefinitionBuilder CreateBuilder()
+        {
+            return new MixIngredientDefinitionBuilder();
+        }
+
+        /// <summary>
+        /// Creates a new ingredient builder by cloning an existing mixing ingredient by ID.
+        /// </summary>
+        /// <param name="sourceItemId">The ID of the ingredient to clone.</param>
+        /// <returns>A builder pre-configured with the source ingredient's properties.</returns>
+        /// <exception cref="ArgumentException">Thrown if the source item does not exist or is not a mixing ingredient.</exception>
+        public static MixIngredientDefinitionBuilder CloneFrom(string sourceItemId)
+        {
+            if (string.IsNullOrWhiteSpace(sourceItemId))
+            {
+                throw new ArgumentException("Source item ID cannot be null or whitespace", nameof(sourceItemId));
+            }
+
+            var sourceDefinition = S1Registry.GetItem(sourceItemId);
+            if (sourceDefinition == null)
+            {
+                throw new ArgumentException($"Source item with ID '{sourceItemId}' not found in registry", nameof(sourceItemId));
+            }
+
+            if (!CrossType.Is(sourceDefinition, out S1Product.PropertyItemDefinition propertyDef))
+            {
+                throw new ArgumentException($"Item '{sourceItemId}' is not a PropertyItemDefinition and cannot be used as a mixing ingredient", nameof(sourceItemId));
+            }
+
+            return new MixIngredientDefinitionBuilder(propertyDef);
+        }
+
+        /// <summary>
+        /// Creates a new ingredient builder by cloning an existing ingredient wrapper.
+        /// </summary>
+        /// <param name="source">The ingredient definition to clone from.</param>
+        /// <returns>A builder pre-configured with the source ingredient's properties.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if the source is null.</exception>
+        public static MixIngredientDefinitionBuilder CloneFrom(MixIngredientDefinition source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source), "Source ingredient definition cannot be null");
+            }
+
+            return new MixIngredientDefinitionBuilder(source.S1IngredientDefinition);
+        }
+    }
+}

--- a/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
+++ b/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
@@ -99,6 +99,12 @@ namespace S1API.Items.Storable
         private readonly GameObject _storedItemPlaceholder;
         private bool _hasCustomStoredItem;
 
+        /// <summary>
+        /// INTERNAL: Whether a custom StoredItem was assigned via <see cref="WithStoredItem"/>.
+        /// Subclasses use this to avoid overwriting a modder-supplied StoredItem.
+        /// </summary>
+        protected bool HasCustomStoredItem => _hasCustomStoredItem;
+
         private TSelf Self => (TSelf)this;
 
         /// <summary>

--- a/S1API/Products/MixReactions.cs
+++ b/S1API/Products/MixReactions.cs
@@ -1,0 +1,115 @@
+#if (IL2CPPMELON)
+using S1Properties = Il2CppScheduleOne.Effects;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Properties = ScheduleOne.Effects;
+#endif
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Properties;
+using S1API.Properties.Interfaces;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Registers custom mixing reactions: deterministic rules that transform the effects a mix produces.
+    /// A rule fires when a product is mixed with an ingredient contributing a specific effect and the result
+    /// already carries another specific effect, letting mods build combo and chain effects.
+    /// </summary>
+    /// <remarks>
+    /// Rules are applied after the game's own mixing calculation, on every client (the calculation is
+    /// deterministic, so no networking is required as long as every peer has the same rules and effects).
+    /// </remarks>
+    public static class MixReactions
+    {
+        /// <summary>
+        /// INTERNAL: A single registered mixing reaction.
+        /// </summary>
+        internal sealed class Rule
+        {
+            internal string MixerEffectId { get; set; } = string.Empty;
+            internal string WhenContainsId { get; set; } = string.Empty;
+            internal PropertyBase AddResult { get; set; } = null!;
+            internal DrugType? Drug { get; set; }
+            internal bool Replace { get; set; }
+            internal S1Properties.Effect? S1Resolved { get; set; }
+        }
+
+        private static readonly object Gate = new object();
+        private static readonly List<Rule> Rules = new List<Rule>();
+
+        /// <summary>
+        /// Adds a mixing reaction rule.
+        /// </summary>
+        /// <param name="mixerEffect">The effect the mixed-in ingredient contributes (drives this reaction).</param>
+        /// <param name="whenResultContains">An effect that must already be present in the mix result for the rule to fire.</param>
+        /// <param name="addResult">The effect produced by the reaction.</param>
+        /// <param name="drug">Restrict the rule to a specific drug, or null to apply to all drugs.</param>
+        /// <param name="replaceMatched">
+        /// If <c>true</c>, the produced effect replaces <paramref name="whenResultContains"/>;
+        /// if <c>false</c>, it is added alongside it (up to the 8-effect cap).
+        /// </param>
+        public static void AddRule(
+            PropertyBase mixerEffect,
+            PropertyBase whenResultContains,
+            PropertyBase addResult,
+            DrugType? drug = null,
+            bool replaceMatched = false)
+        {
+            if (mixerEffect == null)
+                throw new ArgumentNullException(nameof(mixerEffect));
+            if (whenResultContains == null)
+                throw new ArgumentNullException(nameof(whenResultContains));
+            if (addResult == null)
+                throw new ArgumentNullException(nameof(addResult));
+
+            lock (Gate)
+            {
+                Rules.Add(new Rule
+                {
+                    MixerEffectId = mixerEffect.ID,
+                    WhenContainsId = whenResultContains.ID,
+                    AddResult = addResult,
+                    Drug = drug,
+                    Replace = replaceMatched
+                });
+            }
+        }
+
+        /// <summary>
+        /// Removes all registered mixing reaction rules.
+        /// </summary>
+        public static void Clear()
+        {
+            lock (Gate)
+            {
+                Rules.Clear();
+            }
+        }
+
+        /// <summary>
+        /// INTERNAL: Snapshot of the current rules for the mixing patch.
+        /// </summary>
+        internal static Rule[] Snapshot()
+        {
+            lock (Gate)
+            {
+                return Rules.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// INTERNAL: Resolves and caches the produced effect for a rule.
+        /// </summary>
+        internal static S1Properties.Effect? ResolveAddResult(Rule rule)
+        {
+            if (rule.S1Resolved != null)
+                return rule.S1Resolved;
+
+            var resolved = PropertyResolver.ResolveToGameProperties(new[] { rule.AddResult });
+            if (resolved.Count > 0)
+                rule.S1Resolved = resolved[0];
+
+            return rule.S1Resolved;
+        }
+    }
+}

--- a/S1API/Properties/CustomEffect.cs
+++ b/S1API/Properties/CustomEffect.cs
@@ -1,0 +1,24 @@
+#if (IL2CPPMELON)
+using S1Properties = Il2CppScheduleOne.Effects;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Properties = ScheduleOne.Effects;
+#endif
+
+namespace S1API.Properties
+{
+    /// <summary>
+    /// A property/effect created at runtime by a mod.
+    /// Behaves like any other property token and can be passed anywhere a vanilla
+    /// <see cref="Property"/> token is accepted (e.g. a mixing ingredient's effect).
+    /// </summary>
+    public sealed class CustomEffect : ProductPropertyWrapper
+    {
+        /// <summary>
+        /// INTERNAL: Wraps the created native effect.
+        /// </summary>
+        internal CustomEffect(S1Properties.Effect effect)
+            : base(effect)
+        {
+        }
+    }
+}

--- a/S1API/Properties/CustomEffectBuilder.cs
+++ b/S1API/Properties/CustomEffectBuilder.cs
@@ -1,0 +1,240 @@
+#if (IL2CPPMELON)
+using S1Properties = Il2CppScheduleOne.Effects;
+using S1Product = Il2CppScheduleOne.Product;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1Properties = ScheduleOne.Effects;
+using S1Product = ScheduleOne.Product;
+#endif
+using System;
+using System.Collections.Generic;
+using S1API.Entities;
+using S1API.Internal.Properties;
+using S1API.Logging;
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Properties
+{
+    /// <summary>
+    /// Builder for composing a custom effect (drug property) at runtime.
+    /// Configure the effect with fluent methods, then call <see cref="Build"/> to register it.
+    /// </summary>
+    /// <remarks>
+    /// A custom effect is a real game effect that can be imprinted onto products by a mixing ingredient.
+    /// Its display metadata, value contribution, and mixing geometry are configurable. Optional behavior runs
+    /// through the same effect-callback path S1API already uses for overriding vanilla effects.
+    /// </remarks>
+    public sealed class CustomEffectBuilder
+    {
+        private static readonly Log Logger = new Log("CustomEffectBuilder");
+
+        private string _id = string.Empty;
+        private string _name = string.Empty;
+        private string _description = string.Empty;
+        private int _tier = 1;
+        private float _addictiveness = 0.1f;
+        private Color _productColor = Color.white;
+        private Color _labelColor = Color.white;
+        private int _valueChange;
+        private float _valueMultiplier = 1f;
+        private float _addBaseValueMultiple;
+        private Vector2 _mixDirection = Vector2.zero;
+        private float _mixMagnitude = 1f;
+        private Vector2? _mixMapPosition;
+        private float _mixMapRadius;
+        private DrugType[]? _drugs;
+        private Action<Player>? _playerBehavior;
+        private Action<NPC>? _npcBehavior;
+
+        /// <summary>
+        /// Sets the effect's identity and display text.
+        /// </summary>
+        /// <param name="id">Unique effect ID (e.g. "mymod_glow"). Must be unique across all effects.</param>
+        /// <param name="name">Display name shown on products.</param>
+        /// <param name="description">Description shown in tooltips.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithBasicInfo(string id, string name, string description)
+        {
+            _id = id ?? string.Empty;
+            _name = name ?? string.Empty;
+            _description = description ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the effect tier (1-5), which affects its ordering and value contribution.
+        /// </summary>
+        /// <param name="tier">Tier from 1 to 5.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithTier(int tier)
+        {
+            _tier = Mathf.Clamp(tier, 1, 5);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets how addictive this effect makes a product (0 to 1).
+        /// </summary>
+        /// <param name="addictiveness">Addictiveness from 0 to 1.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithAddictiveness(float addictiveness)
+        {
+            _addictiveness = Mathf.Clamp01(addictiveness);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets how this effect changes a product's value.
+        /// </summary>
+        /// <param name="valueChange">Flat value added (-100 to 100).</param>
+        /// <param name="valueMultiplier">Multiplier applied to the product value (0 to 2).</param>
+        /// <param name="addBaseValueMultiple">Fraction of the base value added (-1 to 1).</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithValue(int valueChange, float valueMultiplier = 1f, float addBaseValueMultiple = 0f)
+        {
+            _valueChange = Mathf.Clamp(valueChange, -100, 100);
+            _valueMultiplier = Mathf.Clamp(valueMultiplier, 0f, 2f);
+            _addBaseValueMultiple = Mathf.Clamp(addBaseValueMultiple, -1f, 1f);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the colors used for this effect on the product and its label.
+        /// </summary>
+        /// <param name="productColor">The color tint applied to the product.</param>
+        /// <param name="labelColor">The color used for the effect label.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithColors(Color productColor, Color labelColor)
+        {
+            _productColor = productColor;
+            _labelColor = labelColor;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the mixing geometry used when this effect is the one being mixed into a product.
+        /// </summary>
+        /// <param name="direction">Direction on the mixing plane.</param>
+        /// <param name="magnitude">Magnitude of the mixing vector.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithMixGeometry(Vector2 direction, float magnitude)
+        {
+            _mixDirection = direction;
+            _mixMagnitude = magnitude;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides where this effect sits on each drug's mixing map. By default the effect is placed off to
+        /// the side so it does not capture other mixes; set this to design deliberate reactions.
+        /// </summary>
+        /// <param name="position">Position on the mixing plane.</param>
+        /// <param name="radius">Radius of the effect's region.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithMixMapPlacement(Vector2 position, float radius)
+        {
+            _mixMapPosition = position;
+            _mixMapRadius = radius;
+            return this;
+        }
+
+        /// <summary>
+        /// Restricts which drugs this effect participates in mixing for. Defaults to all mixable drugs.
+        /// </summary>
+        /// <param name="drugs">The drug types to register the effect for.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder ForDrugs(params DrugType[] drugs)
+        {
+            _drugs = drugs;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the behavior run when this effect is applied to the local player.
+        /// </summary>
+        /// <param name="onApply">Callback invoked with the local player when the effect triggers.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithBehavior(Action<Player> onApply)
+        {
+            _playerBehavior = onApply;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the behavior run when this effect is applied to an NPC.
+        /// </summary>
+        /// <param name="onApply">Callback invoked with the NPC when the effect triggers.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithNpcBehavior(Action<NPC> onApply)
+        {
+            _npcBehavior = onApply;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds and registers the custom effect and returns a token usable anywhere a property is accepted.
+        /// </summary>
+        /// <returns>A <see cref="CustomEffect"/> token for the created effect.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if no ID was set.</exception>
+        public CustomEffect Build()
+        {
+            if (string.IsNullOrWhiteSpace(_id))
+            {
+                Logger.Error("Cannot build custom effect: ID is required. Use WithBasicInfo(...) to set the ID.");
+                throw new InvalidOperationException("Cannot build custom effect: ID is required.");
+            }
+
+            // Building the same ID again (e.g. from a per-load setup hook) reuses the first registration, so the
+            // game's ID lookups keep resolving to a single effect object instead of a later, uninjected one.
+            if (CustomEffectRegistry.TryGetExisting(_id, out var existing))
+            {
+                Logger.Warning($"Custom effect '{_id}' is already registered; returning the existing effect.");
+                return new CustomEffect(existing);
+            }
+
+            // A pure no-op vanilla effect is used as the carrier type: it never applies or clears any state,
+            // so the effect only does what its registered behavior does. The carrier type is never checked by
+            // the game; effects are matched by ID and object reference.
+            S1Properties.Effect effect = ScriptableObject.CreateInstance<S1Properties.Refreshing>();
+            effect.name = _id;
+            effect.ID = _id;
+            effect.Name = string.IsNullOrEmpty(_name) ? _id : _name;
+            effect.Description = _description;
+            effect.Tier = _tier;
+            effect.Addictiveness = _addictiveness;
+            effect.ProductColor = _productColor;
+            effect.LabelColor = _labelColor;
+            effect.ValueChange = _valueChange;
+            effect.ValueMultiplier = _valueMultiplier;
+            effect.AddBaseValueMultiple = _addBaseValueMultiple;
+            effect.MixDirection = _mixDirection;
+            effect.MixMagnitude = _mixMagnitude;
+            // Mark the effect as available on all saves, including those created before the mixing rework;
+            // otherwise the game filters it out of tier-based property lookups on older saves.
+            effect.ImplementedPriorMixingRework = true;
+
+            if (_playerBehavior != null)
+                ProductManager.SetEffectCallback(_id, _playerBehavior, allowDefaultEffect: false);
+
+            if (_npcBehavior != null)
+                ProductManager.SetNpcEffectCallback(_id, _npcBehavior, allowDefaultEffect: false);
+
+            CustomEffectRegistry.Register(effect, ResolveDrugs(), _mixMapPosition, _mixMapRadius);
+
+            return new CustomEffect(effect);
+        }
+
+        private S1Product.EDrugType[] ResolveDrugs()
+        {
+            var drugs = _drugs != null && _drugs.Length > 0
+                ? _drugs
+                : new[] { DrugType.Marijuana, DrugType.Methamphetamine, DrugType.Cocaine, DrugType.Shrooms };
+
+            var native = new List<S1Product.EDrugType>(drugs.Length);
+            foreach (var drug in drugs)
+                native.Add((S1Product.EDrugType)drug);
+
+            return native.ToArray();
+        }
+    }
+}

--- a/S1API/Properties/EffectCreator.cs
+++ b/S1API/Properties/EffectCreator.cs
@@ -1,0 +1,18 @@
+namespace S1API.Properties
+{
+    /// <summary>
+    /// Provides convenient static methods for creating custom effects (drug properties).
+    /// </summary>
+    public static class EffectCreator
+    {
+        /// <summary>
+        /// Creates a new builder for composing a custom effect.
+        /// Use fluent methods to configure the effect, then call Build() to register it.
+        /// </summary>
+        /// <returns>A new <see cref="CustomEffectBuilder"/> instance for fluent configuration.</returns>
+        public static CustomEffectBuilder CreateBuilder()
+        {
+            return new CustomEffectBuilder();
+        }
+    }
+}

--- a/S1API/docs/mixing-ingredients.md
+++ b/S1API/docs/mixing-ingredients.md
@@ -1,0 +1,154 @@
+# Mixing Ingredients & Effects
+
+Create custom mixing ingredients (the additives you drop into the Mixing Station),
+custom effects (drug properties), and mixing reactions between them.
+
+## Important Notes
+
+- A mixing ingredient is a builder-only definition. Configure its imprinted effect at build time.
+- S1API re-applies your ingredients and effects on every load, so create them once (the recommended
+  place is `GameLifecycle.OnPreLoad`, or any time after your mod initializes).
+- Custom effects and ingredients are client-local. In multiplayer every player who should see them must
+  run the same mod, so the same effects and ingredients exist on every peer (including the host).
+- A mixing ingredient does not need a station prefab. It only needs an imprinted effect and to be
+  registered, which the builder handles for you.
+
+## Creating a Mixing Ingredient
+
+An ingredient imprints one or more effects onto a product when mixed. The first effect is the one applied.
+
+```csharp
+using MelonLoader;
+using S1API.Items;
+using S1API.Items.Ingredient;
+using S1API.Lifecycle;
+using S1API.Properties;
+
+public class MyMod : MelonMod
+{
+    public override void OnSceneWasLoaded(int buildIndex, string sceneName)
+    {
+        if (sceneName != "Main")
+            return;
+
+        GameLifecycle.OnPreLoad += RegisterContent;
+    }
+
+    private static void RegisterContent()
+    {
+        var chili = MixIngredientItemCreator.CreateBuilder()
+            .WithBasicInfo(
+                id: "mymod_chili",
+                name: "Chili",
+                description: "A fiery pod that adds a kick to the mix.",
+                category: ItemCategory.Ingredient)
+            .WithPricing(basePurchasePrice: 12f, resellMultiplier: 0.4f)
+            .WithEffect(Property.Spicy)
+            .Build();
+
+        MelonLogger.Msg($"Registered ingredient: {chili.Name} ({chili.ID})");
+    }
+}
+```
+
+`WithEffect` accepts any vanilla token from `S1API.Properties.Property` or a custom effect (below).
+Use `WithEffects(...)` to carry more than one effect.
+
+### Appearance
+
+- Set the inventory icon with `WithIcon(sprite)`.
+- The game requires every item to have a physical "stored" body (with a valid footprint) so it can be placed
+  in slots and containers. By default a mixing ingredient reuses a vanilla mixer's body, so it works out of the
+  box. Supply your own with `WithStoredItem(prefab)` if you want a custom world model; that is respected and not
+  overwritten.
+
+### Cloning an existing ingredient
+
+```csharp
+var variant = MixIngredientItemCreator.CloneFrom("cuke")
+    .WithBasicInfo("mymod_super_cuke", "Super Cuke", "An enhanced cuke.", ItemCategory.Ingredient)
+    .Build();
+```
+
+## Creating a Custom Effect
+
+A custom effect is a real game property with configurable metadata, value contribution, and optional
+behavior. The behavior runs through the same effect-callback path used to override vanilla effects.
+
+```csharp
+using S1API.Products;
+using S1API.Properties;
+using UnityEngine;
+
+var glow = EffectCreator.CreateBuilder()
+    .WithBasicInfo("mymod_glow", "Glow", "A soft, warm glow.")
+    .WithTier(2)
+    .WithAddictiveness(0.05f)
+    .WithValue(valueChange: 10, valueMultiplier: 1.1f)
+    .WithColors(productColor: new Color(0.2f, 0.8f, 0.9f), labelColor: Color.white)
+    .WithBehavior(player =>
+    {
+        // Runs when this effect triggers on the local player.
+    })
+    .Build();
+
+// Use the custom effect on an ingredient just like a vanilla one:
+var sparkPowder = MixIngredientItemCreator.CreateBuilder()
+    .WithBasicInfo("mymod_spark_powder", "Spark Powder", "A shimmering powder.", ItemCategory.Ingredient)
+    .WithEffect(glow)
+    .Build();
+```
+
+Notes:
+
+- If you do not set a behavior, the effect is purely cosmetic and value-affecting (it changes the
+  product's name, colour, and value, but does nothing to the player).
+- Custom effects are automatically given a place on each drug's mixing map so they can be mixed again
+  without breaking the game. By default they sit off to the side and do not capture other mixes.
+- Use `ForDrugs(...)` to restrict which drugs an effect applies to, and `WithMixMapPlacement(...)` /
+  `WithMixGeometry(...)` for advanced, geometry-based reactions.
+
+## Mixing Reactions
+
+Reactions transform the effects a mix produces, letting you build combos and chains. A rule fires when a
+product is mixed with an ingredient contributing a specific effect and the result already carries another.
+
+```csharp
+using S1API.Products;
+using S1API.Properties;
+
+// When an ingredient contributing Spicy is mixed onto a Marijuana product that already has Calming,
+// also produce your custom Glow effect.
+MixReactions.AddRule(
+    mixerEffect: Property.Spicy,
+    whenResultContains: Property.Calming,
+    addResult: glow,
+    drug: DrugType.Marijuana,
+    replaceMatched: false);
+```
+
+- `mixerEffect` is the effect the mixed-in ingredient contributes.
+- `whenResultContains` must already be present in the mix result for the rule to fire.
+- `replaceMatched: true` swaps the matched effect for the result; `false` adds it (up to 8 effects).
+- Omit `drug` to apply the rule to every drug.
+
+Reactions run after the game's own mixing calculation and are deterministic, so no networking is needed
+as long as every peer runs the same rules and effects.
+
+## Making an Ingredient Purchasable
+
+An ingredient carries a price and an optional rank requirement, but that alone does not list it in a shop.
+To sell it, add it to a shop's inventory once the shop exists:
+
+```csharp
+using S1API.Shops;
+
+GameLifecycle.OnLoadComplete += () =>
+{
+    var shop = ShopManager.GetShopByName("<shop name>");
+    shop?.AddItem(chili, customPrice: 12f);
+};
+```
+
+Resolve the shop name at runtime with `ShopManager.GetAllShops()`. As with the ingredient itself, adding
+to a shop is client-local, so do it on every peer.

--- a/S1API/docs/toc.yml
+++ b/S1API/docs/toc.yml
@@ -110,6 +110,8 @@
       href: quests-complete-example.md
     - name: Custom Items
       href: item-registration-basics.md
+    - name: Mixing Ingredients & Effects
+      href: mixing-ingredients.md
     - name: Phone App
       href: phone-app.md
     - name: TV App


### PR DESCRIPTION
## What this adds

A public, cross-compatible API for mods to create **custom mixing content**: mixing ingredients, custom effects, and mixing reactions. Today S1API can create items (Storable/Additive/Quality/Clothing/Buildable) and *read* effects, but there is no way to make a mixable ingredient or a new effect. This closes that gap.

Three layers, each independently useful:

- **Ingredients** - `MixIngredientItemCreator` / `MixIngredientDefinition(Builder)`. Creates a `PropertyItemDefinition`, registers it into the game registry and `ValidMixIngredients`, and re-applies on load. Follows the existing item triad (`Definition` + `DefinitionBuilder` + `ItemCreator`).
- **Effects** - `EffectCreator` / `CustomEffectBuilder` / `CustomEffect`. Builds a real game `Effect`, injects it into `PropertyUtility` (both `AllProperties` and the ID lookup), and gives it a spot on each relevant per-drug `MixerMap` so it survives being mixed again. Optional behavior runs through the existing `ProductManager` effect-callback path.
- **Reactions** - `MixReactions.AddRule(...)` + a postfix on `EffectMixCalculator.MixProperties`, so mods can build combos/chains. The postfix clones and reassigns the result rather than mutating the game's list in place.

Docs: `S1API/docs/mixing-ingredients.md` (linked in `toc.yml`).

## Cross-flavor notes

- Namespace aliases keep `IL2CPPBEPINEX` with Mono (`ScheduleOne.*`); collection types keep it with IL2CPP (`Il2CppSystem`), matching `ChemistryStationPatches`.
- I built the two Melon configs clean against matching assemblies. My local game assemblies are a bit behind this branch's target version, so please let CI confirm all four configs (especially the BepInEx ones).
- No public API leaks a game type - public signatures use S1API wrappers, `PropertyBase`, `DrugType`, and Unity types.

## Two things worth a maintainer's eye

- **StoredItem reuse.** A freshly created `StorableItemDefinition` gets a bare placeholder StoredItem with no footprint, which throws when the item is placed into a slot (`StoredItem.FootprintX/Y` on an empty tile list). A mixing ingredient therefore reuses a real mixer's StoredItem (Iodine/Cuke/...), same as any vanilla mixer has one. A modder's own `WithStoredItem` is respected. This placeholder gap looks general to the base builder, not specific to ingredients - happy to file it separately.
- **`ToIl2CppList` duplication.** The IL2CPP list-copy helper is copy-pasted across several builders. I matched the existing name here rather than refactor unrelated files, but a shared `Internal/Utils` helper would be the clean fix if you want one.

## Verification

Live-verified in-game (Il2CppMelon): the ingredient registers and is mixable, mixing imprints the effect, a reaction fires, and a custom effect's behavior callback runs on consume - no crash on a second mix or on save/reload. Registration is idempotent (safe to build the same ID again from a per-load hook), and an ingredient with no effects is rejected up front. Reviewed across several independent static-analysis passes for correctness and convention.

Version left at 3.0.5 - I'll leave versioning to you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a public API for creating custom mixing ingredients, including builders, cloning helpers, and a wrapper type for runtime-defined ingredient items.
- Added a public API for creating custom effects with optional player/NPC behavior, custom stats, and automatic registration across supported game backends.
- Added deterministic mix reaction rules so mods can define ingredient/effect chains without mutating the game’s result lists in place.
- Added lifecycle-aware internal registries and Harmony patches to reapply custom ingredients/effects after loads and recover missing custom effects from mix data.
- Added documentation for the new mixing workflow and linked it from the docs table of contents.
- Exposed a small builder state helper for subclasses to preserve custom stored-item assignments.

| Contributing author | Lines added | Lines removed |
|---|---:|---:|
| Collective PR changes | 1611 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->