### PR TITLE
fix(products): preserve typed wrapper semantics

### DIFF
--- a/S1API.Tests/GlobalUsings.cs
+++ b/S1API.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/S1API.Tests/Products/DrugTypeConversionTests.cs
+++ b/S1API.Tests/Products/DrugTypeConversionTests.cs
@@ -1,0 +1,55 @@
+#if (IL2CPPMELON)
+using NativeDrugType = Il2CppScheduleOne.Product.EDrugType;
+#elif MONOMELON
+using NativeDrugType = ScheduleOne.Product.EDrugType;
+#endif
+
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class DrugTypeConversionTests
+{
+    public static IEnumerable<object[]> KnownMappings
+    {
+        get
+        {
+            yield return new object[] { DrugType.Marijuana, NativeDrugType.Marijuana };
+            yield return new object[] { DrugType.Methamphetamine, NativeDrugType.Methamphetamine };
+            yield return new object[] { DrugType.Cocaine, NativeDrugType.Cocaine };
+            yield return new object[] { DrugType.MDMA, NativeDrugType.MDMA };
+            yield return new object[] { DrugType.Shrooms, NativeDrugType.Shrooms };
+            yield return new object[] { DrugType.Heroin, NativeDrugType.Heroin };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(KnownMappings))]
+    public void KnownValuesRoundTrip(DrugType apiValue, NativeDrugType nativeValue)
+    {
+        Assert.Equal(apiValue, nativeValue.ToAPI());
+        Assert.Equal(nativeValue, apiValue.ToInternal());
+    }
+
+    [Fact]
+    public void ApiAndNativeEnumsExposeTheSameKnownValues()
+    {
+        var apiValues = Enum.GetValues<DrugType>();
+        var nativeValues = Enum.GetValues<NativeDrugType>();
+
+        Assert.Equal(apiValues.Length, nativeValues.Length);
+        Assert.Equal(apiValues.Select(value => (int)value), nativeValues.Select(value => (int)value));
+        Assert.Equal(apiValues.Select(value => value.ToString()), nativeValues.Select(value => value.ToString()));
+    }
+
+    [Fact]
+    public void UnknownNumericValuesRemainRoundTrippable()
+    {
+        const int unknownValue = 42;
+        var apiValue = (DrugType)unknownValue;
+        var nativeValue = (NativeDrugType)unknownValue;
+
+        Assert.Equal(apiValue, nativeValue.ToAPI());
+        Assert.Equal(nativeValue, apiValue.ToInternal());
+    }
+}

