### PR TITLE
feat(products): add custom presentation profiles

### DIFF
--- a/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
@@ -13,6 +13,7 @@ using S1API.Products;
 
 namespace S1API.Tests.Products;
 
+[Collection(CustomProductRegistryCollection.Name)]
 public sealed class CustomProductDefinitionRegistryTests : IDisposable
 {
     private readonly FakeRuntimeAdapter _runtimeAdapter = new FakeRuntimeAdapter();

--- a/S1API.Tests/Products/CustomProductRegistryCollection.cs
+++ b/S1API.Tests/Products/CustomProductRegistryCollection.cs
@@ -1,0 +1,7 @@
+namespace S1API.Tests.Products;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class CustomProductRegistryCollection
+{
+    public const string Name = "Custom product registry";
+}

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -8,6 +8,7 @@ using NativeDrugTypeContainer = ScheduleOne.Product.DrugTypeContainer;
 
 using S1API.Items;
 using S1API.Products;
+using S1API.Rendering;
 
 namespace S1API.Tests.Products;
 
@@ -134,6 +135,161 @@ public sealed class ProductApiCompatibilityTests
         AssertSingleOptionalParameter(setListed, "listed", true);
     }
 
+    [Fact]
+    public void ProductPresentationProfileApiIsAdditiveAndRuntimeAgnostic()
+    {
+        Assert.True(typeof(ProductPresentationProfile).IsSealed);
+        Assert.True(typeof(ProductPresentationProfileBuilder).IsSealed);
+        Assert.True(typeof(ProductPresentationTransform).IsSealed);
+        Assert.True(typeof(ProductPresentationProfileRegistry).IsAbstract);
+        Assert.True(typeof(ProductPresentationProfileRegistry).IsSealed);
+        Assert.Equal(
+            new[]
+            {
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6
+            },
+            Enum.GetValues<ProductPresentationContext>()
+                .Select(value => (int)value));
+
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithLooseVisual),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithStoredVisual),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithHeldVisual),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithStationVisual),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(
+                ProductPresentationProfileBuilder
+                    .WithFunctionalProductVisual),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithIcon),
+            typeof(Func<UnityEngine.Sprite>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithConsumptionPrefab),
+            typeof(Func<UnityEngine.GameObject>));
+        AssertBuilderMethod(
+            nameof(ProductPresentationProfileBuilder.WithLooseVisual),
+            typeof(Func<UnityEngine.GameObject>),
+            typeof(ProductPresentationTransform));
+
+        System.Reflection.ConstructorInfo? presentationTransform =
+            typeof(ProductPresentationTransform).GetConstructor(
+                new[]
+                {
+                    typeof(UnityEngine.Vector3),
+                    typeof(UnityEngine.Vector3),
+                    typeof(UnityEngine.Vector3)
+                });
+        Assert.NotNull(presentationTransform);
+        Assert.NotNull(
+            typeof(ProductPresentationTransform).GetProperty(
+                nameof(ProductPresentationTransform.LocalPosition)));
+        Assert.NotNull(
+            typeof(ProductPresentationTransform).GetProperty(
+                nameof(ProductPresentationTransform.LocalEulerAngles)));
+        Assert.NotNull(
+            typeof(ProductPresentationTransform).GetProperty(
+                nameof(ProductPresentationTransform.LocalScale)));
+
+        System.Reflection.MethodInfo generatedIcon =
+            typeof(ProductPresentationProfileBuilder).GetMethod(
+                nameof(
+                    ProductPresentationProfileBuilder
+                        .WithGeneratedIconFromLooseVisual),
+                new[] { typeof(int) })!;
+        Assert.NotNull(generatedIcon);
+        AssertSingleOptionalParameter(generatedIcon, "size", 512);
+        Assert.NotNull(
+            typeof(ProductPresentationProfileBuilder).GetMethod(
+                nameof(
+                    ProductPresentationProfileBuilder
+                        .WithGeneratedIconFromLooseVisual),
+                new[]
+                {
+                    typeof(int),
+                    typeof(bool),
+                    typeof(float)
+                }));
+
+        Assert.NotNull(
+            typeof(IconFactory).GetMethod(
+                nameof(IconFactory.GenerateIcon),
+                new[]
+                {
+                    typeof(UnityEngine.Transform),
+                    typeof(int),
+                    typeof(bool)
+                }));
+        Assert.NotNull(
+            typeof(IconFactory).GetMethod(
+                nameof(IconFactory.GenerateIcon),
+                new[]
+                {
+                    typeof(UnityEngine.Transform),
+                    typeof(int),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(float)
+                }));
+        Assert.NotNull(
+            typeof(IconFactory).GetMethod(
+                nameof(IconFactory.GenerateIconSprite),
+                new[]
+                {
+                    typeof(UnityEngine.Transform),
+                    typeof(int),
+                    typeof(bool)
+                }));
+        Assert.NotNull(
+            typeof(IconFactory).GetMethod(
+                nameof(IconFactory.GenerateIconSprite),
+                new[]
+                {
+                    typeof(UnityEngine.Transform),
+                    typeof(int),
+                    typeof(bool),
+                    typeof(bool),
+                    typeof(float)
+                }));
+
+        System.Reflection.MethodInfo registerProduct =
+            typeof(ProductPresentationProfileRegistry).GetMethod(
+                nameof(ProductPresentationProfileRegistry.RegisterForProduct),
+                new[]
+                {
+                    typeof(string),
+                    typeof(string),
+                    typeof(ProductPresentationProfile)
+                })!;
+        System.Reflection.MethodInfo registerKind =
+            typeof(ProductPresentationProfileRegistry).GetMethod(
+                nameof(
+                    ProductPresentationProfileRegistry.RegisterForProductKind),
+                new[]
+                {
+                    typeof(string),
+                    typeof(ProductKind),
+                    typeof(ProductPresentationProfile)
+                })!;
+        Assert.NotNull(registerProduct);
+        Assert.NotNull(registerKind);
+        Assert.Equal(typeof(ProductPresentationProfile), registerProduct.ReturnType);
+        Assert.Equal(typeof(ProductPresentationProfile), registerKind.ReturnType);
+    }
+
     private static void AssertObsoleteCompatibilityShim(
         System.Reflection.MemberInfo member,
         string expectedMessage)
@@ -156,5 +312,17 @@ public sealed class ProductApiCompatibilityTests
         Assert.Equal(expectedName, parameter.Name);
         Assert.True(parameter.IsOptional);
         Assert.Equal(expectedDefault, parameter.DefaultValue);
+    }
+
+    private static void AssertBuilderMethod(
+        string name,
+        params Type[] parameterTypes)
+    {
+        System.Reflection.MethodInfo? method =
+            typeof(ProductPresentationProfileBuilder).GetMethod(
+                name,
+                parameterTypes);
+        Assert.NotNull(method);
+        Assert.Equal(typeof(ProductPresentationProfileBuilder), method.ReturnType);
     }
 }

--- a/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
@@ -1,0 +1,63 @@
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+internal static class ProductPresentationProfileApiCompileFixture
+{
+    internal static ProductPresentationProfile CompileRepresentativeCaller(
+        string ownerId,
+        string productId,
+        ProductKind productKind,
+        Func<GameObject?> looseVisual,
+        Func<GameObject?> contextVisual,
+        Func<Sprite?> icon,
+        Func<GameObject?> consumption)
+    {
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(looseVisual)
+                .WithStoredVisual(contextVisual)
+                .WithHeldVisual(contextVisual)
+                .WithStationVisual(contextVisual)
+                .WithFunctionalProductVisual(contextVisual)
+                .WithIcon(icon)
+                .WithConsumptionPrefab(consumption)
+                .Require(
+                    ProductPresentationContext.Loose,
+                    ProductPresentationContext.Stored,
+                    ProductPresentationContext.Held,
+                    ProductPresentationContext.Station,
+                    ProductPresentationContext.FunctionalProduct,
+                    ProductPresentationContext.Icon,
+                    ProductPresentationContext.Consumption)
+                .Build();
+
+        _ = ProductPresentationProfileRegistry.RegisterForProduct(
+            ownerId,
+            productId,
+            profile);
+        _ = ProductPresentationProfileRegistry.RegisterForProductKind(
+            ownerId,
+            productKind,
+            profile);
+        return profile;
+    }
+
+    internal static ProductPresentationProfile CompileGeneratedIconCaller(
+        Func<GameObject?> looseVisual)
+    {
+        var presentationTransform =
+            new ProductPresentationTransform(
+                Vector3.zero,
+                new Vector3(0f, 90f, 0f),
+                Vector3.one * 0.1f);
+        return new ProductPresentationProfileBuilder()
+            .WithLooseVisual(looseVisual, presentationTransform)
+            .WithGeneratedIconFromLooseVisual(
+                512,
+                fitToCamera: true,
+                cameraFill: 0.8f)
+            .Build();
+    }
+}

--- a/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
@@ -1,0 +1,205 @@
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductPresentationProfileBuilderTests
+{
+    [Fact]
+    public void LooseVisualIsTheDeterministicRenderedContextFallback()
+    {
+        Func<GameObject?> loose = () => null;
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(loose)
+                .Build();
+
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.Loose,
+                out Func<GameObject?>? looseProvider));
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.Stored,
+                out Func<GameObject?>? storedProvider));
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.Held,
+                out Func<GameObject?>? heldProvider));
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.Station,
+                out Func<GameObject?>? stationProvider));
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.FunctionalProduct,
+                out Func<GameObject?>? functionalProvider));
+        Assert.Same(loose, looseProvider);
+        Assert.Same(loose, storedProvider);
+        Assert.Same(loose, heldProvider);
+        Assert.Same(loose, stationProvider);
+        Assert.Same(loose, functionalProvider);
+    }
+
+    [Fact]
+    public void ContextSpecificVisualOverridesLooseFallback()
+    {
+        Func<GameObject?> loose = () => null;
+        Func<GameObject?> held = () => null;
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(loose)
+                .WithHeldVisual(held)
+                .Build();
+
+        Assert.True(
+            profile.TryGetVisualProvider(
+                ProductPresentationContext.Held,
+                out Func<GameObject?>? resolved));
+        Assert.Same(held, resolved);
+    }
+
+#if MONOMELON
+    [Fact]
+    public void LooseTransformFallsBackUntilAContextDefinesItsOwnProvider()
+    {
+        var looseTransform =
+            new ProductPresentationTransform(
+                new Vector3(1f, 2f, 3f),
+                new Vector3(10f, 20f, 30f),
+                new Vector3(0.1f, 0.2f, 0.3f));
+        var heldTransform =
+            new ProductPresentationTransform(
+                Vector3.zero,
+                new Vector3(0f, 90f, 0f),
+                Vector3.one);
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(() => null, looseTransform)
+                .WithHeldVisual(() => null, heldTransform)
+                .Build();
+
+        Assert.True(
+            profile.TryGetVisualTransform(
+                ProductPresentationContext.Stored,
+                out ProductPresentationTransform? stored));
+        Assert.Same(looseTransform, stored);
+        Assert.True(
+            profile.TryGetVisualTransform(
+                ProductPresentationContext.Held,
+                out ProductPresentationTransform? held));
+        Assert.Same(heldTransform, held);
+    }
+#endif
+
+    [Fact]
+    public void RequiredContextMustHaveAConfiguredProvider()
+    {
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    new ProductPresentationProfileBuilder()
+                        .Require(ProductPresentationContext.Consumption)
+                        .Build());
+
+        Assert.Contains("Consumption", exception.Message);
+        Assert.Contains("does not have a provider", exception.Message);
+    }
+
+    [Fact]
+    public void RequiredRenderedContextsMayUseLooseFallback()
+    {
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(() => null)
+                .Require(
+                    ProductPresentationContext.Stored,
+                    ProductPresentationContext.Held,
+                    ProductPresentationContext.Station,
+                    ProductPresentationContext.FunctionalProduct)
+                .Build();
+
+        Assert.True(profile.IsRequired(ProductPresentationContext.Stored));
+        Assert.True(profile.IsRequired(ProductPresentationContext.Held));
+        Assert.True(profile.IsRequired(ProductPresentationContext.Station));
+        Assert.True(
+            profile.IsRequired(ProductPresentationContext.FunctionalProduct));
+    }
+
+    [Theory]
+    [InlineData(31)]
+    [InlineData(2049)]
+    public void GeneratedIconSizeIsBounded(int size)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () =>
+                new ProductPresentationProfileBuilder()
+                    .WithGeneratedIconFromLooseVisual(size));
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-0.1f)]
+    [InlineData(2.01f)]
+    public void GeneratedIconCameraFillIsBounded(float cameraFill)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () =>
+                new ProductPresentationProfileBuilder()
+                    .WithGeneratedIconFromLooseVisual(
+                        512,
+                        fitToCamera: true,
+                        cameraFill: cameraFill));
+    }
+
+    [Fact]
+    public void GeneratedIconFramingControlsAreSnapshotted()
+    {
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(() => null)
+                .WithGeneratedIconFromLooseVisual(
+                    256,
+                    fitToCamera: false,
+                    cameraFill: 1.25f)
+                .Build();
+
+        Assert.Equal(256, profile.GeneratedIconSize);
+        Assert.False(profile.FitGeneratedIconToCamera);
+        Assert.Equal(1.25f, profile.GeneratedIconCameraFill);
+    }
+
+    [Fact]
+    public void BuildSnapshotsProvidersAndRequiredContexts()
+    {
+        Func<GameObject?> loose = () => null;
+        var builder =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(loose)
+                .Require(ProductPresentationContext.Stored);
+        ProductPresentationProfile first = builder.Build();
+
+        Func<GameObject?> replacement = () => null;
+        builder
+            .WithLooseVisual(replacement)
+            .Require(ProductPresentationContext.Held);
+
+        Assert.True(
+            first.TryGetVisualProvider(
+                ProductPresentationContext.Stored,
+                out Func<GameObject?>? retained));
+        Assert.Same(loose, retained);
+        Assert.True(first.IsRequired(ProductPresentationContext.Stored));
+        Assert.False(first.IsRequired(ProductPresentationContext.Held));
+    }
+
+    [Theory]
+    [InlineData((ProductPresentationContext)(-1))]
+    [InlineData((ProductPresentationContext)99)]
+    public void UndefinedRequiredContextIsRejected(
+        ProductPresentationContext context)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ProductPresentationProfileBuilder().Require(context));
+    }
+}

--- a/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
@@ -1,0 +1,305 @@
+#if IL2CPPMELON
+using NativeProductDefinition = Il2CppScheduleOne.Product.ProductDefinition;
+#elif MONOMELON
+using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
+#endif
+
+using System.Runtime.CompilerServices;
+using S1API.Internal.Products;
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+[Collection(CustomProductRegistryCollection.Name)]
+public sealed class ProductPresentationProfileRegistryTests : IDisposable
+{
+    private readonly FakeProductRuntime _productRuntime = new();
+    private readonly FakePresentationRuntime _presentationRuntime = new();
+
+    public ProductPresentationProfileRegistryTests()
+    {
+        CustomProductDefinitionRegistry.ResetForTesting(
+            _productRuntime,
+            _presentationRuntime);
+    }
+
+    public void Dispose()
+    {
+        CustomProductDefinitionRegistry.RestoreRuntimeAdapterForTesting();
+    }
+
+    [Fact]
+    public void ProductSpecificProfileTakesPrecedenceOverKindProfile()
+    {
+        string productId = CreateId();
+        ProductKind kind = CreateKind();
+        ProductPresentationProfile kindProfile = CreateProfile();
+        ProductPresentationProfile productProfile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProductKind(
+            "examplemod",
+            kind,
+            kindProfile);
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            productProfile);
+
+        RegisterProduct(productId, kind);
+
+        ProductPresentationProfileRegistration applied =
+            Assert.Single(_presentationRuntime.AppliedProfiles);
+        Assert.Same(productProfile, applied.Profile);
+        Assert.Equal(productId, applied.Key, ignoreCase: true);
+    }
+
+    [Fact]
+    public void KindProfileIsUsedWhenProductProfileIsAbsent()
+    {
+        string productId = CreateId();
+        ProductKind kind = CreateKind();
+        ProductPresentationProfile profile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProductKind(
+            "examplemod",
+            kind,
+            profile);
+
+        RegisterProduct(productId, kind);
+
+        Assert.Same(
+            profile,
+            Assert.Single(_presentationRuntime.AppliedProfiles).Profile);
+    }
+
+    [Fact]
+    public void LateRegistrationAppliesToAnExistingProduct()
+    {
+        string productId = CreateId();
+        ProductKind kind = CreateKind();
+        RegisterProduct(productId, kind);
+        _presentationRuntime.AppliedProfiles.Clear();
+
+        ProductPresentationProfile profile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            profile);
+
+        Assert.Same(
+            profile,
+            Assert.Single(_presentationRuntime.AppliedProfiles).Profile);
+    }
+
+    [Fact]
+    public void LifecycleRestorationReappliesTheResolvedProfile()
+    {
+        string productId = CreateId();
+        ProductKind kind = CreateKind();
+        ProductPresentationProfile profile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            profile);
+        RegisterProduct(productId, kind);
+        _presentationRuntime.AppliedProfiles.Clear();
+
+        CustomProductDefinitionRegistry.InvokePreLoadForTesting();
+        CustomProductDefinitionRegistry.InvokeLoadCompleteForTesting();
+
+        Assert.Equal(2, _presentationRuntime.AppliedProfiles.Count);
+        Assert.All(
+            _presentationRuntime.AppliedProfiles,
+            registration => Assert.Same(profile, registration.Profile));
+    }
+
+    [Fact]
+    public void PresentationFailurePrecedesNativeMutationAndReleasesProductId()
+    {
+        string productId = CreateId();
+        ProductKind kind = CreateKind();
+        ProductPresentationProfile profile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            profile);
+        _presentationRuntime.NextApplyException =
+            new InvalidOperationException("Required presentation is unavailable.");
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => RegisterProduct(productId, kind));
+
+        Assert.Equal("Required presentation is unavailable.", exception.Message);
+        Assert.Equal(0, _productRuntime.ApplyCount);
+
+        RegisterProduct(productId, kind);
+
+        Assert.Equal(1, _productRuntime.ApplyCount);
+        Assert.Same(
+            profile,
+            Assert.Single(_presentationRuntime.AppliedProfiles).Profile);
+    }
+
+    [Fact]
+    public void LegacyRegistrationWithoutGenericMetadataRemainsUnprofiled()
+    {
+        string productId = CreateId();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            CreateProfile());
+
+        CustomProductDefinitionRegistry.Register(
+            "examplemod",
+            productId,
+            "Legacy Product",
+            10f,
+            CreateDefinition());
+
+        Assert.Single(_presentationRuntime.NullProfileProducts);
+        Assert.Empty(_presentationRuntime.AppliedProfiles);
+    }
+
+    [Fact]
+    public void SameOwnerSameProfileRegistrationIsCaseInsensitiveAndIdempotent()
+    {
+        string productId = CreateId();
+        ProductPresentationProfile profile = CreateProfile();
+
+        ProductPresentationProfile first =
+            ProductPresentationProfileRegistry.RegisterForProduct(
+                "ExampleMod",
+                productId,
+                profile);
+        ProductPresentationProfile repeated =
+            ProductPresentationProfileRegistry.RegisterForProduct(
+                "examplemod",
+                productId.ToUpperInvariant(),
+                profile);
+
+        Assert.Same(profile, first);
+        Assert.Same(first, repeated);
+    }
+
+    [Fact]
+    public void ConflictingOwnerFailsWithActionableIdentity()
+    {
+        string productId = CreateId();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "first-mod",
+            productId,
+            CreateProfile());
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    ProductPresentationProfileRegistry.RegisterForProduct(
+                        "second-mod",
+                        productId.ToUpperInvariant(),
+                        CreateProfile()));
+
+        Assert.Contains(productId, exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("first-mod", exception.Message);
+        Assert.Contains("second-mod", exception.Message);
+        Assert.Contains("case-insensitive", exception.Message);
+    }
+
+    [Fact]
+    public void SameOwnerCannotSilentlyReplaceARegisteredProfile()
+    {
+        string productId = CreateId();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            "examplemod",
+            productId,
+            CreateProfile());
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    ProductPresentationProfileRegistry.RegisterForProduct(
+                        "examplemod",
+                        productId,
+                        CreateProfile()));
+
+        Assert.Contains("another profile", exception.Message);
+    }
+
+    private void RegisterProduct(string productId, ProductKind kind)
+    {
+        CustomProductDefinitionRegistry.Register(
+            "examplemod",
+            productId,
+            "Profile Product",
+            10f,
+            CreateDefinition(),
+            new CustomProductDefinitionMetadata(kind, Quality.Standard));
+    }
+
+    private static ProductPresentationProfile CreateProfile()
+    {
+        return new ProductPresentationProfileBuilder()
+            .WithLooseVisual(() => null)
+            .Build();
+    }
+
+    private static ProductKind CreateKind()
+    {
+        return new ProductKindBuilder(CreateId())
+            .WithCompatibilityDrugType(DrugType.MDMA)
+            .Build();
+    }
+
+    private static NativeProductDefinition CreateDefinition()
+    {
+        var definition =
+            (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
+                typeof(NativeProductDefinition));
+        GC.SuppressFinalize(definition);
+        return definition;
+    }
+
+    private static string CreateId()
+    {
+        return $"s1api-tests:{Guid.NewGuid():N}";
+    }
+
+    private sealed class FakeProductRuntime :
+        ICustomProductDefinitionRuntimeAdapter
+    {
+        internal int ApplyCount { get; private set; }
+
+        public bool Apply(CustomProductDefinitionRegistration registration)
+        {
+            ApplyCount++;
+            return true;
+        }
+    }
+
+    private sealed class FakePresentationRuntime :
+        ICustomProductPresentationRuntime
+    {
+        internal List<ProductPresentationProfileRegistration> AppliedProfiles { get; } =
+            new();
+
+        internal List<CustomProductDefinitionRegistration> NullProfileProducts { get; } =
+            new();
+
+        internal Exception? NextApplyException { get; set; }
+
+        public void Apply(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfileRegistration? profile)
+        {
+            if (NextApplyException != null)
+            {
+                Exception exception = NextApplyException;
+                NextApplyException = null;
+                throw exception;
+            }
+
+            if (profile == null)
+                NullProfileProducts.Add(product);
+            else
+                AppliedProfiles.Add(profile);
+        }
+    }
+}