--- a/S1API.Tests/Products/LegacyProductApiCompileFixture.cs
+++ b/S1API.Tests/Products/LegacyProductApiCompileFixture.cs
@@ -1,0 +1,44 @@
+#if (IL2CPPMELON)
+using NativeDrugType = Il2CppScheduleOne.Product.EDrugType;
+using NativeDrugTypeContainer = Il2CppScheduleOne.Product.DrugTypeContainer;
+#elif MONOMELON
+using NativeDrugType = ScheduleOne.Product.EDrugType;
+using NativeDrugTypeContainer = ScheduleOne.Product.DrugTypeContainer;
+#endif
+
+using S1API.Items;
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+/// <summary>
+/// Compile-only coverage for the product API syntax that predates the runtime-agnostic accessors.
+/// </summary>
+internal static class LegacyProductApiCompileFixture
+{
+    internal static void CompileLegacyProductAccess(
+        ProductDefinition definition,
+        ProductInstance instance)
+    {
+#pragma warning disable CS0618
+        ItemDefinition itemDefinition = definition;
+        NativeDrugType nativePrimaryType = definition.DrugType;
+#if IL2CPPMELON
+        IReadOnlyList<NativeDrugTypeContainer> nativeTypes = definition.DrugTypes;
+#else
+        List<NativeDrugTypeContainer> nativeTypes = definition.DrugTypes;
+#endif
+        ProductDefinition wrapped = ProductDefinitionWrapper.Wrap(definition);
+        ProductDefinition instanceDefinition = instance.Definition;
+
+        ItemDefinition? legacyLookup = ItemManager.GetItemDefinition(definition.ID);
+#pragma warning restore CS0618
+
+        _ = itemDefinition;
+        _ = nativePrimaryType;
+        _ = nativeTypes;
+        _ = wrapped;
+        _ = instanceDefinition;
+        _ = legacyLookup;
+    }
+}

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -1,0 +1,69 @@
+#if (IL2CPPMELON)
+using NativeDrugType = Il2CppScheduleOne.Product.EDrugType;
+using NativeDrugTypeContainer = Il2CppScheduleOne.Product.DrugTypeContainer;
+#elif MONOMELON
+using NativeDrugType = ScheduleOne.Product.EDrugType;
+using NativeDrugTypeContainer = ScheduleOne.Product.DrugTypeContainer;
+#endif
+
+using S1API.Items;
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductApiCompatibilityTests
+{
+    [Fact]
+    public void ExistingPublicMemberSignaturesRemainAvailable()
+    {
+#pragma warning disable CS0618
+        var nativeDrugType = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.DrugType));
+        var nativeDrugTypes = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.DrugTypes));
+#pragma warning restore CS0618
+        var wrapperMethod = typeof(ProductDefinitionWrapper).GetMethod(
+            nameof(ProductDefinitionWrapper.Wrap),
+            new[] { typeof(ProductDefinition) });
+        var legacyLookup = typeof(ItemManager).GetMethod(
+            nameof(ItemManager.GetItemDefinition),
+            new[] { typeof(string) });
+
+        Assert.NotNull(nativeDrugType);
+        Assert.Equal(typeof(NativeDrugType), nativeDrugType.PropertyType);
+        AssertObsoleteCompatibilityShim(nativeDrugType, "Use PrimaryDrugType instead.");
+        Assert.NotNull(nativeDrugTypes);
+#if IL2CPPMELON
+        Assert.Equal(typeof(IReadOnlyList<NativeDrugTypeContainer>), nativeDrugTypes.PropertyType);
+#else
+        Assert.Equal(typeof(List<NativeDrugTypeContainer>), nativeDrugTypes.PropertyType);
+#endif
+        AssertObsoleteCompatibilityShim(nativeDrugTypes, "Use DrugTypeValues instead.");
+        Assert.NotNull(wrapperMethod);
+        Assert.Equal(typeof(ProductDefinition), wrapperMethod.ReturnType);
+        Assert.NotNull(legacyLookup);
+        Assert.Equal(typeof(ItemDefinition), legacyLookup.ReturnType);
+    }
+
+    [Fact]
+    public void NewRuntimeAgnosticMembersAreAdditive()
+    {
+        var primaryDrugType = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.PrimaryDrugType));
+        var drugTypeValues = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.DrugTypeValues));
+
+        Assert.NotNull(primaryDrugType);
+        Assert.Equal(typeof(DrugType), primaryDrugType.PropertyType);
+        Assert.NotNull(drugTypeValues);
+        Assert.Equal(typeof(IReadOnlyList<DrugType>), drugTypeValues.PropertyType);
+    }
+
+    private static void AssertObsoleteCompatibilityShim(
+        System.Reflection.MemberInfo member,
+        string expectedMessage)
+    {
+        var obsolete = member.GetCustomAttributes(typeof(ObsoleteAttribute), false)
+            .Cast<ObsoleteAttribute>()
+            .Single();
+
+        Assert.Equal(expectedMessage, obsolete.Message);
+        Assert.False(obsolete.IsError);
+    }
+}