--- a/S1API/Internal/Patches/LoadingScreenPatches.cs
+++ b/S1API/Internal/Patches/LoadingScreenPatches.cs
@@ -30,24 +30,26 @@ namespace S1API.Internal.Patches
     internal static class LoadingScreenPatches
     {
         private static readonly Log Logger = new Log("LoadingScreenPatches");
-        private static bool _isWaitingForMugshots = false;
+        private static bool _isWaitingForRenderedIcons;
+        private static bool _waitForMugshots;
         private static bool _hasCustomNpcTypes = false;
         private static bool _allowGameClose;
 
         /// <summary>
-        /// Patch GetLoadStatusText to return our custom text when waiting for mugshots
+        /// Patch GetLoadStatusText to describe the rendered-icon work still pending.
         /// </summary>
         [HarmonyPatch(typeof(S1Persistence.LoadManager), "GetLoadStatusText")]
         [HarmonyPostfix]
         private static void GetLoadStatusText_Postfix(ref string __result)
         {
-            if (_isWaitingForMugshots)
-            {
-                __result =
-                    CustomProductPresentationRuntime.GeneratedIconWorkComplete
-                        ? "Generating NPC Mugshots..."
-                        : "Generating Product Icons...";
-            }
+            if (!_isWaitingForRenderedIcons)
+                return;
+
+            if (!CustomProductPresentationRuntime.GeneratedIconWorkComplete)
+                __result = "Generating Product Icons...";
+            else if (_waitForMugshots &&
+                     !NPCAppearance.MugshotsProcessingComplete)
+                __result = "Generating NPC Mugshots...";
         }
 
         /// <summary>
@@ -71,10 +73,11 @@ namespace S1API.Internal.Patches
             if (!waitForMugshots && !waitForProductIcons)
                 return true;
 
-            if (_isWaitingForMugshots)
+            if (_isWaitingForRenderedIcons)
                 return false;
 
-            _isWaitingForMugshots = true;
+            _isWaitingForRenderedIcons = true;
+            _waitForMugshots = waitForMugshots;
             MelonCoroutines.Start(
                 WaitForRenderedIconsThenClose(
                     __instance,
@@ -162,7 +165,7 @@ namespace S1API.Internal.Patches
         }
 
         /// <summary>
-        /// Coroutine that waits for mugshot generation to complete, then closes the loading screen
+        /// Waits for product-icon and optional mugshot work before closing the loading screen.
         /// </summary>
         private static IEnumerator WaitForRenderedIconsThenClose(
             S1UI.LoadingScreen loadingScreen,
@@ -185,7 +188,10 @@ namespace S1API.Internal.Patches
             if (waitForMugshots &&
                 !HasOutstandingMugshotWork() &&
                 !NPCAppearance.MugshotsProcessingComplete)
+            {
                 waitForMugshots = false;
+                _waitForMugshots = false;
+            }
 
             while ((!CustomProductPresentationRuntime.GeneratedIconWorkComplete ||
                     (waitForMugshots &&
@@ -196,7 +202,8 @@ namespace S1API.Internal.Patches
                 timer += 0.1f;
             }
             
-            _isWaitingForMugshots = false;
+            _isWaitingForRenderedIcons = false;
+            _waitForMugshots = false;
             
             if (timer >= TIMEOUT)
             {
@@ -258,7 +265,8 @@ namespace S1API.Internal.Patches
         /// </summary>
         internal static void ResetState()
         {
-            _isWaitingForMugshots = false;
+            _isWaitingForRenderedIcons = false;
+            _waitForMugshots = false;
             _allowGameClose = false;
             _hasCustomNpcTypes = ReflectionUtils.GetDerivedClasses<NPC>()
                 .Any(t => t != null && !t.IsAbstract && t.Assembly != typeof(NPC).Assembly);

--- a/S1API/Internal/Patches/LoadingScreenPatches.cs
+++ b/S1API/Internal/Patches/LoadingScreenPatches.cs
@@ -11,6 +11,7 @@ using S1DevUtilities = ScheduleOne.DevUtilities;
 using HarmonyLib;
 using MelonLoader;
 using S1API.Entities;
+using S1API.Internal.Products;
 using S1API.Internal.Utils;
 using S1API.Logging;
 using System;
@@ -22,8 +23,8 @@ using UnityEngine.SceneManagement;
 namespace S1API.Internal.Patches
 {
     /// <summary>
-    /// INTERNAL: Patches the LoadingScreen to delay closing until NPC mugshot generation is complete.
-    /// This ensures players see the loading screen while S1API NPC portraits are being generated.
+    /// INTERNAL: Patches the LoadingScreen to delay closing until queued rendered icons complete.
+    /// This ensures players see the loading screen while S1API portraits and product icons generate.
     /// </summary>
     [HarmonyPatch]
     internal static class LoadingScreenPatches
@@ -42,7 +43,10 @@ namespace S1API.Internal.Patches
         {
             if (_isWaitingForMugshots)
             {
-                __result = "Generating NPC Mugshots...";
+                __result =
+                    CustomProductPresentationRuntime.GeneratedIconWorkComplete
+                        ? "Generating NPC Mugshots..."
+                        : "Generating Product Icons...";
             }
         }
 
@@ -59,29 +63,39 @@ namespace S1API.Internal.Patches
             if (!IsGameLoading())
                 return true;
 
-            if (S1APIPreferences.EnableMugshotLoadingScreen?.Value == false)
-                return true;
-
-            if (!_hasCustomNpcTypes)
-                return true;
-
-            if (!HasCustomNpcInstances() && !HasOutstandingMugshotWork())
-                return true;
-
-            if (NPCAppearance.MugshotsProcessingComplete)
+            bool waitForMugshots =
+                ShouldWaitForMugshots() &&
+                !NPCAppearance.MugshotsProcessingComplete;
+            bool waitForProductIcons =
+                !CustomProductPresentationRuntime.GeneratedIconWorkComplete;
+            if (!waitForMugshots && !waitForProductIcons)
                 return true;
 
             if (_isWaitingForMugshots)
                 return false;
 
             _isWaitingForMugshots = true;
-            MelonCoroutines.Start(WaitForMugshotsThenClose(__instance));
+            MelonCoroutines.Start(
+                WaitForRenderedIconsThenClose(
+                    __instance,
+                    waitForMugshots));
 
             return false;
         }
 
         private static bool HasCustomNpcInstances() =>
             NPC.All.Any(npc => npc != null && npc.IsCustomNPC);
+
+        private static bool ShouldWaitForMugshots()
+        {
+            if (S1APIPreferences.EnableMugshotLoadingScreen?.Value == false ||
+                !_hasCustomNpcTypes)
+            {
+                return false;
+            }
+
+            return HasCustomNpcInstances() || HasOutstandingMugshotWork();
+        }
 
         /// <summary>
         /// Check if we're currently in the final phase of game loading where NPC mugshots should complete.
@@ -150,27 +164,33 @@ namespace S1API.Internal.Patches
         /// <summary>
         /// Coroutine that waits for mugshot generation to complete, then closes the loading screen
         /// </summary>
-        private static IEnumerator WaitForMugshotsThenClose(S1UI.LoadingScreen loadingScreen)
+        private static IEnumerator WaitForRenderedIconsThenClose(
+            S1UI.LoadingScreen loadingScreen,
+            bool waitForMugshots)
         {
             const float START_TIMEOUT = 5f;
             const float TIMEOUT = 90f;
             float startTimer = 0f;
             float timer = 0f;
 
-            while (!HasOutstandingMugshotWork() && !NPCAppearance.MugshotsProcessingComplete && startTimer < START_TIMEOUT)
+            while (waitForMugshots &&
+                   !HasOutstandingMugshotWork() &&
+                   !NPCAppearance.MugshotsProcessingComplete &&
+                   startTimer < START_TIMEOUT)
             {
                 yield return new WaitForSeconds(0.1f);
                 startTimer += 0.1f;
             }
 
-            if (!HasOutstandingMugshotWork() && !NPCAppearance.MugshotsProcessingComplete)
-            {
-                _isWaitingForMugshots = false;
-                CloseLoadingScreenDirectly(loadingScreen);
-                yield break;
-            }
+            if (waitForMugshots &&
+                !HasOutstandingMugshotWork() &&
+                !NPCAppearance.MugshotsProcessingComplete)
+                waitForMugshots = false;
 
-            while (!NPCAppearance.MugshotsProcessingComplete && timer < TIMEOUT)
+            while ((!CustomProductPresentationRuntime.GeneratedIconWorkComplete ||
+                    (waitForMugshots &&
+                     !NPCAppearance.MugshotsProcessingComplete)) &&
+                   timer < TIMEOUT)
             {
                 yield return new WaitForSeconds(0.1f);
                 timer += 0.1f;
@@ -181,7 +201,11 @@ namespace S1API.Internal.Patches
             if (timer >= TIMEOUT)
             {
                 int remaining = GetMugshotQueueCount();
-                Logger.Warning($"Mugshot generation timeout reached after {TIMEOUT}s. {remaining} NPCs may have incomplete portraits.");
+                Logger.Warning(
+                    $"Rendered icon generation timeout reached after {TIMEOUT}s. " +
+                    $"{remaining} NPCs may have incomplete portraits; " +
+                    $"product icons complete: " +
+                    $"{CustomProductPresentationRuntime.GeneratedIconWorkComplete}.");
             }
             
             CloseLoadingScreenDirectly(loadingScreen);

--- a/S1API/Internal/Products/CustomProductDefinitionMetadata.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionMetadata.cs
@@ -1,3 +1,9 @@
+#if IL2CPPMELON
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+#endif
+
 using System;
 using System.Collections.Generic;
 using S1API.Products;
@@ -16,7 +22,8 @@ namespace S1API.Internal.Products
             : this(
                 productKind,
                 defaultQuality,
-                Array.Empty<PackagingDefinition>())
+                Array.Empty<PackagingDefinition>(),
+                null)
         {
         }
 
@@ -24,6 +31,15 @@ namespace S1API.Internal.Products
             ProductKind productKind,
             Quality defaultQuality,
             IReadOnlyList<PackagingDefinition> validPackaging)
+            : this(productKind, defaultQuality, validPackaging, null)
+        {
+        }
+
+        internal CustomProductDefinitionMetadata(
+            ProductKind productKind,
+            Quality defaultQuality,
+            IReadOnlyList<PackagingDefinition> validPackaging,
+            S1Product.ProductDefinition? representationTemplate)
         {
             ProductKind = productKind;
             DefaultQuality = defaultQuality;
@@ -32,6 +48,7 @@ namespace S1API.Internal.Products
 
             ValidPackaging =
                 new List<PackagingDefinition>(validPackaging).AsReadOnly();
+            RepresentationTemplate = representationTemplate;
         }
 
         internal ProductKind ProductKind { get; }
@@ -39,5 +56,7 @@ namespace S1API.Internal.Products
         internal Quality DefaultQuality { get; }
 
         internal IReadOnlyList<PackagingDefinition> ValidPackaging { get; }
+
+        internal S1Product.ProductDefinition? RepresentationTemplate { get; }
     }
 }

--- a/S1API/Internal/Products/CustomProductDefinitionRegistration.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistration.cs
@@ -55,5 +55,7 @@ namespace S1API.Internal.Products
         internal S1Product.ProductDefinition Definition { get; }
 
         internal CustomProductDefinitionMetadata? Metadata { get; }
+
+        internal CustomProductPresentationState? PresentationState { get; set; }
     }
 }

--- a/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
@@ -7,6 +7,7 @@ using S1Product = ScheduleOne.Product;
 using System;
 using System.Collections.Generic;
 using S1API.Lifecycle;
+using S1API.Products;
 
 namespace S1API.Internal.Products
 {
@@ -25,6 +26,8 @@ namespace S1API.Internal.Products
 
         private static ICustomProductDefinitionRuntimeAdapter _runtimeAdapter =
             CustomProductDefinitionRuntimeAdapter.Instance;
+        private static ICustomProductPresentationRuntime _presentationRuntime =
+            CustomProductPresentationRuntime.Instance;
         private static bool _hooked;
 
         /// <summary>
@@ -115,12 +118,35 @@ namespace S1API.Internal.Products
 
                 try
                 {
+                    ProductPresentationProfileRegistration? profile =
+                        ResolvePresentationProfile(registration);
+                    if (profile != null)
+                        _presentationRuntime.Apply(registration, profile);
+
                     _runtimeAdapter.Apply(registration);
+
+                    if (profile == null)
+                        _presentationRuntime.Apply(registration, null);
                 }
                 catch
                 {
                     if (added)
                     {
+                        if (registration.PresentationState != null)
+                        {
+                            try
+                            {
+                                _presentationRuntime.Apply(registration, null);
+                            }
+                            catch (Exception rollbackException)
+                            {
+                                MelonLoader.MelonLogger.Error(
+                                    "[CustomProductDefinitionRegistry] Failed to restore " +
+                                    $"presentation fallbacks after rejecting " +
+                                    $"'{normalizedProductId}': {rollbackException}");
+                            }
+                        }
+
                         lock (Gate)
                         {
                             if (Registrations.TryGetValue(
@@ -234,6 +260,7 @@ namespace S1API.Internal.Products
                     try
                     {
                         _runtimeAdapter.Apply(registration);
+                        ApplyPresentationProfile(registration);
                     }
                     catch (Exception exception)
                     {
@@ -258,7 +285,8 @@ namespace S1API.Internal.Products
         }
 
         internal static void ResetForTesting(
-            ICustomProductDefinitionRuntimeAdapter runtimeAdapter)
+            ICustomProductDefinitionRuntimeAdapter runtimeAdapter,
+            ICustomProductPresentationRuntime? presentationRuntime = null)
         {
             if (runtimeAdapter == null)
                 throw new ArgumentNullException(nameof(runtimeAdapter));
@@ -275,14 +303,29 @@ namespace S1API.Internal.Products
 
                     Registrations.Clear();
                     _runtimeAdapter = runtimeAdapter;
+                    _presentationRuntime =
+                        presentationRuntime ?? CustomProductPresentationRuntime.Instance;
                     _hooked = false;
                 }
             }
+
+            ProductPresentationProfileRegistry.ResetForTesting();
         }
 
         internal static void RestoreRuntimeAdapterForTesting()
         {
-            ResetForTesting(CustomProductDefinitionRuntimeAdapter.Instance);
+            ResetForTesting(
+                CustomProductDefinitionRuntimeAdapter.Instance,
+                CustomProductPresentationRuntime.Instance);
+        }
+
+        internal static void ApplyPresentationProfiles()
+        {
+            lock (ApplyGate)
+            {
+                foreach (CustomProductDefinitionRegistration registration in Snapshot())
+                    ApplyPresentationProfile(registration);
+            }
         }
 
         internal static void InvokePreLoadForTesting()
@@ -303,6 +346,28 @@ namespace S1API.Internal.Products
                    (left is UnityEngine.Object leftObject &&
                     right is UnityEngine.Object rightObject &&
                     leftObject == rightObject);
+        }
+
+        private static void ApplyPresentationProfile(
+            CustomProductDefinitionRegistration registration)
+        {
+            _presentationRuntime.Apply(
+                registration,
+                ResolvePresentationProfile(registration));
+        }
+
+        private static ProductPresentationProfileRegistration?
+            ResolvePresentationProfile(
+                CustomProductDefinitionRegistration registration)
+        {
+            if (registration.Metadata == null)
+                return null;
+
+            ProductPresentationProfileRegistry.TryResolve(
+                registration.ProductId,
+                registration.Metadata.ProductKind.Id,
+                out ProductPresentationProfileRegistration? profile);
+            return profile;
         }
     }
 }

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -1,0 +1,1041 @@
+#if IL2CPPMELON
+using S1AvatarEquipping = Il2CppScheduleOne.AvatarFramework.Equipping;
+using S1Equipping = Il2CppScheduleOne.Equipping;
+using S1Product = Il2CppScheduleOne.Product;
+using S1Station = Il2CppScheduleOne.StationFramework;
+using S1Storage = Il2CppScheduleOne.Storage;
+#elif MONOMELON
+using S1AvatarEquipping = ScheduleOne.AvatarFramework.Equipping;
+using S1Equipping = ScheduleOne.Equipping;
+using S1Product = ScheduleOne.Product;
+using S1Station = ScheduleOne.StationFramework;
+using S1Storage = ScheduleOne.Storage;
+#endif
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MelonLoader;
+using S1API.Internal.Utils;
+using S1API.Items;
+using S1API.Products;
+using S1API.Rendering;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Clones native presentation scaffolds and replaces only their visual payload.
+    /// </summary>
+    internal sealed class CustomProductPresentationRuntime :
+        ICustomProductPresentationRuntime
+    {
+        internal static readonly CustomProductPresentationRuntime Instance =
+            new CustomProductPresentationRuntime();
+        private static GameObject? _cacheRoot;
+        private static readonly object GeneratedIconQueueGate = new object();
+        private static readonly Queue<GeneratedIconRequest> GeneratedIconQueue =
+            new Queue<GeneratedIconRequest>();
+        private static bool _isProcessingGeneratedIcons;
+
+        private sealed class GeneratedIconRequest
+        {
+            internal GeneratedIconRequest(
+                CustomProductDefinitionRegistration product,
+                ProductPresentationProfileRegistration registration,
+                CustomProductPresentationState state)
+            {
+                Product = product;
+                Registration = registration;
+                State = state;
+            }
+
+            internal CustomProductDefinitionRegistration Product { get; }
+
+            internal ProductPresentationProfileRegistration Registration { get; }
+
+            internal CustomProductPresentationState State { get; }
+        }
+
+        private enum GeneratedIconAttemptResult
+        {
+            Success,
+            Retry,
+            Failure
+        }
+
+        private CustomProductPresentationRuntime()
+        {
+        }
+
+        public void Apply(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfileRegistration? profile)
+        {
+            if (product.Metadata == null)
+                return;
+
+            if (profile == null)
+            {
+                if (product.PresentationState != null)
+                    RestoreBaseline(product);
+                return;
+            }
+
+            CustomProductPresentationState state =
+                product.PresentationState ??=
+                    new CustomProductPresentationState(
+                        product.Definition,
+                        product.Metadata);
+            if (ReferenceEquals(state.AppliedRegistration, profile) &&
+                GeneratedObjectsAreAlive(state.GeneratedObjects))
+            {
+                QueuePendingGeneratedIcon(product, profile, state);
+                return;
+            }
+
+            BuildAndCommit(product, profile);
+        }
+
+        private static void BuildAndCommit(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfileRegistration registration)
+        {
+            ProductPresentationProfile profile = registration.Profile;
+            CustomProductPresentationState state =
+                product.PresentationState ??
+                throw new InvalidOperationException(
+                    "Presentation state was not initialized.");
+            var created = new List<Object>();
+            var sources =
+                new Dictionary<Func<GameObject?>, GameObject?>();
+
+            var stored = state.BaselineStoredItem;
+            var held = state.BaselineEquippable;
+            var station = state.BaselineStationItem;
+            var functional = state.BaselineFunctionalProduct;
+            var icon = state.BaselineIcon;
+            var consumption = state.BaselineConsumeAnimation;
+            bool generatedIconPending = false;
+
+            try
+            {
+                stored = BuildStored(
+                    product,
+                    profile,
+                    sources,
+                    created,
+                    state.BaselineStoredItem);
+                held = BuildHeld(
+                    product,
+                    profile,
+                    sources,
+                    created,
+                    state.BaselineEquippable);
+                station = BuildStation(
+                    product,
+                    profile,
+                    sources,
+                    created,
+                    state.TemplateStationItem ?? state.BaselineStationItem);
+                functional = BuildFunctional(
+                    product,
+                    profile,
+                    sources,
+                    created,
+                    state.BaselineFunctionalProduct);
+                icon =
+                    BuildIcon(
+                        product,
+                        profile,
+                        sources,
+                        created,
+                        state.BaselineIcon,
+                        out generatedIconPending);
+                consumption =
+                    BuildConsumption(
+                        product,
+                        profile,
+                        created,
+                        state.BaselineConsumeAnimation);
+            }
+            catch
+            {
+                DestroyAll(created);
+                throw;
+            }
+
+            S1Product.ProductDefinition definition = product.Definition;
+            definition.StoredItem = stored;
+            definition.Equippable = held;
+            definition.StationItem = station;
+            definition.FunctionalProduct = functional;
+            definition.Icon = icon;
+            definition.ConsumeAnimation = consumption;
+
+            List<Object> previous = state.GeneratedObjects;
+            state.GeneratedObjects = created;
+            state.AppliedRegistration = registration;
+            state.IsGeneratedIconPending = generatedIconPending;
+            DestroyAll(previous);
+            QueuePendingGeneratedIcon(product, registration, state);
+        }
+
+        private static S1Storage.StoredItem? BuildStored(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            Dictionary<Func<GameObject?>, GameObject?> sources,
+            List<Object> created,
+            S1Storage.StoredItem? fallback)
+        {
+            GameObject? source =
+                GetVisualSource(
+                    product,
+                    profile,
+                    ProductPresentationContext.Stored,
+                    sources);
+            if (source == null)
+                return fallback;
+            if (fallback == null)
+                return MissingScaffold(product, profile, ProductPresentationContext.Stored, fallback);
+
+            var clone =
+                Object.Instantiate(fallback, GetCacheRoot().transform);
+            PrepareCachedPrefab(clone.gameObject);
+            created.Add(clone.gameObject);
+            if (!CrossType.Is(clone, out S1Product.Product_Stored stored))
+            {
+                return InvalidScaffold(
+                    product,
+                    profile,
+                    ProductPresentationContext.Stored,
+                    clone,
+                    fallback,
+                    created,
+                    "Product_Stored");
+            }
+
+            stored.Visuals =
+                ReplaceVisual(
+                    stored.gameObject,
+                    stored.Visuals,
+                    source,
+                    profile,
+                    ProductPresentationContext.Stored);
+            return clone;
+        }
+
+        private static S1Equipping.Equippable? BuildHeld(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            Dictionary<Func<GameObject?>, GameObject?> sources,
+            List<Object> created,
+            S1Equipping.Equippable? fallback)
+        {
+            GameObject? source =
+                GetVisualSource(
+                    product,
+                    profile,
+                    ProductPresentationContext.Held,
+                    sources);
+            if (source == null)
+                return fallback;
+            if (fallback == null)
+                return MissingScaffold(product, profile, ProductPresentationContext.Held, fallback);
+
+            var clone =
+                Object.Instantiate(fallback, GetCacheRoot().transform);
+            PrepareCachedPrefab(clone.gameObject);
+            created.Add(clone.gameObject);
+            if (!CrossType.Is(clone, out S1Product.Product_Equippable held))
+            {
+                return InvalidScaffold(
+                    product,
+                    profile,
+                    ProductPresentationContext.Held,
+                    clone,
+                    fallback,
+                    created,
+                    "Product_Equippable");
+            }
+
+            held.Visuals =
+                ReplaceVisual(
+                    held.gameObject,
+                    held.Visuals,
+                    source,
+                    profile,
+                    ProductPresentationContext.Held);
+            held.ModelContainer = held.Visuals.VisualsContainer;
+            held.AvatarEquippable =
+                BuildAvatarEquippable(
+                    product,
+                    held.AvatarEquippable,
+                    source,
+                    profile,
+                    created);
+            return clone;
+        }
+
+        private static S1Station.StationItem? BuildStation(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            Dictionary<Func<GameObject?>, GameObject?> sources,
+            List<Object> created,
+            S1Station.StationItem? fallback)
+        {
+            GameObject? source =
+                GetVisualSource(
+                    product,
+                    profile,
+                    ProductPresentationContext.Station,
+                    sources);
+            if (source == null)
+                return product.PresentationState?.BaselineStationItem;
+            if (fallback == null)
+                return MissingScaffold(product, profile, ProductPresentationContext.Station, fallback);
+
+            var clone =
+                Object.Instantiate(fallback, GetCacheRoot().transform);
+            PrepareCachedPrefab(clone.gameObject);
+            created.Add(clone.gameObject);
+            if (!CrossType.Is(clone, out S1Station.ProductStationItem station))
+            {
+                return InvalidScaffold(
+                    product,
+                    profile,
+                    ProductPresentationContext.Station,
+                    clone,
+                    product.PresentationState?.BaselineStationItem,
+                    created,
+                    "ProductStationItem");
+            }
+
+            station.Visuals =
+                ReplaceVisual(
+                    station.gameObject,
+                    station.Visuals,
+                    source,
+                    profile,
+                    ProductPresentationContext.Station);
+            return clone;
+        }
+
+        private static S1Product.FunctionalProduct? BuildFunctional(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            Dictionary<Func<GameObject?>, GameObject?> sources,
+            List<Object> created,
+            S1Product.FunctionalProduct? fallback)
+        {
+            GameObject? source =
+                GetVisualSource(
+                    product,
+                    profile,
+                    ProductPresentationContext.FunctionalProduct,
+                    sources);
+            if (source == null)
+                return fallback;
+            if (fallback == null)
+            {
+                return MissingScaffold(
+                    product,
+                    profile,
+                    ProductPresentationContext.FunctionalProduct,
+                    fallback);
+            }
+
+            var clone =
+                Object.Instantiate(fallback, GetCacheRoot().transform);
+            PrepareCachedPrefab(clone.gameObject);
+            created.Add(clone.gameObject);
+            if (!CrossType.Is(clone, out S1Product.FunctionalProduct functional))
+            {
+                return InvalidScaffold(
+                    product,
+                    profile,
+                    ProductPresentationContext.FunctionalProduct,
+                    clone,
+                    fallback,
+                    created,
+                    "FunctionalProduct");
+            }
+
+            functional.Visuals =
+                ReplaceVisual(
+                    functional.gameObject,
+                    functional.Visuals,
+                    source,
+                    profile,
+                    ProductPresentationContext.FunctionalProduct);
+            EnsureCollider(functional.Visuals.VisualsContainer.gameObject);
+            return clone;
+        }
+
+        private static Sprite? BuildIcon(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            Dictionary<Func<GameObject?>, GameObject?> sources,
+            List<Object> created,
+            Sprite? fallback,
+            out bool generatedIconPending)
+        {
+            generatedIconPending = false;
+            if (profile.IconProvider != null)
+            {
+                try
+                {
+                    Sprite? sprite = profile.IconProvider();
+                    if (sprite != null)
+                        return sprite;
+                    return ProviderFailed(
+                        product,
+                        profile,
+                        ProductPresentationContext.Icon,
+                        "returned null",
+                        fallback);
+                }
+                catch (Exception exception)
+                {
+                    return ProviderFailed(
+                        product,
+                        profile,
+                        ProductPresentationContext.Icon,
+                        exception.Message,
+                        fallback);
+                }
+            }
+
+            if (!profile.GenerateIconFromLooseVisual)
+                return MissingProvider(
+                    product,
+                    profile,
+                    ProductPresentationContext.Icon,
+                    "no icon provider was configured",
+                    fallback);
+
+            generatedIconPending = true;
+            return fallback;
+        }
+
+        internal static bool GeneratedIconWorkComplete
+        {
+            get
+            {
+                lock (GeneratedIconQueueGate)
+                {
+                    return !_isProcessingGeneratedIcons &&
+                           GeneratedIconQueue.Count == 0;
+                }
+            }
+        }
+
+        private static void QueuePendingGeneratedIcon(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfileRegistration registration,
+            CustomProductPresentationState state)
+        {
+            if (!state.IsGeneratedIconPending ||
+                state.IsGeneratedIconQueued ||
+                !registration.Profile.GenerateIconFromLooseVisual)
+            {
+                return;
+            }
+
+            bool startProcessor = false;
+            lock (GeneratedIconQueueGate)
+            {
+                if (state.IsGeneratedIconQueued)
+                    return;
+
+                state.IsGeneratedIconQueued = true;
+                GeneratedIconQueue.Enqueue(
+                    new GeneratedIconRequest(product, registration, state));
+                if (!_isProcessingGeneratedIcons)
+                {
+                    _isProcessingGeneratedIcons = true;
+                    startProcessor = true;
+                }
+            }
+
+            if (startProcessor)
+                MelonCoroutines.Start(ProcessGeneratedIconQueue());
+        }
+
+        private static IEnumerator ProcessGeneratedIconQueue()
+        {
+            while (true)
+            {
+                GeneratedIconRequest? request;
+                lock (GeneratedIconQueueGate)
+                {
+                    if (GeneratedIconQueue.Count == 0)
+                    {
+                        _isProcessingGeneratedIcons = false;
+                        yield break;
+                    }
+
+                    request = GeneratedIconQueue.Dequeue();
+                }
+
+                CustomProductPresentationState state = request.State;
+                try
+                {
+                    if (!state.IsGeneratedIconPending ||
+                        !ReferenceEquals(
+                            state.AppliedRegistration,
+                            request.Registration))
+                    {
+                        continue;
+                    }
+
+                    const int readinessFrames = 300;
+                    int readinessFrame = 0;
+                    while (!IconFactory.IsItemIconGeneratorReady &&
+                           readinessFrame < readinessFrames)
+                    {
+                        readinessFrame++;
+                        yield return null;
+                    }
+
+                    if (!IconFactory.IsItemIconGeneratorReady)
+                    {
+                        LogGeneratedIconFailure(
+                            request,
+                            "the native item-icon rendering rig did not become ready");
+                        continue;
+                    }
+
+                    const int maxRetries = 30;
+                    string lastError = "the native renderer returned no visible pixels";
+                    for (int attempt = 0; attempt <= maxRetries; attempt++)
+                    {
+                        yield return null;
+                        yield return new WaitForEndOfFrame();
+
+                        GeneratedIconAttemptResult result =
+                            TryGenerateIcon(
+                                request,
+                                out Sprite? icon,
+                                out Texture2D? texture,
+                                out lastError);
+                        if (result == GeneratedIconAttemptResult.Success)
+                        {
+                            request.Product.Definition.Icon = icon;
+                            state.GeneratedObjects.Add(texture!);
+                            state.GeneratedObjects.Add(icon!);
+                            state.IsGeneratedIconPending = false;
+                            MelonLogger.Msg(
+                                $"[ProductPresentationProfile] Generated loose icon for " +
+                                $"'{request.Product.ProductId}' after {attempt + 1} render attempt(s).");
+                            break;
+                        }
+
+                        if (result == GeneratedIconAttemptResult.Failure)
+                            break;
+                    }
+
+                    if (state.IsGeneratedIconPending)
+                        LogGeneratedIconFailure(request, lastError);
+                }
+                finally
+                {
+                    state.IsGeneratedIconQueued = false;
+                    if (state.IsGeneratedIconPending &&
+                        state.AppliedRegistration != null &&
+                        !ReferenceEquals(
+                            state.AppliedRegistration,
+                            request.Registration))
+                    {
+                        QueuePendingGeneratedIcon(
+                            request.Product,
+                            state.AppliedRegistration,
+                            state);
+                    }
+                }
+            }
+        }
+
+        private static GeneratedIconAttemptResult TryGenerateIcon(
+            GeneratedIconRequest request,
+            out Sprite? icon,
+            out Texture2D? texture,
+            out string error)
+        {
+            icon = null;
+            texture = null;
+            ProductPresentationProfile profile = request.Registration.Profile;
+            if (!profile.TryGetVisualProvider(
+                    ProductPresentationContext.Loose,
+                    out Func<GameObject?>? provider) ||
+                provider == null)
+            {
+                error = "no loose visual provider was configured";
+                return GeneratedIconAttemptResult.Failure;
+            }
+
+            GameObject? source;
+            try
+            {
+                source = provider();
+            }
+            catch (Exception exception)
+            {
+                error = $"the loose visual provider failed: {exception.Message}";
+                return GeneratedIconAttemptResult.Failure;
+            }
+
+            if (source == null)
+            {
+                error = "the loose visual provider returned null";
+                return GeneratedIconAttemptResult.Failure;
+            }
+
+            GameObject model = Object.Instantiate(source);
+            try
+            {
+                ApplyVisualTransform(
+                    model.transform,
+                    profile,
+                    ProductPresentationContext.Loose);
+                texture =
+                    IconFactory.GenerateIcon(
+                        model.transform,
+                        profile.GeneratedIconSize,
+                        bakeSkinnedMeshes: true,
+                        fitToCamera: profile.FitGeneratedIconToCamera,
+                        cameraFill: profile.GeneratedIconCameraFill);
+            }
+            finally
+            {
+                Object.Destroy(model);
+            }
+
+            if (texture == null)
+            {
+                error = "the native renderer returned no visible pixels";
+                return GeneratedIconAttemptResult.Retry;
+            }
+
+            icon = global::S1API.Utils.ImageUtils.TextureToSprite(texture);
+            if (icon != null)
+            {
+                error = string.Empty;
+                return GeneratedIconAttemptResult.Success;
+            }
+
+            Object.Destroy(texture);
+            texture = null;
+            error = "the generated texture could not be converted to a sprite";
+            return GeneratedIconAttemptResult.Failure;
+        }
+
+        private static void LogGeneratedIconFailure(
+            GeneratedIconRequest request,
+            string reason)
+        {
+            string message =
+                $"Product presentation context 'Icon' for " +
+                $"'{request.Product.ProductId}' could not be applied because {reason}.";
+            if (request.Registration.Profile.IsRequired(
+                    ProductPresentationContext.Icon))
+            {
+                MelonLogger.Error($"[ProductPresentationProfile] {message}");
+            }
+            else
+            {
+                MelonLogger.Warning(
+                    $"[ProductPresentationProfile] {message} " +
+                    "Preserving the template fallback.");
+            }
+        }
+
+        private static S1Product.ProductConsumeAnimation? BuildConsumption(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            List<Object> created,
+            S1Product.ProductConsumeAnimation? fallback)
+        {
+            if (profile.ConsumptionPrefabProvider == null)
+            {
+                return MissingProvider(
+                    product,
+                    profile,
+                    ProductPresentationContext.Consumption,
+                    "no consumption prefab provider was configured",
+                    fallback);
+            }
+
+            GameObject? source;
+            try
+            {
+                source = profile.ConsumptionPrefabProvider();
+            }
+            catch (Exception exception)
+            {
+                return ProviderFailed(
+                    product,
+                    profile,
+                    ProductPresentationContext.Consumption,
+                    exception.Message,
+                    fallback);
+            }
+
+            if (source == null)
+            {
+                return ProviderFailed(
+                    product,
+                    profile,
+                    ProductPresentationContext.Consumption,
+                    "returned null",
+                    fallback);
+            }
+
+            GameObject clone =
+                Object.Instantiate(source, GetCacheRoot().transform);
+            PrepareCachedPrefab(clone);
+            created.Add(clone);
+            S1Product.ProductConsumeAnimation? animation =
+                clone.GetComponent<S1Product.ProductConsumeAnimation>();
+            if (animation != null)
+                return animation;
+
+            created.Remove(clone);
+            Object.Destroy(clone);
+            return RequireOrFallback(
+                product,
+                profile,
+                ProductPresentationContext.Consumption,
+                "the supplied prefab does not contain ProductConsumeAnimation",
+                fallback);
+        }
+
+        private static GameObject? GetVisualSource(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            Dictionary<Func<GameObject?>, GameObject?> sources)
+        {
+            if (!profile.TryGetVisualProvider(context, out Func<GameObject?>? provider) ||
+                provider == null)
+            {
+                return MissingProvider<GameObject?>(
+                    product,
+                    profile,
+                    context,
+                    "no visual provider or loose-visual fallback was configured",
+                    null);
+            }
+
+            if (sources.TryGetValue(provider, out GameObject? retained))
+            {
+                return retained ??
+                       ProviderFailed<GameObject?>(
+                           product,
+                           profile,
+                           context,
+                           "returned null or failed during an earlier context",
+                           null);
+            }
+
+            try
+            {
+                GameObject? source = provider();
+                sources.Add(provider, source);
+                if (source != null)
+                    return source;
+                return ProviderFailed<GameObject?>(
+                    product,
+                    profile,
+                    context,
+                    "returned null",
+                    null);
+            }
+            catch (Exception exception)
+            {
+                sources.Add(provider, null);
+                return ProviderFailed<GameObject?>(
+                    product,
+                    profile,
+                    context,
+                    exception.Message,
+                    null);
+            }
+        }
+
+        private static StaticProductVisualsSetter ReplaceVisual(
+            GameObject scaffold,
+            S1Product.ProductVisualsSetter oldSetter,
+            GameObject source,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context)
+        {
+            Transform parent =
+                oldSetter != null && oldSetter.VisualsContainer != null &&
+                oldSetter.VisualsContainer != scaffold.transform
+                    ? oldSetter.VisualsContainer.parent
+                    : scaffold.transform;
+
+            if (oldSetter != null &&
+                oldSetter.VisualsContainer != null &&
+                oldSetter.VisualsContainer != scaffold.transform)
+            {
+                oldSetter.VisualsContainer.gameObject.SetActive(false);
+            }
+
+            GameObject visual = Object.Instantiate(source);
+            visual.transform.SetParent(parent, false);
+            ApplyVisualTransform(visual.transform, profile, context);
+            visual.SetActive(true);
+
+            StaticProductVisualsSetter setter =
+                scaffold.AddComponent<StaticProductVisualsSetter>();
+            setter.VisualsContainer = visual.transform;
+            return setter;
+        }
+
+        private static S1AvatarEquipping.AvatarEquippable BuildAvatarEquippable(
+            CustomProductDefinitionRegistration product,
+            S1AvatarEquipping.AvatarEquippable template,
+            GameObject source,
+            ProductPresentationProfile profile,
+            List<Object> created)
+        {
+            var root =
+                new GameObject(
+                    $"{product.ProductId} Held Avatar Presentation");
+            root.transform.SetParent(GetCacheRoot().transform, false);
+            PrepareCachedPrefab(root);
+            created.Add(root);
+            GameObject visual = Object.Instantiate(source);
+            visual.transform.SetParent(root.transform, false);
+            ApplyVisualTransform(
+                visual.transform,
+                profile,
+                ProductPresentationContext.Held);
+
+            S1AvatarEquipping.AvatarEquippable avatar =
+                root.AddComponent<S1AvatarEquipping.AvatarEquippable>();
+            avatar.AlignmentPoint = root.transform;
+            if (template != null)
+            {
+                avatar.Suspiciousness = template.Suspiciousness;
+                avatar.Hand = template.Hand;
+                avatar.TriggerType = template.TriggerType;
+                avatar.AnimationTrigger = template.AnimationTrigger;
+            }
+
+            string assetPath =
+                $"S1API/ProductPresentation/{product.ProductId}/Held";
+            avatar.AssetPath = assetPath;
+            if (!AvatarEquippableRegistry.RegisterAvatarEquippable(assetPath, root))
+            {
+                throw new InvalidOperationException(
+                    $"Could not register third-person held presentation path '{assetPath}'.");
+            }
+
+            return avatar;
+        }
+
+        private static void ApplyVisualTransform(
+            Transform target,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context)
+        {
+            if (profile.TryGetVisualTransform(
+                    context,
+                    out ProductPresentationTransform? presentationTransform))
+            {
+                presentationTransform?.ApplyTo(target);
+            }
+        }
+
+        private static GameObject GetCacheRoot()
+        {
+            if (_cacheRoot != null)
+                return _cacheRoot;
+
+            var root = new GameObject("S1API_ProductPresentationCache");
+            root.hideFlags = HideFlags.HideAndDontSave;
+            root.transform.position = new Vector3(0f, -10000f, 0f);
+            Object.DontDestroyOnLoad(root);
+            _cacheRoot = root;
+            return root;
+        }
+
+        private static void PrepareCachedPrefab(GameObject prefab)
+        {
+            prefab.hideFlags = HideFlags.HideAndDontSave;
+        }
+
+        private static void EnsureCollider(GameObject visual)
+        {
+            if (visual.GetComponentInChildren<Collider>(true) != null)
+                return;
+
+            Renderer[] renderers =
+                visual.GetComponentsInChildren<Renderer>(true);
+            if (renderers.Length == 0)
+                return;
+
+            Bounds bounds = new Bounds(
+                visual.transform.InverseTransformPoint(renderers[0].bounds.center),
+                Vector3.zero);
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                Bounds rendererBounds = renderers[i].bounds;
+                Vector3 min = rendererBounds.min;
+                Vector3 max = rendererBounds.max;
+                for (int x = 0; x <= 1; x++)
+                {
+                    for (int y = 0; y <= 1; y++)
+                    {
+                        for (int z = 0; z <= 1; z++)
+                        {
+                            bounds.Encapsulate(
+                                visual.transform.InverseTransformPoint(
+                                    new Vector3(
+                                        x == 0 ? min.x : max.x,
+                                        y == 0 ? min.y : max.y,
+                                        z == 0 ? min.z : max.z)));
+                        }
+                    }
+                }
+            }
+
+            BoxCollider collider = visual.AddComponent<BoxCollider>();
+            collider.center = bounds.center;
+            collider.size = bounds.size;
+        }
+
+        private static T MissingScaffold<T>(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            T fallback)
+        {
+            return RequireOrFallback(
+                product,
+                profile,
+                context,
+                "the representation template does not provide the required native scaffold",
+                fallback);
+        }
+
+        private static T InvalidScaffold<T>(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            Component clone,
+            T fallback,
+            List<Object> created,
+            string requiredComponent)
+        {
+            created.Remove(clone.gameObject);
+            Object.Destroy(clone.gameObject);
+            return RequireOrFallback(
+                product,
+                profile,
+                context,
+                $"the template scaffold does not contain {requiredComponent}",
+                fallback);
+        }
+
+        private static T ProviderFailed<T>(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            string reason,
+            T fallback)
+        {
+            return RequireOrFallback(
+                product,
+                profile,
+                context,
+                $"the provider failed: {reason}",
+                fallback);
+        }
+
+        private static T MissingProvider<T>(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            string reason,
+            T fallback)
+        {
+            if (profile.IsRequired(context))
+            {
+                throw new InvalidOperationException(
+                    $"Product presentation context '{context}' for '{product.ProductId}' could " +
+                    $"not be applied because {reason}.");
+            }
+
+            return fallback;
+        }
+
+        private static T RequireOrFallback<T>(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context,
+            string reason,
+            T fallback)
+        {
+            string message =
+                $"Product presentation context '{context}' for '{product.ProductId}' could not " +
+                $"be applied because {reason}.";
+            if (profile.IsRequired(context))
+                throw new InvalidOperationException(message);
+
+            MelonLogger.Warning(
+                $"[ProductPresentationProfile] {message} Preserving the template fallback.");
+            return fallback;
+        }
+
+        private static void RestoreBaseline(
+            CustomProductDefinitionRegistration product)
+        {
+            CustomProductPresentationState state =
+                product.PresentationState ??
+                throw new InvalidOperationException(
+                    "Presentation state was not initialized.");
+            S1Product.ProductDefinition definition = product.Definition;
+            definition.Icon = state.BaselineIcon;
+            definition.StoredItem = state.BaselineStoredItem;
+            definition.Equippable = state.BaselineEquippable;
+            definition.StationItem = state.BaselineStationItem;
+            definition.FunctionalProduct = state.BaselineFunctionalProduct;
+            definition.ConsumeAnimation = state.BaselineConsumeAnimation;
+            DestroyAll(state.GeneratedObjects);
+            state.GeneratedObjects = new List<Object>();
+            state.AppliedRegistration = null;
+            state.IsGeneratedIconPending = false;
+        }
+
+        private static bool GeneratedObjectsAreAlive(IReadOnlyList<Object> objects)
+        {
+            for (int i = 0; i < objects.Count; i++)
+            {
+                if (objects[i] == null)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static void DestroyAll(IReadOnlyList<Object> objects)
+        {
+            for (int i = 0; i < objects.Count; i++)
+            {
+                if (objects[i] != null)
+                    Object.Destroy(objects[i]);
+            }
+        }
+
+        private static bool AreSameUnityObject(Object? left, Object? right)
+        {
+            return ReferenceEquals(left, right) ||
+                   (left != null && right != null && left == right);
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -117,6 +117,7 @@ namespace S1API.Internal.Products
             var functional = state.BaselineFunctionalProduct;
             var icon = state.BaselineIcon;
             var consumption = state.BaselineConsumeAnimation;
+            GameObject? registeredAvatarPrefab = null;
             bool generatedIconPending = false;
 
             try
@@ -127,12 +128,6 @@ namespace S1API.Internal.Products
                     sources,
                     created,
                     state.BaselineStoredItem);
-                held = BuildHeld(
-                    product,
-                    profile,
-                    sources,
-                    created,
-                    state.BaselineEquippable);
                 station = BuildStation(
                     product,
                     profile,
@@ -159,6 +154,13 @@ namespace S1API.Internal.Products
                         profile,
                         created,
                         state.BaselineConsumeAnimation);
+                held = BuildHeld(
+                    product,
+                    profile,
+                    sources,
+                    created,
+                    state.BaselineEquippable,
+                    out registeredAvatarPrefab);
             }
             catch
             {
@@ -175,7 +177,9 @@ namespace S1API.Internal.Products
             definition.ConsumeAnimation = consumption;
 
             List<Object> previous = state.GeneratedObjects;
+            UnregisterHeldAvatar(product, state);
             state.GeneratedObjects = created;
+            state.RegisteredAvatarPrefab = registeredAvatarPrefab;
             state.AppliedRegistration = registration;
             state.IsGeneratedIconPending = generatedIconPending;
             DestroyAll(previous);
@@ -231,8 +235,10 @@ namespace S1API.Internal.Products
             ProductPresentationProfile profile,
             Dictionary<Func<GameObject?>, GameObject?> sources,
             List<Object> created,
-            S1Equipping.Equippable? fallback)
+            S1Equipping.Equippable? fallback,
+            out GameObject? registeredAvatarPrefab)
         {
+            registeredAvatarPrefab = null;
             GameObject? source =
                 GetVisualSource(
                     product,
@@ -275,6 +281,7 @@ namespace S1API.Internal.Products
                     source,
                     profile,
                     created);
+            registeredAvatarPrefab = held.AvatarEquippable.gameObject;
             return clone;
         }
 
@@ -1006,10 +1013,26 @@ namespace S1API.Internal.Products
             definition.StationItem = state.BaselineStationItem;
             definition.FunctionalProduct = state.BaselineFunctionalProduct;
             definition.ConsumeAnimation = state.BaselineConsumeAnimation;
+            UnregisterHeldAvatar(product, state);
             DestroyAll(state.GeneratedObjects);
             state.GeneratedObjects = new List<Object>();
+            state.RegisteredAvatarPrefab = null;
             state.AppliedRegistration = null;
             state.IsGeneratedIconPending = false;
+        }
+
+        private static void UnregisterHeldAvatar(
+            CustomProductDefinitionRegistration product,
+            CustomProductPresentationState state)
+        {
+            if (state.RegisteredAvatarPrefab == null)
+                return;
+
+            string assetPath =
+                $"S1API/ProductPresentation/{product.ProductId}/Held";
+            RuntimeResourceRegistry.UnregisterAssetIfMatches(
+                assetPath,
+                state.RegisteredAvatarPrefab);
         }
 
         private static bool GeneratedObjectsAreAlive(IReadOnlyList<Object> objects)
@@ -1032,10 +1055,5 @@ namespace S1API.Internal.Products
             }
         }
 
-        private static bool AreSameUnityObject(Object? left, Object? right)
-        {
-            return ReferenceEquals(left, right) ||
-                   (left != null && right != null && left == right);
-        }
     }
 }

--- a/S1API/Internal/Products/CustomProductPresentationState.cs
+++ b/S1API/Internal/Products/CustomProductPresentationState.cs
@@ -1,0 +1,58 @@
+#if IL2CPPMELON
+using S1Equipping = Il2CppScheduleOne.Equipping;
+using S1Product = Il2CppScheduleOne.Product;
+using S1Station = Il2CppScheduleOne.StationFramework;
+using S1Storage = Il2CppScheduleOne.Storage;
+#elif MONOMELON
+using S1Equipping = ScheduleOne.Equipping;
+using S1Product = ScheduleOne.Product;
+using S1Station = ScheduleOne.StationFramework;
+using S1Storage = ScheduleOne.Storage;
+#endif
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Retains immutable template references and generated presentation objects.
+    /// </summary>
+    internal sealed class CustomProductPresentationState
+    {
+        internal CustomProductPresentationState(
+            S1Product.ProductDefinition definition,
+            CustomProductDefinitionMetadata? metadata)
+        {
+            BaselineIcon = definition.Icon;
+            BaselineStoredItem = definition.StoredItem;
+            BaselineEquippable = definition.Equippable;
+            BaselineStationItem = definition.StationItem;
+            BaselineFunctionalProduct = definition.FunctionalProduct;
+            BaselineConsumeAnimation = definition.ConsumeAnimation;
+            TemplateStationItem = metadata?.RepresentationTemplate?.StationItem;
+        }
+
+        internal Sprite? BaselineIcon { get; }
+
+        internal S1Storage.StoredItem? BaselineStoredItem { get; }
+
+        internal S1Equipping.Equippable? BaselineEquippable { get; }
+
+        internal S1Station.StationItem? BaselineStationItem { get; }
+
+        internal S1Station.StationItem? TemplateStationItem { get; }
+
+        internal S1Product.FunctionalProduct? BaselineFunctionalProduct { get; }
+
+        internal S1Product.ProductConsumeAnimation? BaselineConsumeAnimation { get; }
+
+        internal ProductPresentationProfileRegistration? AppliedRegistration { get; set; }
+
+        internal bool IsGeneratedIconPending { get; set; }
+
+        internal bool IsGeneratedIconQueued { get; set; }
+
+        internal List<Object> GeneratedObjects { get; set; } = new List<Object>();
+    }
+}