--- a/S1API.Tests/Products/ProductDefinitionWrapperTests.cs
+++ b/S1API.Tests/Products/ProductDefinitionWrapperTests.cs
@@ -1,0 +1,63 @@
+#if MONOMELON
+using System.Runtime.CompilerServices;
+using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
+#endif
+
+using S1API.Items;
+using S1API.Products;
+using NamespacedStorableItemDefinition = S1API.Items.Storable.StorableItemDefinition;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductDefinitionWrapperTests
+{
+    [Fact]
+    public void ProductDefinitionsPreserveStorableAndPropertySemantics()
+    {
+        Assert.True(typeof(ItemDefinition).IsAssignableFrom(typeof(ProductDefinition)));
+        Assert.True(typeof(NamespacedStorableItemDefinition).IsAssignableFrom(typeof(ProductDefinition)));
+        Assert.NotNull(typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.BasePurchasePrice)));
+        Assert.NotNull(typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.Properties)));
+    }
+
+#if MONOMELON
+    public static IEnumerable<object[]> WrapperCases
+    {
+        get
+        {
+            yield return new object[] { typeof(ScheduleOne.Product.ProductDefinition), typeof(ProductDefinition) };
+            yield return new object[] { typeof(ScheduleOne.Product.WeedDefinition), typeof(WeedDefinition) };
+            yield return new object[] { typeof(ScheduleOne.Product.MethDefinition), typeof(MethDefinition) };
+            yield return new object[] { typeof(ScheduleOne.Product.CocaineDefinition), typeof(CocaineDefinition) };
+            yield return new object[] { typeof(ScheduleOne.Product.ShroomDefinition), typeof(ShroomDefinition) };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(WrapperCases))]
+    public void NativeAndExistingWrapperPathsReturnTheSameTypedWrapper(
+        Type nativeDefinitionType,
+        Type expectedWrapperType)
+    {
+        var nativeDefinition = (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(nativeDefinitionType);
+
+        var wrappedFromNative = ProductDefinitionWrapper.Wrap(nativeDefinition);
+        var wrappedFromExistingWrapper = ProductDefinitionWrapper.Wrap(new ProductDefinition(nativeDefinition));
+
+        Assert.IsType(expectedWrapperType, wrappedFromNative);
+        Assert.IsType(expectedWrapperType, wrappedFromExistingWrapper);
+    }
+
+    [Fact]
+    public void ExistingGenericWrapperRemainsTheFallbackInstance()
+    {
+        var nativeDefinition = (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
+            typeof(NativeProductDefinition));
+        var existingWrapper = new ProductDefinition(nativeDefinition);
+
+        var wrapped = ProductDefinitionWrapper.Wrap(existingWrapper);
+
+        Assert.Same(existingWrapper, wrapped);
+    }
+#endif
+}

--- a/S1API.Tests/S1API.Tests.csproj
+++ b/S1API.Tests/S1API.Tests.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="../github.build.props" Condition="Exists('../github.build.props')" />
+    <Import Project="../local.build.props" Condition="Exists('../local.build.props')" />
+    <Import Project="../ci.build.props" Condition="Exists('../ci.build.props')" />
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <Configurations>MonoMelon;Il2CppMelon</Configurations>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">
+        <DefineConstants>$(DefineConstants);MONOMELON</DefineConstants>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Il2CppMelon'">
+        <DefineConstants>$(DefineConstants);IL2CPPMELON</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <ProjectReference Include="../S1API/S1API.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'MonoMelon'">
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(MonoAssembliesPath)/Assembly-CSharp.dll</HintPath>
+        </Reference>
+        <Reference Include="ScheduleOne.Core">
+            <HintPath>$(MonoAssembliesPath)/ScheduleOne.Core.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine">
+            <HintPath>$(MonoAssembliesPath)/UnityEngine.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(MonoAssembliesPath)/UnityEngine.CoreModule.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Il2CppMelon'">
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Common.dll" />
+        <Reference Include="$(MelonLoaderAssembliesPath)\Il2CppInterop.Runtime.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\Assembly-CSharp.dll" />
+        <Reference Include="Il2CppScheduleOne.Core">
+            <HintPath>$(Il2CppAssembliesPath)\Il2CppScheduleOne.Core.dll</HintPath>
+        </Reference>
+        <Reference Include="$(Il2CppAssembliesPath)\Il2Cppmscorlib.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.CoreModule.dll" />
+    </ItemGroup>
+</Project>

--- a/S1API.sln
+++ b/S1API.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "S1API", "S1API\S1API.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "S1APILoader", "S1APILoader\S1APILoader.csproj", "{B97277C2-27FE-4BB9-AB5A-D479C8DF6827}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "S1API.Tests", "S1API.Tests\S1API.Tests.csproj", "{516A4E1C-BDCB-4A58-A35A-08858F8BF077}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Il2CppMelon|Any CPU = Il2CppMelon|Any CPU
@@ -18,5 +20,9 @@ Global
 		{B97277C2-27FE-4BB9-AB5A-D479C8DF6827}.Il2CppMelon|Any CPU.Build.0 = Il2CppMelon|Any CPU
 		{B97277C2-27FE-4BB9-AB5A-D479C8DF6827}.MonoMelon|Any CPU.ActiveCfg = MonoMelon|Any CPU
 		{B97277C2-27FE-4BB9-AB5A-D479C8DF6827}.MonoMelon|Any CPU.Build.0 = MonoMelon|Any CPU