--- a/S1API/Internal/Products/CustomProductPresentationState.cs
+++ b/S1API/Internal/Products/CustomProductPresentationState.cs
@@ -53,6 +53,8 @@ namespace S1API.Internal.Products
 
         internal bool IsGeneratedIconQueued { get; set; }
 
+        internal GameObject? RegisteredAvatarPrefab { get; set; }
+
         internal List<Object> GeneratedObjects { get; set; } = new List<Object>();
     }
 }

--- a/S1API/Internal/Products/ICustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/ICustomProductPresentationRuntime.cs
@@ -1,0 +1,12 @@
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Applies one resolved presentation profile to a retained custom product.
+    /// </summary>
+    internal interface ICustomProductPresentationRuntime
+    {
+        void Apply(
+            CustomProductDefinitionRegistration product,
+            ProductPresentationProfileRegistration? profile);
+    }
+}

--- a/S1API/Internal/Products/ProductPresentationProfileRegistration.cs
+++ b/S1API/Internal/Products/ProductPresentationProfileRegistration.cs
@@ -1,0 +1,26 @@
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Records one owned presentation-profile registration.
+    /// </summary>
+    internal sealed class ProductPresentationProfileRegistration
+    {
+        internal ProductPresentationProfileRegistration(
+            string ownerId,
+            string key,
+            ProductPresentationProfile profile)
+        {
+            OwnerId = ownerId;
+            Key = key;
+            Profile = profile;
+        }
+
+        internal string OwnerId { get; }
+
+        internal string Key { get; }
+
+        internal ProductPresentationProfile Profile { get; }
+    }
+}

--- a/S1API/Internal/Products/StaticProductVisualsSetter.cs
+++ b/S1API/Internal/Products/StaticProductVisualsSetter.cs
@@ -1,0 +1,43 @@
+#if IL2CPPMELON
+using Il2CppInterop.Runtime.Attributes;
+using Il2CppInterop.Runtime.Injection;
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+#endif
+
+using System;
+using MelonLoader;
+using UnityEngine;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Activates a profile-supplied static visual without native-family casts.
+    /// </summary>
+#if IL2CPPMELON
+    [RegisterTypeInIl2Cpp]
+#endif
+    internal sealed class StaticProductVisualsSetter : S1Product.ProductVisualsSetter
+    {
+#if IL2CPPMELON
+        public StaticProductVisualsSetter(IntPtr pointer)
+            : base(pointer)
+        {
+        }
+
+        public StaticProductVisualsSetter()
+            : base(ClassInjector.DerivedConstructorPointer<StaticProductVisualsSetter>())
+        {
+            ClassInjector.DerivedConstructorBody(this);
+        }
+#endif
+
+        /// <inheritdoc />
+        public override void ApplyVisuals(S1Product.ProductDefinition productDefinition)
+        {
+            if (VisualsContainer != null)
+                VisualsContainer.gameObject.SetActive(true);
+        }
+    }
+}

--- a/S1API/Products/CustomProductDefinitionBuilder.cs
+++ b/S1API/Products/CustomProductDefinitionBuilder.cs
@@ -28,10 +28,13 @@ namespace S1API.Products
     /// </para>
     /// <para>
     /// Presentation references are borrowed from an existing product through
-    /// <see cref="WithRepresentationsFrom(ProductDefinition)"/>. Custom presentation providers,
-    /// packaged-content visuals, product-manager UI tabs, station recipes, and mixing are outside
-    /// this builder's scope. Register the same definition before save-item restoration on every
-    /// participating peer; the game cannot restore or transmit a definition supplied by a missing mod.
+    /// <see cref="WithRepresentationsFrom(ProductDefinition)"/>. A registered
+    /// <see cref="ProductPresentationProfile"/> may replace the generic product's loose presentation
+    /// contexts while preserving the borrowed native scaffolds. Packaged-content visuals,
+    /// product-manager UI tabs, station recipes, and mixing remain outside this builder's scope.
+    /// Register the same definition and presentation profile before save-item restoration on every
+    /// participating peer; the game cannot restore or transmit definitions or assets supplied by a
+    /// missing mod.
     /// </para>
     /// </remarks>
     public sealed class CustomProductDefinitionBuilder
@@ -397,7 +400,8 @@ namespace S1API.Products
             var metadata = new CustomProductDefinitionMetadata(
                 _productKind,
                 _defaultQuality,
-                packagingSnapshot);
+                packagingSnapshot,
+                _representationTemplate.S1ProductDefinition);
             RegisterCreatedDefinition(
                 _ownerId,
                 _id,

--- a/S1API/Products/ProductPresentationContext.cs
+++ b/S1API/Products/ProductPresentationContext.cs
@@ -1,0 +1,43 @@
+namespace S1API.Products
+{
+    /// <summary>
+    /// Identifies a custom product presentation context.
+    /// </summary>
+    public enum ProductPresentationContext
+    {
+        /// <summary>
+        /// The shared loose visual used as the default source for rendered contexts.
+        /// </summary>
+        Loose = 0,
+
+        /// <summary>
+        /// The product while placed in storage.
+        /// </summary>
+        Stored = 1,
+
+        /// <summary>
+        /// The product while equipped in first or third person.
+        /// </summary>
+        Held = 2,
+
+        /// <summary>
+        /// The product while placed in a compatible station slot.
+        /// </summary>
+        Station = 3,
+
+        /// <summary>
+        /// The draggable product used by functional station interactions.
+        /// </summary>
+        FunctionalProduct = 4,
+
+        /// <summary>
+        /// The loose inventory icon.
+        /// </summary>
+        Icon = 5,
+
+        /// <summary>
+        /// The product consumption animation prefab.
+        /// </summary>
+        Consumption = 6
+    }
+}

--- a/S1API/Products/ProductPresentationProfile.cs
+++ b/S1API/Products/ProductPresentationProfile.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Describes the mod-owned presentation sources for a custom product.
+    /// </summary>
+    /// <remarks>
+    /// Providers return reusable prefab sources. S1API clones returned objects before attaching
+    /// them to native presentation scaffolds. The profile does not transmit assets to other peers;
+    /// every participating peer must register the same profile locally.
+    /// </remarks>
+    public sealed class ProductPresentationProfile
+    {
+        internal ProductPresentationProfile(
+            IReadOnlyDictionary<ProductPresentationContext, Func<GameObject?>>
+                visualProviders,
+            IReadOnlyDictionary<ProductPresentationContext, ProductPresentationTransform>
+                visualTransforms,
+            Func<Sprite?>? iconProvider,
+            Func<GameObject?>? consumptionPrefabProvider,
+            bool generateIconFromLooseVisual,
+            int generatedIconSize,
+            bool fitGeneratedIconToCamera,
+            float generatedIconCameraFill,
+            IReadOnlyCollection<ProductPresentationContext> requiredContexts)
+        {
+            VisualProviders = visualProviders;
+            VisualTransforms = visualTransforms;
+            IconProvider = iconProvider;
+            ConsumptionPrefabProvider = consumptionPrefabProvider;
+            GenerateIconFromLooseVisual = generateIconFromLooseVisual;
+            GeneratedIconSize = generatedIconSize;
+            FitGeneratedIconToCamera = fitGeneratedIconToCamera;
+            GeneratedIconCameraFill = generatedIconCameraFill;
+            RequiredContexts = requiredContexts;
+        }
+
+        internal IReadOnlyDictionary<ProductPresentationContext, Func<GameObject?>>
+            VisualProviders { get; }
+
+        internal IReadOnlyDictionary<
+            ProductPresentationContext,
+            ProductPresentationTransform> VisualTransforms { get; }
+
+        internal Func<Sprite?>? IconProvider { get; }
+
+        internal Func<GameObject?>? ConsumptionPrefabProvider { get; }
+
+        internal bool GenerateIconFromLooseVisual { get; }
+
+        internal int GeneratedIconSize { get; }
+
+        internal bool FitGeneratedIconToCamera { get; }
+
+        internal float GeneratedIconCameraFill { get; }
+
+        internal IReadOnlyCollection<ProductPresentationContext> RequiredContexts { get; }
+
+        internal bool IsRequired(ProductPresentationContext context)
+        {
+            foreach (ProductPresentationContext required in RequiredContexts)
+            {
+                if (required == context)
+                    return true;
+            }
+
+            return false;
+        }
+
+        internal bool TryGetVisualProvider(
+            ProductPresentationContext context,
+            out Func<GameObject?>? provider)
+        {
+            if (VisualProviders.TryGetValue(context, out provider))
+                return true;
+
+            if (context != ProductPresentationContext.Loose &&
+                VisualProviders.TryGetValue(
+                    ProductPresentationContext.Loose,
+                    out provider))
+            {
+                return true;
+            }
+
+            provider = null;
+            return false;
+        }
+
+        internal bool TryGetVisualTransform(
+            ProductPresentationContext context,
+            out ProductPresentationTransform? presentationTransform)
+        {
+            if (VisualTransforms.TryGetValue(context, out presentationTransform))
+                return true;
+
+            if (context != ProductPresentationContext.Loose &&
+                !VisualProviders.ContainsKey(context) &&
+                VisualTransforms.TryGetValue(
+                    ProductPresentationContext.Loose,
+                    out presentationTransform))
+            {
+                return true;
+            }
+
+            presentationTransform = null;
+            return false;
+        }
+    }
+}