+		{516A4E1C-BDCB-4A58-A35A-08858F8BF077}.Il2CppMelon|Any CPU.ActiveCfg = Il2CppMelon|Any CPU
+		{516A4E1C-BDCB-4A58-A35A-08858F8BF077}.Il2CppMelon|Any CPU.Build.0 = Il2CppMelon|Any CPU
+		{516A4E1C-BDCB-4A58-A35A-08858F8BF077}.MonoMelon|Any CPU.ActiveCfg = MonoMelon|Any CPU
+		{516A4E1C-BDCB-4A58-A35A-08858F8BF077}.MonoMelon|Any CPU.Build.0 = MonoMelon|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/S1API/Items/ItemManager.cs
+++ b/S1API/Items/ItemManager.cs
@@ -42,7 +42,7 @@ namespace S1API.Items
             // Check for specific types first (most derived to least derived)
             if (CrossType.Is(itemDefinition,
                     out S1Product.ProductDefinition productDefinition))
-                return new ProductDefinition(productDefinition);
+                return ProductDefinitionWrapper.Wrap(productDefinition);
 
             if (CrossType.Is(itemDefinition,
                     out S1ItemFramework.CashDefinition cashDefinition))
@@ -90,7 +90,7 @@ namespace S1API.Items
             // Check for specific types first (most derived to least derived)
             if (CrossType.Is(itemDefinition,
                     out S1Product.ProductDefinition productDefinition))
-                return new ProductDefinition(productDefinition);
+                return ProductDefinitionWrapper.Wrap(productDefinition);
 
             if (CrossType.Is(itemDefinition,
                     out S1ItemFramework.CashDefinition cashDefinition))

--- a/S1API/Products/DrugType.cs
+++ b/S1API/Products/DrugType.cs
@@ -1,8 +1,18 @@
+#if (IL2CPPMELON)
+using NativeDrugType = Il2CppScheduleOne.Product.EDrugType;
+#elif MONOMELON
+using NativeDrugType = ScheduleOne.Product.EDrugType;
+#endif
+
 namespace S1API.Products
 {
     /// <summary>
     /// API-safe product type enum. Mirrors base game drug types.
     /// </summary>
+    /// <remarks>
+    /// The presence of a value only mirrors the native enum. In particular, <see cref="MDMA"/> and
+    /// <see cref="Heroin"/> do not imply that every native product system supports those types.
+    /// </remarks>
     public enum DrugType
     {
         Marijuana = 0,
@@ -11,6 +21,50 @@ namespace S1API.Products
         MDMA = 3,
         Shrooms = 4,
         Heroin = 5
+    }
+
+    /// <summary>
+    /// INTERNAL: Converts between native and API-safe drug type values.
+    /// </summary>
+    internal static class DrugTypeExtensions
+    {
+        /// <summary>
+        /// Converts a native drug type to its API-safe equivalent.
+        /// </summary>
+        /// <param name="drugType">The native drug type.</param>
+        /// <returns>The API-safe drug type.</returns>
+        internal static DrugType ToAPI(this NativeDrugType drugType)
+        {
+            return drugType switch
+            {
+                NativeDrugType.Marijuana => DrugType.Marijuana,
+                NativeDrugType.Methamphetamine => DrugType.Methamphetamine,
+                NativeDrugType.Cocaine => DrugType.Cocaine,
+                NativeDrugType.MDMA => DrugType.MDMA,
+                NativeDrugType.Shrooms => DrugType.Shrooms,
+                NativeDrugType.Heroin => DrugType.Heroin,
+                _ => (DrugType)(int)drugType
+            };
+        }
+
+        /// <summary>
+        /// Converts an API-safe drug type to its native equivalent.
+        /// </summary>
+        /// <param name="drugType">The API-safe drug type.</param>
+        /// <returns>The native drug type.</returns>
+        internal static NativeDrugType ToInternal(this DrugType drugType)
+        {
+            return drugType switch
+            {
+                DrugType.Marijuana => NativeDrugType.Marijuana,
+                DrugType.Methamphetamine => NativeDrugType.Methamphetamine,
+                DrugType.Cocaine => NativeDrugType.Cocaine,
+                DrugType.MDMA => NativeDrugType.MDMA,
+                DrugType.Shrooms => NativeDrugType.Shrooms,
+                DrugType.Heroin => NativeDrugType.Heroin,
+                _ => (NativeDrugType)(int)drugType
+            };
+        }
     }
 }
 

--- a/S1API/Products/ProductDefinition.cs
+++ b/S1API/Products/ProductDefinition.cs
@@ -22,7 +22,7 @@ namespace S1API.Products
     /// <summary>
     /// Represents a product definition in the game.
     /// </summary>
-    public class ProductDefinition : ItemDefinition
+    public class ProductDefinition : Items.Storable.StorableItemDefinition
     {
         /// <summary>
         /// INTERNAL: Stored reference to the game product definition.
@@ -34,11 +34,10 @@ namespace S1API.Products
         /// INTERNAL: Creates a product definition from the in-game product definition.
         /// </summary>
         /// <param name="productDefinition"></param>
-#if  IL2CPPMELON
-        internal ProductDefinition(ItemFramework.ItemDefinition productDefinition) : base(productDefinition) { }
-#else
-        internal ProductDefinition(ItemFramework.ItemDefinition productDefinition) : base(productDefinition) { }
-#endif
+        internal ProductDefinition(S1Product.ProductDefinition productDefinition)
+            : base(productDefinition)
+        {
+        }
         /// <summary>
         /// The price associated with this product.
         /// </summary>
@@ -94,10 +93,46 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// The list of drug types associated with this product definition.
-        /// Returns a C# list for IL2CPP builds to avoid type mismatches.
+        /// Gets all drug types associated with this product definition without exposing runtime-specific game types.
         /// </summary>
+        public IReadOnlyList<DrugType> DrugTypeValues
+        {
+            get
+            {
+                var source = S1ProductDefinition.DrugTypes;
+                var converted = new List<DrugType>(source != null ? source.Count : 0);
+
+                if (source != null)
+                {
+                    for (int i = 0; i < source.Count; i++)
+                    {
+                        var container = source[i];
+                        if (container != null)
+                            converted.Add(container.DrugType.ToAPI());
+                    }
+                }
+
+                return converted.AsReadOnly();
+            }
+        }
+
+        /// <summary>
+        /// Gets the primary drug type for this product without exposing runtime-specific game types.
+        /// </summary>
+        public DrugType PrimaryDrugType =>
+            S1ProductDefinition.DrugType.ToAPI();
+
+        /// <summary>
+        /// The list of native drug type containers associated with this product definition.
+        /// Returns a C# list for IL2CPP builds to avoid collection type mismatches.
+        /// </summary>
+        /// <remarks>
+        /// This compatibility member exposes native game types whose concrete definitions differ between
+        /// Mono and IL2CPP. It is not cross-runtime compatible and is retained only for existing consumers.
+        /// Prefer <see cref="DrugTypeValues"/> in cross-runtime mods.
+        /// </remarks>
 #if (IL2CPPMELON)
+        [System.Obsolete("Use DrugTypeValues instead.", false)]
         public System.Collections.Generic.IReadOnlyList<S1Product.DrugTypeContainer> DrugTypes
         {
             get
@@ -113,13 +148,20 @@ namespace S1API.Products
             }
         }
 #else
+        [System.Obsolete("Use DrugTypeValues instead.", false)]
         public System.Collections.Generic.List<S1Product.DrugTypeContainer> DrugTypes =>
             S1ProductDefinition.DrugTypes;
 #endif
 
         /// <summary>
-        /// The primary drug type for this product (convenience property).
+        /// The native primary drug type for this product.
         /// </summary>
+        /// <remarks>
+        /// This compatibility member exposes a native game enum whose concrete type differs between
+        /// Mono and IL2CPP. It is not cross-runtime compatible and is retained only for existing consumers.
+        /// Prefer <see cref="PrimaryDrugType"/> in cross-runtime mods.
+        /// </remarks>
+        [System.Obsolete("Use PrimaryDrugType instead.", false)]
         public S1Product.EDrugType DrugType =>
             S1ProductDefinition.DrugType;
 

--- a/S1API/Products/ProductDefinitionWrapper.cs
+++ b/S1API/Products/ProductDefinitionWrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using S1API.Internal.Utils;
 #if (IL2CPPMELON)
 using S1Product = Il2CppScheduleOne.Product;