--- a/S1API/Products/ProductPresentationProfileBuilder.cs
+++ b/S1API/Products/ProductPresentationProfileBuilder.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Builds an immutable custom product presentation profile.
+    /// </summary>
+    public sealed class ProductPresentationProfileBuilder
+    {
+        private readonly Dictionary<ProductPresentationContext, Func<GameObject?>>
+            _visualProviders =
+                new Dictionary<ProductPresentationContext, Func<GameObject?>>();
+        private readonly HashSet<ProductPresentationContext> _requiredContexts =
+            new HashSet<ProductPresentationContext>();
+        private readonly Dictionary<
+            ProductPresentationContext,
+            ProductPresentationTransform> _visualTransforms =
+                new Dictionary<
+                    ProductPresentationContext,
+                    ProductPresentationTransform>();
+
+        private Func<Sprite?>? _iconProvider;
+        private Func<GameObject?>? _consumptionPrefabProvider;
+        private bool _generateIconFromLooseVisual;
+        private int _generatedIconSize = 512;
+        private bool _fitGeneratedIconToCamera = true;
+        private float _generatedIconCameraFill = 0.72f;
+
+        /// <summary>
+        /// Sets the shared loose visual provider. Stored, held, station, and functional-product
+        /// contexts use this provider when they do not define a context-specific visual.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithLooseVisual(
+            Func<GameObject?> provider)
+        {
+            return SetVisualProvider(ProductPresentationContext.Loose, provider);
+        }
+
+        /// <summary>
+        /// Sets the shared loose visual provider and an explicit local transform override.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <param name="presentationTransform">The cloned visual root transform.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithLooseVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.Loose,
+                provider,
+                presentationTransform);
+        }
+
+        /// <summary>
+        /// Sets the stored-item visual provider.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithStoredVisual(
+            Func<GameObject?> provider)
+        {
+            return SetVisualProvider(ProductPresentationContext.Stored, provider);
+        }
+
+        /// <summary>
+        /// Sets the stored-item visual provider and an explicit local transform override.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <param name="presentationTransform">The cloned visual root transform.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithStoredVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.Stored,
+                provider,
+                presentationTransform);
+        }
+
+        /// <summary>
+        /// Sets the first- and third-person held visual provider.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithHeldVisual(
+            Func<GameObject?> provider)
+        {
+            return SetVisualProvider(ProductPresentationContext.Held, provider);
+        }
+
+        /// <summary>
+        /// Sets the held visual provider and an explicit local transform override.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <param name="presentationTransform">The cloned visual root transform.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithHeldVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.Held,
+                provider,
+                presentationTransform);
+        }
+
+        /// <summary>
+        /// Sets the station-item visual provider.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithStationVisual(
+            Func<GameObject?> provider)
+        {
+            return SetVisualProvider(ProductPresentationContext.Station, provider);
+        }
+
+        /// <summary>
+        /// Sets the station-item visual provider and an explicit local transform override.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <param name="presentationTransform">The cloned visual root transform.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithStationVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.Station,
+                provider,
+                presentationTransform);
+        }
+
+        /// <summary>
+        /// Sets the functional-product visual provider.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithFunctionalProductVisual(
+            Func<GameObject?> provider)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.FunctionalProduct,
+                provider);
+        }
+
+        /// <summary>
+        /// Sets the functional-product visual provider and an explicit local transform override.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned visual prefab source.</param>
+        /// <param name="presentationTransform">The cloned visual root transform.</param>
+        /// <returns>This builder.</returns>
+        public ProductPresentationProfileBuilder WithFunctionalProductVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            return SetVisualProvider(
+                ProductPresentationContext.FunctionalProduct,
+                provider,
+                presentationTransform);
+        }
+
+        /// <summary>
+        /// Sets an explicit loose inventory icon provider.
+        /// </summary>
+        /// <param name="provider">A provider that returns a mod-owned sprite.</param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="provider"/> is <see langword="null"/>.
+        /// </exception>
+        public ProductPresentationProfileBuilder WithIcon(Func<Sprite?> provider)
+        {
+            _iconProvider =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            _generateIconFromLooseVisual = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Generates the loose inventory icon from the loose visual through the game's
+        /// item-icon rendering rig exposed by <see cref="Rendering.IconFactory"/>.
+        /// </summary>
+        /// <param name="size">The square icon size, from 32 through 2048 pixels.</param>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// S1API keeps the representation template's icon while it queues capture. The queue
+        /// waits for the native rig, yields through a complete render frame, rejects transparent
+        /// cold-start captures, and finishes while the loading screen is still open.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="size"/> is outside 32 through 2048.
+        /// </exception>
+        public ProductPresentationProfileBuilder WithGeneratedIconFromLooseVisual(
+            int size = 512)
+        {
+            return ConfigureGeneratedIcon(
+                size,
+                fitToCamera: true,
+                cameraFill: 0.72f);
+        }
+
+        /// <summary>
+        /// Generates the loose inventory icon with explicit native-camera framing controls.
+        /// </summary>
+        /// <param name="size">The square icon size, from 32 through 2048 pixels.</param>
+        /// <param name="fitToCamera">
+        /// Whether S1API should fit renderer bounds to the native fixed thumbnail camera.
+        /// Set false to preserve the provider's authored scale.
+        /// </param>
+        /// <param name="cameraFill">
+        /// The target share of the native camera's vertical view when fitting, greater than
+        /// zero through 2. Values above 1 intentionally crop the model.
+        /// </param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="size"/> is outside 32 through 2048 or
+        /// <paramref name="cameraFill"/> is not greater than zero through 2.
+        /// </exception>
+        public ProductPresentationProfileBuilder WithGeneratedIconFromLooseVisual(
+            int size,
+            bool fitToCamera,
+            float cameraFill = 0.72f)
+        {
+            return ConfigureGeneratedIcon(size, fitToCamera, cameraFill);
+        }
+
+        /// <summary>
+        /// Sets the consumption prefab provider.
+        /// </summary>
+        /// <param name="provider">
+        /// A provider that returns a prefab source containing the game's
+        /// <c>ProductConsumeAnimation</c> component.
+        /// </param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="provider"/> is <see langword="null"/>.
+        /// </exception>
+        public ProductPresentationProfileBuilder WithConsumptionPrefab(
+            Func<GameObject?> provider)
+        {
+            _consumptionPrefabProvider =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            return this;
+        }
+
+        /// <summary>
+        /// Marks contexts as required. A missing provider, missing native scaffold, null result,
+        /// or provider failure then produces a clear registration error instead of falling back.
+        /// </summary>
+        /// <param name="contexts">Defined presentation contexts to require.</param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="contexts"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when a context is not a defined <see cref="ProductPresentationContext"/> value.
+        /// </exception>
+        public ProductPresentationProfileBuilder Require(
+            params ProductPresentationContext[] contexts)
+        {
+            if (contexts == null)
+                throw new ArgumentNullException(nameof(contexts));
+
+            for (int i = 0; i < contexts.Length; i++)
+            {
+                ProductPresentationContext context = contexts[i];
+                if (!Enum.IsDefined(typeof(ProductPresentationContext), context))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(contexts),
+                        context,
+                        "Presentation contexts must be defined values.");
+                }
+
+                _requiredContexts.Add(context);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an immutable presentation profile snapshot.
+        /// </summary>
+        /// <returns>The presentation profile.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when a required context has no configured provider or loose-visual fallback.
+        /// </exception>
+        public ProductPresentationProfile Build()
+        {
+            ValidateRequiredProviders();
+
+            return new ProductPresentationProfile(
+                new Dictionary<ProductPresentationContext, Func<GameObject?>>(
+                    _visualProviders),
+                new Dictionary<
+                    ProductPresentationContext,
+                    ProductPresentationTransform>(_visualTransforms),
+                _iconProvider,
+                _consumptionPrefabProvider,
+                _generateIconFromLooseVisual,
+                _generatedIconSize,
+                _fitGeneratedIconToCamera,
+                _generatedIconCameraFill,
+                new List<ProductPresentationContext>(_requiredContexts).AsReadOnly());
+        }
+
+        private ProductPresentationProfileBuilder SetVisualProvider(
+            ProductPresentationContext context,
+            Func<GameObject?> provider)
+        {
+            _visualProviders[context] =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            _visualTransforms.Remove(context);
+            return this;
+        }
+
+        private ProductPresentationProfileBuilder SetVisualProvider(
+            ProductPresentationContext context,
+            Func<GameObject?> provider,
+            ProductPresentationTransform presentationTransform)
+        {
+            _visualProviders[context] =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            _visualTransforms[context] =
+                presentationTransform ??
+                throw new ArgumentNullException(nameof(presentationTransform));
+            return this;
+        }
+
+        private ProductPresentationProfileBuilder ConfigureGeneratedIcon(
+            int size,
+            bool fitToCamera,
+            float cameraFill)
+        {
+            if (size < 32 || size > 2048)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(size),
+                    size,
+                    "Generated icon size must be between 32 and 2048 pixels.");
+            }
+
+            if (cameraFill <= 0f || cameraFill > 2f)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(cameraFill),
+                    cameraFill,
+                    "Generated icon camera fill must be greater than zero and at most 2.");
+            }
+
+            _iconProvider = null;
+            _generateIconFromLooseVisual = true;
+            _generatedIconSize = size;
+            _fitGeneratedIconToCamera = fitToCamera;
+            _generatedIconCameraFill = cameraFill;
+            return this;
+        }
+
+        private void ValidateRequiredProviders()
+        {
+            foreach (ProductPresentationContext context in _requiredContexts)
+            {
+                bool configured;
+                switch (context)
+                {
+                    case ProductPresentationContext.Icon:
+                        configured =
+                            _iconProvider != null ||
+                            (_generateIconFromLooseVisual &&
+                             _visualProviders.ContainsKey(
+                                 ProductPresentationContext.Loose));
+                        break;
+                    case ProductPresentationContext.Consumption:
+                        configured = _consumptionPrefabProvider != null;
+                        break;
+                    default:
+                        configured =
+                            _visualProviders.ContainsKey(context) ||
+                            (context != ProductPresentationContext.Loose &&
+                             _visualProviders.ContainsKey(
+                                 ProductPresentationContext.Loose));
+                        break;
+                }
+
+                if (!configured)
+                {
+                    throw new InvalidOperationException(
+                        $"Required presentation context '{context}' does not have a provider. " +
+                        "Configure that context or a supported loose-visual fallback before Build().");
+                }
+            }
+        }
+    }
+}