@@ -19,20 +20,39 @@ namespace S1API.Products
         /// <returns>A wrapped instance of <see cref="ProductDefinition"/> with type-specific methods and properties, or the input definition if no specific wrapper applies.</returns>
         public static ProductDefinition Wrap(ProductDefinition def)
         {
-            var item = def.S1ItemDefinition;
-            if (CrossType.Is<S1Product.WeedDefinition>(item, out var weed))
+            return Wrap(def.S1ProductDefinition, def);
+        }
+
+        /// <summary>
+        /// INTERNAL: Creates the most specific API wrapper for a native product definition.
+        /// </summary>
+        /// <param name="definition">The native product definition to wrap.</param>
+        /// <returns>The most specific available product definition wrapper.</returns>
+        internal static ProductDefinition Wrap(S1Product.ProductDefinition definition)
+        {
+            if (ReferenceEquals(definition, null))
+                throw new ArgumentNullException(nameof(definition));
+
+            return Wrap(definition, null);
+        }
+
+        private static ProductDefinition Wrap(
+            S1Product.ProductDefinition definition,
+            ProductDefinition? fallback)
+        {
+            if (CrossType.Is<S1Product.WeedDefinition>(definition, out var weed))
                 return new WeedDefinition(weed);
 
-            if (CrossType.Is<S1Product.MethDefinition>(item, out var meth))
+            if (CrossType.Is<S1Product.MethDefinition>(definition, out var meth))
                 return new MethDefinition(meth);
 
-            if (CrossType.Is<S1Product.CocaineDefinition>(item, out var coke))
+            if (CrossType.Is<S1Product.CocaineDefinition>(definition, out var coke))
                 return new CocaineDefinition(coke);
 
-            if (CrossType.Is<S1Product.ShroomDefinition>(item, out var shroom))
+            if (CrossType.Is<S1Product.ShroomDefinition>(definition, out var shroom))
                 return new ShroomDefinition(shroom);
 
-            return def;
+            return fallback ?? new ProductDefinition(definition);
         }
     }
 }

--- a/S1API/Products/ProductInstance.cs
+++ b/S1API/Products/ProductInstance.cs
@@ -59,7 +59,8 @@ namespace S1API.Products
         /// Gets the definition of the product associated with this instance.
         /// </summary>
         public new ProductDefinition Definition =>
-            new ProductDefinition(CrossType.As<S1Product.ProductDefinition>(S1ProductInstance.Definition));
+            ProductDefinitionWrapper.Wrap(
+                CrossType.As<S1Product.ProductDefinition>(S1ProductInstance.Definition));
 
         /// <summary>
         /// Gets the list of properties associated with the product definition.

--- a/S1API/Products/ProductManager.cs
+++ b/S1API/Products/ProductManager.cs
@@ -59,21 +59,21 @@ namespace S1API.Products
         /// A list of product definitions discovered on this save.
         /// </summary>
         public static ProductDefinition[] DiscoveredProducts => S1Product.ProductManager.DiscoveredProducts.ToArray()
-            .Select(productDefinition => ProductDefinitionWrapper.Wrap(new ProductDefinition(productDefinition)))
+            .Select(productDefinition => ProductDefinitionWrapper.Wrap(productDefinition))
             .ToArray();
 
         /// <summary>
         /// A list of products currently listed for sale.
         /// </summary>
         public static ProductDefinition[] ListedProducts => S1Product.ProductManager.ListedProducts.ToArray()
-            .Select(productDefinition => ProductDefinitionWrapper.Wrap(new ProductDefinition(productDefinition)))
+            .Select(productDefinition => ProductDefinitionWrapper.Wrap(productDefinition))
             .ToArray();
 
         /// <summary>
         /// A list of favourited products.
         /// </summary>
         public static ProductDefinition[] FavouritedProducts => S1Product.ProductManager.FavouritedProducts.ToArray()
-            .Select(productDefinition => ProductDefinitionWrapper.Wrap(new ProductDefinition(productDefinition)))
+            .Select(productDefinition => ProductDefinitionWrapper.Wrap(productDefinition))
             .ToArray();
 
         /// <summary>

--- a/S1API/Properties/AssemblyInfo.cs
+++ b/S1API/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("S1API.Tests")]

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -6,7 +6,7 @@ If you want customer preference configuration, see `S1API/docs/products-system.m
 
 ## Key types
 
-- `S1API.Products.ProductDefinition`: product definition wrapper (inherits `S1API.Items.ItemDefinition`)
+- `S1API.Products.ProductDefinition`: product definition wrapper (inherits `S1API.Items.Storable.StorableItemDefinition`)
 - `S1API.Products.ProductInstance`: product instance wrapper (inherits `S1API.Items.ItemInstance`)
 - `S1API.Products.ProductManager`: access to products discovered in the current save
 - `S1API.Products.ProductDefinitionWrapper`: converts a `ProductDefinition` into a typed subclass when possible
@@ -24,8 +24,8 @@ using S1API.Products;
 
 foreach (var product in ProductManager.DiscoveredProducts)
 {
-    // These are already passed through ProductDefinitionWrapper.Wrap(...)
-    // so you may see WeedDefinition/MethDefinition/etc.
+    // ProductManager, ItemManager, and ProductInstance.Definition all use the same typed factory,
+    // so this may be WeedDefinition, MethDefinition, CocaineDefinition, or ShroomDefinition.
     MelonLoader.MelonLogger.Msg($"{product.ID}: {product.Name} (${product.Price})");
 }
 ```
@@ -38,12 +38,15 @@ Products are also item definitions, so you can look them up by item ID.
 using S1API.Items;
 using S1API.Products;
 
-var def = ItemManager.GetItemDefinition("weed") as ProductDefinition;
+var def = ItemManager.GetDefinition("weed") as ProductDefinition;
 if (def != null)
 {
     MelonLoader.MelonLogger.Msg(def.MarketValue);
 }
 ```
+
+Product definitions preserve the native storable-item inheritance contract, so members such as
+`BasePurchasePrice`, `ResellMultiplier`, and `RequiredRank` are also available.
 
 ## Typed product definitions
 
@@ -78,6 +81,25 @@ foreach (var prop in def.Properties)
     MelonLoader.MelonLogger.Msg(prop.ID);
 }
 ```
+
+## Drug types
+
+Use the API-safe accessors when your mod targets both Mono and IL2CPP:
+
+```csharp
+using System.Collections.Generic;
+using S1API.Products;
+
+DrugType primaryType = def.PrimaryDrugType;
+IReadOnlyList<DrugType> allTypes = def.DrugTypeValues;
+```
+
+The older `DrugType` and `DrugTypes` members remain available as non-error obsolete compatibility
+members. They expose native game types that differ between Mono and IL2CPP, are not cross-runtime
+compatible, and therefore require conditional compilation in cross-runtime mods.
+
+`DrugType.MDMA` and `DrugType.Heroin` mirror values present in the native enum. Their presence does
+not mean that every native product system supports those types.
 
 ## Overriding product effect behavior with callbacks
 


### PR DESCRIPTION
## Summary

- Route every public product lookup path through one typed wrapper factory.
- Restore `ProductDefinition` storable-item inheritance and expose API-safe `PrimaryDrugType` / `DrugTypeValues` accessors backed by complete native conversion helpers.
- Add focused dual-runtime tests for wrapper selection, enum round-trips, retained signatures, and legacy source syntax; update the product API docs.

## Compatibility

- Existing `ProductDefinition.DrugType` and `ProductDefinition.DrugTypes` syntax, return types, and native behavior are retained. Both are non-error obsolete compatibility members with migration messages for the new cross-runtime accessors.
- Existing `ProductDefinitionWrapper.Wrap(ProductDefinition)` remains public with the same signature and preserves the original generic wrapper as its fallback.
- `ItemManager.GetItemDefinition(string)` and current lookup return types remain unchanged. Product lookups now consistently return the most specific available wrapper without changing non-product defaults.
- `ProductDefinition` remains assignable to `ItemDefinition`; its direct base is now `S1API.Items.Storable.StorableItemDefinition` so the public wrapper matches native storable semantics. Code that reflects on the exact direct `BaseType` will observe this intentional change.
- A metadata comparison against the exact `origin/beta` baseline found zero missing public signatures in MonoMelon (4,598 baseline / 4,602 current) and Il2CppMelon (4,596 baseline / 4,600 current).
- Migration: use `PrimaryDrugType` and `DrugTypeValues` for one code path across Mono and IL2CPP. The retained native members are explicitly documented as not cross-runtime compatible.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — 0 warnings, 0 errors
- `dotnet test S1API.Tests\S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 17 passed
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` — 0 warnings, 0 errors
- `dotnet test S1API.Tests\S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 11 passed
- `docfx docfx.json` — 0 warnings, 0 errors; all site/PDF outputs generated
- Documentation coverage gate — 80.59% (2,752/3,415; minimum 80%)

## Notes

No in-game smoke was run. Remaining optional verification is to compare the wrapper type returned for the same native product through `ItemManager.GetDefinition`, `ProductManager` collections, and `ProductInstance.Definition` in both Mono and IL2CPP. No builders, product creation, or later custom-product work is included.

Closes #97