--- a/S1API/Products/ProductPresentationProfileRegistry.cs
+++ b/S1API/Products/ProductPresentationProfileRegistry.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Registers process-lifetime presentation profiles for generic custom products.
+    /// </summary>
+    /// <remarks>
+    /// Product IDs and product-kind IDs are case-insensitive. A product-specific profile takes
+    /// deterministic precedence over a kind profile. Registration does not transmit assets;
+    /// every participating peer must register matching product definitions and profiles locally.
+    /// </remarks>
+    public static class ProductPresentationProfileRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, ProductPresentationProfileRegistration>
+            ProductProfiles =
+                new Dictionary<string, ProductPresentationProfileRegistration>(
+                    StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, ProductPresentationProfileRegistration>
+            KindProfiles =
+                new Dictionary<string, ProductPresentationProfileRegistration>(
+                    StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Registers a profile for one stable custom product ID.
+        /// </summary>
+        /// <param name="ownerId">The stable ID of the owning mod.</param>
+        /// <param name="productId">The stable product ID.</param>
+        /// <param name="profile">The immutable presentation profile.</param>
+        /// <returns>The registered profile, or the same retained profile on an idempotent call.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when an ID is empty or <paramref name="productId"/> is not namespaced.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the key has a conflicting owner or profile, or a required context cannot
+        /// be applied to an existing product.
+        /// </exception>
+        public static ProductPresentationProfile RegisterForProduct(
+            string ownerId,
+            string productId,
+            ProductPresentationProfile profile)
+        {
+            return Register(
+                ProductProfiles,
+                "product ID",
+                ownerId,
+                ProductKindId.Normalize(productId, nameof(productId)),
+                profile);
+        }
+
+        /// <summary>
+        /// Registers a profile for every generic custom product of one product kind.
+        /// </summary>
+        /// <param name="ownerId">The stable ID of the owning mod.</param>
+        /// <param name="productKind">The immutable product kind.</param>
+        /// <param name="profile">The immutable presentation profile.</param>
+        /// <returns>The registered profile, or the same retained profile on an idempotent call.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKind"/> or <paramref name="profile"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the key has a conflicting owner or profile, or a required context cannot
+        /// be applied to an existing product.
+        /// </exception>
+        public static ProductPresentationProfile RegisterForProductKind(
+            string ownerId,
+            ProductKind productKind,
+            ProductPresentationProfile profile)
+        {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+
+            return Register(
+                KindProfiles,
+                "product-kind ID",
+                ownerId,
+                productKind.Id,
+                profile);
+        }
+
+        private static ProductPresentationProfile Register(
+            Dictionary<string, ProductPresentationProfileRegistration> registrations,
+            string keyDescription,
+            string ownerId,
+            string key,
+            ProductPresentationProfile profile)
+        {
+            string normalizedOwnerId = NormalizeRequired(ownerId, nameof(ownerId));
+            string normalizedKey = NormalizeRequired(key, nameof(key));
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+
+            ProductPresentationProfileRegistration registration;
+            bool added = false;
+            lock (Gate)
+            {
+                if (registrations.TryGetValue(
+                        normalizedKey,
+                        out ProductPresentationProfileRegistration? existing))
+                {
+                    if (!string.Equals(
+                            existing.OwnerId,
+                            normalizedOwnerId,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Presentation profile {keyDescription} '{normalizedKey}' is already " +
+                            $"owned by '{existing.OwnerId}' and cannot be registered by " +
+                            $"'{normalizedOwnerId}'. Registration keys are case-insensitive.");
+                    }
+
+                    if (!ReferenceEquals(existing.Profile, profile))
+                    {
+                        throw new InvalidOperationException(
+                            $"Presentation profile {keyDescription} '{normalizedKey}' is already " +
+                            "registered by this owner with another profile. Reuse the original " +
+                            "profile or choose another stable key.");
+                    }
+
+                    return existing.Profile;
+                }
+
+                registration =
+                    new ProductPresentationProfileRegistration(
+                        normalizedOwnerId,
+                        normalizedKey,
+                        profile);
+                registrations.Add(normalizedKey, registration);
+                added = true;
+            }
+
+            try
+            {
+                CustomProductDefinitionRegistry.ApplyPresentationProfiles();
+                return registration.Profile;
+            }
+            catch
+            {
+                if (added)
+                {
+                    lock (Gate)
+                    {
+                        if (registrations.TryGetValue(
+                                normalizedKey,
+                                out ProductPresentationProfileRegistration? current) &&
+                            ReferenceEquals(current, registration))
+                        {
+                            registrations.Remove(normalizedKey);
+                        }
+                    }
+
+                    try
+                    {
+                        CustomProductDefinitionRegistry.ApplyPresentationProfiles();
+                    }
+                    catch (Exception rollbackException)
+                    {
+                        MelonLoader.MelonLogger.Error(
+                            "[ProductPresentationProfileRegistry] Failed to restore " +
+                            $"presentation fallbacks after rejecting '{normalizedKey}': " +
+                            rollbackException);
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        internal static bool TryResolve(
+            string productId,
+            string productKindId,
+            out ProductPresentationProfileRegistration? registration)
+        {
+            lock (Gate)
+            {
+                if (ProductProfiles.TryGetValue(productId, out registration))
+                    return true;
+
+                return KindProfiles.TryGetValue(productKindId, out registration);
+            }
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+            {
+                ProductProfiles.Clear();
+                KindProfiles.Clear();
+            }
+        }
+
+        private static string NormalizeRequired(string value, string parameterName)
+        {
+            if (value == null)
+                throw new ArgumentNullException(parameterName);
+
+            string normalized = value.Trim();
+            if (normalized.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Value cannot be empty or whitespace.",
+                    parameterName);
+            }
+
+            return normalized;
+        }
+    }
+}

--- a/S1API/Products/ProductPresentationTransform.cs
+++ b/S1API/Products/ProductPresentationTransform.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Defines an explicit local transform for a product presentation visual.
+    /// </summary>
+    /// <remarks>
+    /// Presentation transforms are applied to S1API's cloned visual root. Omit a transform
+    /// override to preserve the position, rotation, and scale authored by the provider.
+    /// </remarks>
+    public sealed class ProductPresentationTransform
+    {
+        /// <summary>
+        /// Initializes a product presentation transform.
+        /// </summary>
+        /// <param name="localPosition">The cloned visual root's local position.</param>
+        /// <param name="localEulerAngles">The cloned visual root's local Euler rotation.</param>
+        /// <param name="localScale">The cloned visual root's local scale.</param>
+        public ProductPresentationTransform(
+            Vector3 localPosition,
+            Vector3 localEulerAngles,
+            Vector3 localScale)
+        {
+            LocalPosition = localPosition;
+            LocalEulerAngles = localEulerAngles;
+            LocalScale = localScale;
+        }
+
+        /// <summary>
+        /// Gets the cloned visual root's local position.
+        /// </summary>
+        public Vector3 LocalPosition { get; }
+
+        /// <summary>
+        /// Gets the cloned visual root's local Euler rotation.
+        /// </summary>
+        public Vector3 LocalEulerAngles { get; }
+
+        /// <summary>
+        /// Gets the cloned visual root's local scale.
+        /// </summary>
+        public Vector3 LocalScale { get; }
+
+        internal void ApplyTo(Transform target)
+        {
+            target.localPosition = LocalPosition;
+            target.localEulerAngles = LocalEulerAngles;
+            target.localScale = LocalScale;
+        }
+    }
+}

--- a/S1API/Rendering/IconFactory.cs
+++ b/S1API/Rendering/IconFactory.cs
@@ -21,8 +21,9 @@ namespace S1API.Rendering
     /// <summary>
     /// Factory for generating item icons using the game's IconGenerator and MugshotGenerator.
     /// <para>
-    /// <b>Item Icon Generation (Experimental):</b> Direct item icon generation using IconGenerator is experimental.
-    /// Use <see cref="GenerateIcon"/> for static mesh item models.
+    /// <b>Item Icon Generation:</b> Use
+    /// <see cref="GenerateIcon(Transform, int, bool)"/> for static mesh item models.
+    /// S1API centers and fits the model to the game's fixed item-thumbnail camera.
     /// </para>
     /// <para>
     /// <b>Accessory Icon Generation (Confirmed Working):</b> Accessory icon generation using MugshotGenerator
@@ -41,6 +42,28 @@ namespace S1API.Rendering
             S1DevUtils.IconGenerator.Instance;
 
         /// <summary>
+        /// INTERNAL: Whether the active scene provides a complete item-icon rendering rig.
+        /// </summary>
+        internal static bool IsItemIconGeneratorReady
+        {
+            get
+            {
+                try
+                {
+                    S1DevUtils.IconGenerator generator = S1IconGenerator;
+                    return generator != null &&
+                           generator.CameraPosition != null &&
+                           generator.MainContainer != null &&
+                           generator.ItemContainer != null;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
         /// INTERNAL: Reference to the game's MugshotGenerator instance.
         /// </summary>
         internal static S1AvatarFramework.MugshotGenerator S1MugshotGenerator =>
@@ -52,10 +75,65 @@ namespace S1API.Rendering
         /// <param name="model">The model to generate an icon for.</param>
         /// <param name="size">The size of the square icon (default 512).</param>
         /// <param name="bakeSkinnedMeshes">If true, bakes SkinnedMeshRenderers to static MeshRenderers to ensure correct bounds (default true).</param>
-        /// <returns>A Texture2D containing the icon, or null if generation failed.</returns>
-        public static Texture2D? GenerateIcon(Transform model, int size = 512, bool bakeSkinnedMeshes = true)
+        /// <returns>
+        /// A Texture2D containing the icon, or null if generation failed or the render pipeline
+        /// produced a transparent cold-start capture.
+        /// </returns>
+        /// <remarks>
+        /// This synchronous method requires a render-ready Main or Tutorial scene. Product
+        /// presentation profiles use a loading-screen queue that waits and retries automatically.
+        /// </remarks>
+        public static Texture2D? GenerateIcon(
+            Transform model,
+            int size = 512,
+            bool bakeSkinnedMeshes = true) =>
+            GenerateIcon(
+                model,
+                size,
+                bakeSkinnedMeshes,
+                fitToCamera: true,
+                cameraFill: 0.72f);
+
+        /// <summary>
+        /// Generates a preview texture with explicit native-camera framing controls.
+        /// </summary>
+        /// <param name="model">The model to generate an icon for.</param>
+        /// <param name="size">The size of the square icon.</param>
+        /// <param name="bakeSkinnedMeshes">
+        /// Whether to bake skinned renderers to static renderers before capture.
+        /// </param>
+        /// <param name="fitToCamera">
+        /// Whether to fit renderer bounds to the native fixed thumbnail camera. Set false
+        /// to preserve the model's authored scale.
+        /// </param>
+        /// <param name="cameraFill">
+        /// The target share of the native camera's vertical view when fitting, greater than
+        /// zero through 2. Values above 1 intentionally crop the model.
+        /// </param>
+        /// <returns>
+        /// A Texture2D containing the icon, or null if generation failed or produced no
+        /// visible pixels.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="cameraFill"/> is not greater than zero through 2.
+        /// </exception>
+        public static Texture2D? GenerateIcon(
+            Transform model,
+            int size,
+            bool bakeSkinnedMeshes,
+            bool fitToCamera,
+            float cameraFill = 0.72f)
         {
-            if (S1IconGenerator == null)
+            if (cameraFill <= 0f || cameraFill > 2f)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(cameraFill),
+                    cameraFill,
+                    "Icon camera fill must be greater than zero and at most 2.");
+            }
+
+            S1DevUtils.IconGenerator generator = S1IconGenerator;
+            if (generator == null)
             {
                 Logger.Error("IconGenerator not found in scene. Cannot generate icon.");
                 return null;
@@ -67,20 +145,23 @@ namespace S1API.Rendering
                 return null;
             }
 
+            Transform? originalParent = model.parent;
+            Vector3 originalPos = model.localPosition;
+            Quaternion originalRot = model.localRotation;
+            Vector3 originalScale = model.localScale;
+            bool wasActive = model.gameObject.activeSelf;
+            int originalSize = generator.IconSize;
+            bool originalModifyLighting = generator.ModifyLighting;
+            List<SkinnedMeshRendererState>? bakedRenderers = null;
+            Texture2D? texture = null;
+
             try
             {
-                // Store original transform state for restoration after generation
-                Transform? originalParent = model.parent;
-                Vector3 originalPos = model.localPosition;
-                Quaternion originalRot = model.localRotation;
-                Vector3 originalScale = model.localScale;
-                bool wasActive = model.gameObject.activeSelf;
-
                 // Parent to ItemContainer first (like the game expects) then position
-                model.SetParent(S1IconGenerator.ItemContainer, false);
+                model.SetParent(generator.ItemContainer, false);
                 model.localPosition = Vector3.zero;
-                model.localRotation = Quaternion.identity;
-                model.localScale = Vector3.one;
+                model.localRotation = originalRot;
+                model.localScale = originalScale;
                 
                 // Now activate and set layers (after parenting)
                 model.gameObject.SetActive(true);
@@ -89,13 +170,18 @@ namespace S1API.Rendering
                 if (iconLayer != -1)
                 {
                     // Set layers recursively on ItemContainer to match game's approach
-                    S1DevUtils.LayerUtility.SetLayerRecursively(S1IconGenerator.ItemContainer.gameObject, iconLayer);
+                    S1DevUtils.LayerUtility.SetLayerRecursively(
+                        generator.ItemContainer.gameObject,
+                        iconLayer);
                 }
 
-                Logger.Msg($"Icon generation for '{model.name}': world pos={model.position}, layer={model.gameObject.layer} ({LayerMask.LayerToName(model.gameObject.layer)}), container pos={S1IconGenerator.ItemContainer.position}");
+                Logger.Msg(
+                    $"Icon generation for '{model.name}': world pos={model.position}, " +
+                    $"layer={model.gameObject.layer} " +
+                    $"({LayerMask.LayerToName(model.gameObject.layer)}), " +
+                    $"container pos={generator.ItemContainer.position}");
 
                 // Bake SkinnedMeshRenderers if requested to fix bounds calculation issues
-                System.Collections.Generic.List<SkinnedMeshRendererState>? bakedRenderers = null;
                 if (bakeSkinnedMeshes)
                 {
                     bakedRenderers = BakeSkinnedMeshRenderers(model.gameObject);
@@ -103,40 +189,54 @@ namespace S1API.Rendering
                 }
 
                 // Center the model in the container to ensure it's in view of the camera
-                CenterModelInContainer(model, S1IconGenerator.ItemContainer);
+                CenterModelInContainer(model, generator.ItemContainer);
+                if (fitToCamera)
+                {
+                    FitModelToGeneratorCamera(
+                        model,
+                        generator.ItemContainer,
+                        generator.CameraPosition,
+                        cameraFill);
+                    CenterModelInContainer(model, generator.ItemContainer);
+                }
 
                 // Temporarily override IconGenerator state
-                int originalSize = S1IconGenerator.IconSize;
-                bool originalModifyLighting = S1IconGenerator.ModifyLighting;
+                generator.IconSize = size;
+                generator.ModifyLighting = true;
 
-                S1IconGenerator.IconSize = size;
-                S1IconGenerator.ModifyLighting = true;
-
-                Texture2D texture = S1IconGenerator.GetTexture(model);
+                texture = generator.GetTexture(model);
                 Logger.Msg($"Generated texture: {(texture != null ? $"{texture.width}x{texture.height}" : "null")}");
-
-                // Restore original state
-                S1IconGenerator.IconSize = originalSize;
-                S1IconGenerator.ModifyLighting = originalModifyLighting;
-
-                // Restore SkinnedMeshRenderers if they were baked
-                if (bakedRenderers != null)
+                if (texture != null && !HasVisibleContent(texture))
                 {
-                    RestoreSkinnedMeshRenderers(bakedRenderers);
+                    Logger.Warning(
+                        $"Generated texture for '{model.name}' contains no visible pixels. " +
+                        "Retry after the scene render pipeline has warmed up.");
+                    UnityEngine.Object.Destroy(texture);
+                    texture = null;
                 }
-                
-                model.SetParent(originalParent, false);
-                model.localPosition = originalPos;
-                model.localRotation = originalRot;
-                model.localScale = originalScale;
-                model.gameObject.SetActive(wasActive);
 
                 return texture;
             }
             catch (System.Exception ex)
             {
                 Logger.Error($"Failed to generate icon for {model.name}: {ex.Message}");
+                if (texture != null)
+                    UnityEngine.Object.Destroy(texture);
                 return null;
+            }
+            finally
+            {
+                generator.IconSize = originalSize;
+                generator.ModifyLighting = originalModifyLighting;
+
+                if (bakedRenderers != null)
+                    RestoreSkinnedMeshRenderers(bakedRenderers);
+
+                model.SetParent(originalParent, false);
+                model.localPosition = originalPos;
+                model.localRotation = originalRot;
+                model.localScale = originalScale;
+                model.gameObject.SetActive(wasActive);
             }
         }
 
@@ -174,6 +274,38 @@ namespace S1API.Rendering
         /// <returns>A Sprite containing the icon, or null if generation failed.</returns>
         public static Sprite? GenerateIconSprite(Transform model, int size = 512, bool bakeSkinnedMeshes = true) =>
             ImageUtils.TextureToSprite(GenerateIcon(model, size, bakeSkinnedMeshes));
+
+        /// <summary>
+        /// Generates a preview sprite with explicit native-camera framing controls.
+        /// </summary>
+        /// <param name="model">The model to generate an icon for.</param>
+        /// <param name="size">The size of the square icon.</param>
+        /// <param name="bakeSkinnedMeshes">
+        /// Whether to bake skinned renderers to static renderers before capture.
+        /// </param>
+        /// <param name="fitToCamera">
+        /// Whether to fit renderer bounds to the native fixed thumbnail camera.
+        /// </param>
+        /// <param name="cameraFill">
+        /// The target share of the native camera's vertical view when fitting.
+        /// </param>
+        /// <returns>A Sprite containing the icon, or null if generation failed.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="cameraFill"/> is not greater than zero through 2.
+        /// </exception>
+        public static Sprite? GenerateIconSprite(
+            Transform model,
+            int size,
+            bool bakeSkinnedMeshes,
+            bool fitToCamera,
+            float cameraFill = 0.72f) =>
+            ImageUtils.TextureToSprite(
+                GenerateIcon(
+                    model,
+                    size,
+                    bakeSkinnedMeshes,
+                    fitToCamera,
+                    cameraFill));
 
         /// <summary>
         /// Generates an icon as a Sprite for a packaging ID and product ID.
@@ -344,32 +476,11 @@ namespace S1API.Rendering
         /// </summary>
         private static void CenterModelInContainer(Transform model, Transform container)
         {
-            var renderers = model.GetComponentsInChildren<Renderer>();
-            if (renderers.Length == 0) return;
-
-            Bounds bounds = new Bounds(model.position, Vector3.zero);
-            bool hasBounds = false;
-
-            foreach (var r in renderers)
-            {
-                if (!r.enabled) continue; // Skip disabled renderers (like baked SkinnedMeshRenderers)
-                
-                if (!hasBounds)
-                {
-                    bounds = r.bounds;
-                    hasBounds = true;
-                }
-                else
-                {
-                    bounds.Encapsulate(r.bounds);
-                }
-            }
-
-            if (hasBounds)
+            if (TryGetRendererBounds(model, out Bounds bounds))
             {
                 // Calculate how far the center of bounds is from the container pivot
                 Vector3 centerOffset = container.position - bounds.center;
-                
+
                 // We only want to center, we don't want to mess up scale or anything.
                 // Moving the model position shifts the bounds center to the container position.
                 model.position += centerOffset;
@@ -380,6 +491,104 @@ namespace S1API.Rendering
             {
                 Logger.Warning($"Could not calculate bounds for {model.name} (no enabled renderers?). Icon might be empty.");
             }
+        }
+
+        /// <summary>
+        /// Fits an arbitrary model to the fixed camera framing used by the game's item-icon rig.
+        /// The caller restores the model's original scale after capture.
+        /// </summary>
+        private static void FitModelToGeneratorCamera(
+            Transform model,
+            Transform container,
+            Camera camera,
+            float cameraFill)
+        {
+            if (!TryGetRendererBounds(model, out Bounds bounds))
+                return;
+
+            float largestDimension =
+                Mathf.Max(bounds.size.x, Mathf.Max(bounds.size.y, bounds.size.z));
+            float cameraDistance =
+                Vector3.Distance(camera.transform.position, container.position);
+            float visibleHeight =
+                2f *
+                cameraDistance *
+                Mathf.Tan(camera.fieldOfView * 0.5f * Mathf.Deg2Rad);
+            float targetDimension = visibleHeight * cameraFill;
+            if (largestDimension <= Mathf.Epsilon ||
+                targetDimension <= Mathf.Epsilon)
+            {
+                return;
+            }
+
+            float scaleFactor = targetDimension / largestDimension;
+            model.localScale *= scaleFactor;
+            Logger.Msg(
+                $"Fit model '{model.name}' to native icon camera. " +
+                $"Bounds={bounds.size}, target={targetDimension:F3}, scale={scaleFactor:F3}");
+        }
+
+        private static bool TryGetRendererBounds(
+            Transform model,
+            out Bounds bounds)
+        {
+            Renderer[] renderers = model.GetComponentsInChildren<Renderer>();
+            bounds = new Bounds(model.position, Vector3.zero);
+            bool hasBounds = false;
+
+            foreach (Renderer renderer in renderers)
+            {
+                if (!renderer.enabled)
+                    continue;
+
+                if (!hasBounds)
+                {
+                    bounds = renderer.bounds;
+                    hasBounds = true;
+                }
+                else
+                {
+                    bounds.Encapsulate(renderer.bounds);
+                }
+            }
+
+            return hasBounds;
+        }
+
+        /// <summary>
+        /// INTERNAL: Detects the transparent cold-start captures produced before the icon
+        /// render pipeline has completed a frame.
+        /// </summary>
+        internal static bool HasVisibleContent(Texture2D texture)
+        {
+            if (texture == null || texture.width <= 0 || texture.height <= 0)
+                return false;
+
+            const int sampleCount = 12;
+            for (int y = 0; y < sampleCount; y++)
+            {
+                int pixelY =
+                    Mathf.Clamp(
+                        Mathf.RoundToInt(
+                            (texture.height - 1) *
+                            ((y + 0.5f) / sampleCount)),
+                        0,
+                        texture.height - 1);
+                for (int x = 0; x < sampleCount; x++)
+                {
+                    int pixelX =
+                        Mathf.Clamp(
+                            Mathf.RoundToInt(
+                                (texture.width - 1) *
+                                ((x + 0.5f) / sampleCount)),
+                            0,
+                            texture.width - 1);
+                    if (texture.GetPixel(pixelX, pixelY).a > 0.02f)
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         #endregion

--- a/S1API/Rendering/IconFactory.cs
+++ b/S1API/Rendering/IconFactory.cs
@@ -414,29 +414,36 @@ namespace S1API.Rendering
             var states = new System.Collections.Generic.List<SkinnedMeshRendererState>();
             var skinnedRenderers = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
 
-            foreach (var smr in skinnedRenderers)
+            try
             {
-                var state = new SkinnedMeshRendererState(smr);
+                foreach (var smr in skinnedRenderers)
+                {
+                    var state = new SkinnedMeshRendererState(smr);
+                    states.Add(state);
 
-                // Create baked mesh
-                state.BakedMesh = new Mesh();
-                smr.BakeMesh(state.BakedMesh);
+                    // Create baked mesh
+                    state.BakedMesh = new Mesh();
+                    smr.BakeMesh(state.BakedMesh);
 
-                // Add static mesh components
-                state.MeshFilter = smr.gameObject.AddComponent<MeshFilter>();
-                state.MeshRenderer = smr.gameObject.AddComponent<MeshRenderer>();
+                    // Add static mesh components
+                    state.MeshFilter = smr.gameObject.AddComponent<MeshFilter>();
+                    state.MeshRenderer = smr.gameObject.AddComponent<MeshRenderer>();
 
-                // Apply the baked mesh
-                state.MeshFilter.sharedMesh = state.BakedMesh;
-                state.MeshRenderer.sharedMaterials = smr.sharedMaterials;
+                    // Apply the baked mesh
+                    state.MeshFilter.sharedMesh = state.BakedMesh;
+                    state.MeshRenderer.sharedMaterials = smr.sharedMaterials;
 
-                // Disable the SkinnedMeshRenderer so only the static mesh is rendered
-                smr.enabled = false;
+                    // Disable the SkinnedMeshRenderer so only the static mesh is rendered
+                    smr.enabled = false;
+                }
 
-                states.Add(state);
+                return states;
             }
-
-            return states;
+            catch
+            {
+                RestoreSkinnedMeshRenderers(states);
+                throw;
+            }
         }
 
         /// <summary>

--- a/S1API/Rendering/RuntimeResourceRegistry.cs
+++ b/S1API/Rendering/RuntimeResourceRegistry.cs
@@ -176,9 +176,56 @@ namespace S1API.Rendering
             return asset;
         }
 
+        /// <summary>
+        /// Removes only registrations at a path that still reference the expected asset.
+        /// </summary>
+        internal static bool UnregisterAssetIfMatches(
+            string resourcePath,
+            Object expectedAsset)
+        {
+            if (string.IsNullOrEmpty(resourcePath) ||
+                ReferenceEquals(expectedAsset, null))
+            {
+                return false;
+            }
+
+            bool removed = false;
+            if (_registeredAssets.TryGetValue(
+                    resourcePath,
+                    out Object? registered) &&
+                AreSameAsset(registered, expectedAsset))
+            {
+                removed = _registeredAssets.Remove(resourcePath);
+            }
+
+            string typedPrefix = resourcePath + "|";
+            var typedKeys = new List<string>();
+            foreach (KeyValuePair<string, Object> entry in _typedAssets)
+            {
+                if (entry.Key.StartsWith(
+                        typedPrefix,
+                        StringComparison.Ordinal) &&
+                    AreSameAsset(entry.Value, expectedAsset))
+                {
+                    typedKeys.Add(entry.Key);
+                }
+            }
+
+            for (int i = 0; i < typedKeys.Count; i++)
+                removed = _typedAssets.Remove(typedKeys[i]) || removed;
+
+            return removed;
+        }
+
         #endregion
 
         #region Private Implementation
+
+        private static bool AreSameAsset(Object left, Object right)
+        {
+            return ReferenceEquals(left, right) ||
+                   (left != null && right != null && left == right);
+        }
 
         /// <summary>
         /// Gets a typed key for the typed asset dictionary.

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -101,7 +101,125 @@ native-backed item equality; do not use `ReferenceEquals` across lookup calls.
 The template's icon, stored/held representations, functional product,
 consumption animation, and item UI references are shared rather than cloned.
 The builder does not export, embed, or redistribute those game assets. Its
-station representation is deliberately not copied.
+station representation is deliberately not copied unless a presentation
+profile supplies a station visual.
+
+## Custom presentation profiles
+
+`ProductPresentationProfile` lets a generic custom product use mod-owned visuals
+without subclassing a native drug family. Register the profile by stable product
+ID before building the definition:
+
+```csharp
+using S1API.Products;
+using UnityEngine;
+
+// Load once through S1API.AssetBundles, MAPI's embedded GLB loader, or another
+// local mod-owned asset path. Providers should return this reusable prefab source.
+GameObject pillVisual = LoadPillVisual();
+
+ProductPresentationProfile pillProfile =
+    new ProductPresentationProfileBuilder()
+        .WithLooseVisual(() => pillVisual)
+        .WithGeneratedIconFromLooseVisual(size: 512)
+        .Require(
+            ProductPresentationContext.Stored,
+            ProductPresentationContext.Held,
+            ProductPresentationContext.Station,
+            ProductPresentationContext.FunctionalProduct)
+        .Build();
+
+ProductPresentationProfileRegistry.RegisterForProduct(
+    ownerId: "example.mod",
+    productId: "example.mod:products/focus-tablet",
+    profile: pillProfile);
+```
+
+The loose visual is the deterministic default for the stored, held, station,
+and functional-product contexts. Providers may author the desired root
+transform directly. For reusable source objects, pass a
+`ProductPresentationTransform` to set an explicit local position, Euler
+rotation, and scale on S1API's cloned visual root:
+
+```csharp
+var pillPose =
+    new ProductPresentationTransform(
+        localPosition: Vector3.zero,
+        localEulerAngles:
+            (Quaternion.Euler(78f, 0f, -8f) *
+             Quaternion.Euler(0f, 90f, 0f)).eulerAngles,
+        localScale: Vector3.one * 0.06f);
+
+ProductPresentationProfile profile =
+    new ProductPresentationProfileBuilder()
+        .WithLooseVisual(() => pillVisual, pillPose)
+        .WithHeldVisual(() => heldPillVisual, heldPose)
+        .WithStationVisual(() => stationPillVisual, stationPose)
+        .WithIcon(() => pillIcon)
+        .WithConsumptionPrefab(() => pillConsumeAnimationPrefab)
+        .Build();
+```
+
+Visual providers return a `GameObject` prefab source. S1API clones the source
+and preserves its root local position, rotation, and scale unless an explicit
+presentation transform overrides them. A loose transform follows the loose
+provider into fallback contexts; a context-specific provider and transform
+take precedence. S1API also clones the representation template's native
+stored-item, equippable, station-item, and functional-product scaffolds,
+replacing only their family-specific visual setter. This keeps native storage
+footprints, station modules, draggable behavior, first-person equip behavior,
+and consumption wiring intact.
+
+The held context also creates a third-person `AvatarEquippable` under the
+deterministic resource path
+`S1API/ProductPresentation/{productId}/Held`. Every peer must register the same
+product and profile locally before that path is received over the network.
+S1API does not transmit the mesh, materials, textures, definition, or profile.
+
+An explicit consumption provider must return a prefab containing the native
+`ProductConsumeAnimation` component. Generated icons reuse the base game's
+`IconGenerator` through `S1API.Rendering.IconFactory`; explicit sprites can be
+supplied with `WithIcon`. S1API preserves the representation template's icon
+while capture is queued, waits for the native `@IconGenerator` rig, yields
+through a complete render frame, and rejects transparent cold-start captures.
+The loading screen stays open until queued product icons complete or reach the
+bounded retry timeout. `MugshotGenerator` remains reserved for avatar/accessory
+previews. The generated icon is the loose inventory icon only.
+`ProductIconManager` packaging combinations are intentionally unchanged.
+
+Automatic icon fitting targets 72% of the native thumbnail camera by default.
+Adjust the framing or preserve the authored scale with the additive overload:
+
+```csharp
+.WithGeneratedIconFromLooseVisual(
+    size: 512,
+    fitToCamera: true,
+    cameraFill: 0.82f)
+```
+
+Set `fitToCamera: false` when the provider's scale is already authored for the
+base-game thumbnail rig. The loose presentation transform controls icon
+rotation; `cameraFill` controls only automatic scale fitting. Direct
+`IconFactory.GenerateIcon` and `GenerateIconSprite` overloads expose the same
+framing controls.
+
+Profiles may instead be registered by `ProductKind` with
+`RegisterForProductKind`. A product-ID profile always wins over a kind profile,
+and both key types are case-insensitive. The first owner wins; an owner may
+repeat the same profile registration idempotently but cannot silently replace
+it with another profile.
+
+Missing optional providers preserve the original template reference. Provider
+exceptions, null results, incompatible native scaffolds, and icon-rendering
+failures also preserve that reference and log a warning. `Require(...)` changes
+those conditions into an actionable registration error once the relevant
+native scene service is available. Profiles and generated prefabs are retained
+for the process lifetime and reapplied during pre-load and load-complete
+restoration.
+
+Presentation profiles affect only generic custom products registered with
+`CustomProductDefinitionBuilder`. Vanilla definitions, native-family builders,
+and legacy custom registrations are not modified.
 
 ## Loose and packaged instances
 
@@ -159,7 +277,8 @@ Supported in this milestone:
   S1API custom-product lifecycle registry;
 - stable loose and packaged item instances;
 - fixed name, description, price, effects, legality, addictiveness, quality,
-  packaging policy, and borrowed consumption references;
+  packaging policy, borrowed consumption references, and optional mod-owned
+  loose presentation profiles;
 - same-mod save/load and native item network serialization; and
 - explicit discovery, Product Manager listing, and existing shop integration.
 
@@ -167,9 +286,8 @@ Not supported:
 
 - mixing, generated variants, native family conversion, or production-station
   recipes;
-- custom models, icons, loose/stored/held providers, consumption providers, or
-  Product Manager UI categories;
 - packaged contents, composite package icons, or packaging-content save data;
+- custom packaging definitions or Product Manager UI categories;
 - definition transfer to a peer without the defining mod; or
 - recovery of a saved custom item after its mod or stable definition ID is
   removed.
@@ -185,4 +303,6 @@ This API is additive. Existing `ProductDefinition`, `ProductInstance`,
 behavior, save IDs, and network payloads are unchanged. The wrapper factory
 selects `CustomProductDefinition` only for definitions registered with the new
 builder metadata; all previous generic and native-family fallback behavior
-remains intact.
+remains intact. Presentation-profile registration is opt-in, and definitions
+without a resolved profile keep the exact representation references selected by
+`WithRepresentationsFrom`.

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -15,6 +15,9 @@ If you want customer preference configuration, see `S1API/docs/products-system.m
 - `S1API.Products.CustomProductItemCreator`: creates generic non-mixable product builders
 - `S1API.Products.CustomProductDefinitionBuilder`: validates and lifecycle-registers a fixed generic product
 - `S1API.Products.CustomProductDefinition`: typed wrapper for a registered generic custom product
+- `S1API.Products.ProductPresentationProfileBuilder`: configures mod-owned loose presentation contexts
+- `S1API.Products.ProductPresentationTransform`: overrides a cloned context visual's local transform
+- `S1API.Products.ProductPresentationProfileRegistry`: registers profiles by stable product ID or logical product kind
 - `S1API.Products.PackagingDefinition`: packaging definition wrapper
 - `S1API.Products.Quality`: API-safe quality enum
 


### PR DESCRIPTION
﻿## Summary

- add immutable custom product presentation profiles registered by stable product ID or `ProductKind`, with product-specific precedence and first-owner/idempotent collision behavior
- reuse native stored, held, station, functional-product, third-person avatar, and consumption scaffolds while replacing only mod-owned visual payloads
- generate loose icons through the base game's `IconGenerator` at loading-screen timing, with transparent-capture rejection, bounded retries, automatic camera fitting, and explicit scale/rotation/framing controls
- restore resolved profiles through the existing custom-product pre-load/load-complete lifecycle; preserve template references for optional unsupported or failing contexts
- document the provider, transform, fallback, icon-timing, multiplayer registration, and non-goal boundaries

Closes #101.

## Compatibility

- **Public API inventory:** additive `ProductPresentationContext`, `ProductPresentationProfile`, `ProductPresentationProfileBuilder`, `ProductPresentationProfileRegistry`, and `ProductPresentationTransform` types; additive `IconFactory.GenerateIcon`/`GenerateIconSprite` framing overloads.
- **Source compatibility:** unchanged. No existing public/protected type, member, namespace, parameter name, or required argument was removed or renamed. Compile fixtures cover representative new callers.
- **Binary compatibility:** unchanged. Existing `IconFactory` three-parameter signatures remain present and forward to the corrected implementation; reflection tests freeze both old and new signatures.
- **Behavioral compatibility:** vanilla products, legacy custom registrations, and generic custom products without a resolved profile retain their existing representation references. The existing experimental `IconFactory` call intentionally now preserves authored rotation/scale, fits arbitrary bounds to the native camera, restores generator/model state in `finally`, and rejects transparent cold-start output; this corrects its previously broken scaling/timing behavior without changing its signature.
- **Save compatibility:** unchanged stable product IDs and native save payloads. Separate-process create/reload smoke passes restored the profiled product and all contexts in both runtimes.
- **Network compatibility:** no serialization or payload changes and no asset transmission. Third-person presentation uses deterministic `S1API/ProductPresentation/{productId}/Held` resource IDs; every peer must register the same product/profile and load its own assets locally.

## Validation

### Automated

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` ? **0 warnings, 0 errors**
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` ? **144/144 passed**
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` ? **0 warnings, 0 errors**
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` ? **137/137 passed**
- `docfx docfx.json` ? **succeeded, 0 errors**; 4 existing unresolved external-assembly warnings (`Mono.WebBrowser`, `Mono.Posix`, and two `Newtonsoft.Json` references)
- documentation coverage ? **81.05% (2,845/3,510), minimum 80%**
- `git diff --check` ? **passed**

Tests cover enum/signature contracts, legacy `IconFactory` signatures, builder snapshots/defaults/invalid inputs, required-context validation, case-insensitive ownership, product-over-kind precedence, late registration, lifecycle restoration, initial-failure rollback before native mutation, and legacy unprofiled behavior.

### Dual-runtime game smoke

A local-only smoke mod embedded the mod-owned `heartpill.glb` via MAPI, registered one required product presentation profile, and declared a physical custom NPC without an explicit icon so the product-icon and NPC-mugshot queues ran during the same load. Smoke source, model data, isolated installs, saves, logs, and screenshots are not committed. The disposable harness compiled in both configurations with 0 errors; nullable-analysis warnings remained confined to the local harness.

Both MonoMelon and Il2CppMelon passed a create run and a separate-process save reload:

`StoredTriangles=17504 | HeldTriangles=17504 | StationTriangles=17504 | FunctionalTriangles=17504 | ConsumptionTriangles=17504 | Icon=Generated | AvatarEquippable=True | FunctionalCollider=True`

- MonoMelon create: **PASS**, save written; reload: **PASS**, `RestoredFromSave=True`
- Il2CppMelon create: **PASS**, save written; reload: **PASS**, `RestoredFromSave=True`
- combined icon/mugshot validation: all four create/reload runs produced a 512x512 heartpill icon and a 512x512 custom-NPC mugshot with independently validated visible pixels and color variation; both textures were exported and visually inspected as nonblank
- clean-log audit: final Mono and IL2CPP create/reload logs contained **0 exceptions, 0 `[ERROR]` entries, and 0 `FAIL` markers**
- visual inspection: all supported contexts rendered the same heart-pill mesh; the generated loose icon contained visible pixels; the heart cleft is at the top and point at the bottom in both runtimes

Final context and generated-icon screenshots for both runtimes are attached to this PR.

## Asset and native-seam research

The local GLB was selected over the `.blend` and `.fbx` inputs because it is self-contained, works with MAPI's embedded runtime loader, and retains its materials/textures without a derived Unity project. Inspection found one mesh/primitive, 8,994 vertices, 17,504 triangles, normals, UV0/UV1/UV2, three embedded 2048px PNG textures, bounds of approximately 0.725 x 0.740 x 0.280 m, and a bottom pivot. Tangents were absent and recalculated in the local smoke loader. The tested presentation transform used 0.06 scale and explicit composed Euler rotation.

The implementation follows the native `@IconGenerator`/`ProductIconManager` scene evidence and S1API's existing loading-screen mugshot warmup pattern: wait for the render rig, yield a normal frame plus `WaitForEndOfFrame`, reject empty output, and retry while loading remains covered. `MugshotGenerator` remains for avatar/accessory previews. Packaged combination icons remain owned by `ProductIconManager` and are unchanged.

## Notes

- Filled baggie/jar contents and packaged icons remain #102 and are not implemented here.
- No custom packaging definitions, extracted game assets, generated wrappers, assemblies, smoke harnesses, saves, logs, or local evidence are committed.
- The single heart mesh is structurally reusable for future repeated placement, but 17,504 triangles plus three 2048px textures is too heavy to duplicate naively inside packaging. #102 should use instancing and/or an optimized LOD/material set rather than repeating the current mesh directly.
