### PR TITLE
feat(products): add packaging content profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ S1API.sln orchestrates two primary projects: `S1API/` for the modding API and `S
 ## Research Workflow
 When implementing or extending S1API features that mirror or hook into the base game, inspect `../` first to confirm the upstream type, member, and behavior you are targeting. Search the game codebase for the relevant symbols before making API changes. Also use the `../.agents/skills/schedule-one-modding` skill when working with upstream game types so you follow the repository's modding-specific guidance and references. Example: if asked to add `onHourPass` support to `TimeManager`, look for `onHourPass` and `TimeManager` in `../` to verify naming, signatures, and call flow before editing `S1API`, and use the `schedule-one-modding` skill to guide the upstream research and integration approach.
 
+Treat native icon, mugshot, and preview generators as shared render rigs rather than ordinary synchronous helpers. Multiple captures must be serialized, with the rig fully reset and at least one settled frame (`Update` plus `WaitForEndOfFrame` where appearance state is applied late) between subjects. A managed lock alone does not prevent Unity/GPU transition frames from combining the outgoing and incoming subjects. During visual iteration, render and inspect one targeted capture first; run the complete runtime/save/scene matrix only after that capture is correct.
+
 ## Build, Test, and Development Commands
 - `dotnet restore S1API.sln -p:Configuration=MonoMelon` — restores the Mono graph.
 - `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — builds Mono without deploying into a live game.

--- a/S1API.Tests/Products/ProductPackagingContentApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentApiCompatibilityTests.cs
@@ -1,0 +1,48 @@
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductPackagingContentApiCompatibilityTests
+{
+    [Fact]
+    public void PackagingContentApiIsAdditiveAndRuntimeAgnostic()
+    {
+        Assert.True(typeof(ProductPackagingContentProfile).IsSealed);
+        Assert.True(typeof(ProductPackagingContentProfileBuilder).IsSealed);
+        Assert.True(typeof(ProductPackagingContentProfileRegistry).IsAbstract);
+        Assert.True(typeof(ProductPackagingContentProfileRegistry).IsSealed);
+
+        System.Reflection.MethodInfo withContent =
+            typeof(ProductPackagingContentProfileBuilder).GetMethod(
+                nameof(ProductPackagingContentProfileBuilder.WithContent),
+                new[] { typeof(Func<GameObject>) })!;
+        System.Reflection.MethodInfo addPlacement =
+            typeof(ProductPackagingContentProfileBuilder).GetMethod(
+                nameof(ProductPackagingContentProfileBuilder.AddPlacement),
+                new[] { typeof(ProductPresentationTransform) })!;
+        System.Reflection.MethodInfo addPlacements =
+            typeof(ProductPackagingContentProfileBuilder).GetMethod(
+                nameof(ProductPackagingContentProfileBuilder.AddPlacements),
+                new[] { typeof(ProductPresentationTransform[]) })!;
+        System.Reflection.MethodInfo register =
+            typeof(ProductPackagingContentProfileRegistry).GetMethod(
+                nameof(ProductPackagingContentProfileRegistry.Register),
+                new[]
+                {
+                    typeof(string),
+                    typeof(string),
+                    typeof(string),
+                    typeof(ProductPackagingContentProfile)
+                })!;
+
+        Assert.NotNull(withContent);
+        Assert.NotNull(addPlacement);
+        Assert.NotNull(addPlacements);
+        Assert.NotNull(register);
+        Assert.Equal(typeof(ProductPackagingContentProfileBuilder), withContent.ReturnType);
+        Assert.Equal(typeof(ProductPackagingContentProfileBuilder), addPlacement.ReturnType);
+        Assert.Equal(typeof(ProductPackagingContentProfileBuilder), addPlacements.ReturnType);
+        Assert.Equal(typeof(ProductPackagingContentProfile), register.ReturnType);
+    }
+}

--- a/S1API.Tests/Products/ProductPackagingContentApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductPackagingContentApiCompileFixture.cs
@@ -1,0 +1,26 @@
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+internal static class ProductPackagingContentApiCompileFixture
+{
+    internal static ProductPackagingContentProfile CompileRepresentativeCaller(
+        GameObject contentPrefab,
+        ProductPresentationTransform firstPlacement,
+        params ProductPresentationTransform[] additionalPlacements)
+    {
+        ProductPackagingContentProfile profile =
+            new ProductPackagingContentProfileBuilder()
+                .WithContent(provider: () => contentPrefab)
+                .AddPlacement(placement: firstPlacement)
+                .AddPlacements(placements: additionalPlacements)
+                .Build();
+
+        return ProductPackagingContentProfileRegistry.Register(
+            ownerId: "compile-fixture",
+            productId: "compile-fixture:product",
+            packagingId: "baggie",
+            profile: profile);
+    }
+}

--- a/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
@@ -78,17 +78,18 @@ public sealed class ProductPackagingContentProfileRegistryTests : IDisposable
     }
 
     [Fact]
-    public void UnregisteredPairPreservesNativeFallback()
+    public void RegisteredProductWithUnregisteredPackagingPreservesNativeFallback()
     {
+        string productId = CreateProductId();
         ProductPackagingContentProfileRegistry.Register(
             "examplemod",
-            CreateProductId(),
+            productId,
             "baggie",
             CreateProfile());
 
         Assert.False(
             ProductPackagingContentProfileRegistry.TryResolve(
-                CreateProductId(),
+                productId,
                 "jar",
                 out _));
     }

--- a/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
@@ -1,0 +1,230 @@
+using S1API.Internal.Products;
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductPackagingContentProfileRegistryTests : IDisposable
+{
+    public ProductPackagingContentProfileRegistryTests()
+    {
+        ProductPackagingContentProfileRegistry.ResetForTesting();
+    }
+
+    public void Dispose()
+    {
+        ProductPackagingContentProfileRegistry.ResetForTesting();
+    }
+
+    [Fact]
+    public void ProductAndPackagingPairIsCaseInsensitiveAndIdempotent()
+    {
+        string productId = CreateProductId();
+        ProductPackagingContentProfile profile = CreateProfile();
+
+        ProductPackagingContentProfile first =
+            ProductPackagingContentProfileRegistry.Register(
+                "ExampleMod",
+                productId,
+                "Baggie",
+                profile);
+        ProductPackagingContentProfile repeated =
+            ProductPackagingContentProfileRegistry.Register(
+                "examplemod",
+                productId.ToUpperInvariant(),
+                "baggie",
+                profile);
+
+        Assert.Same(profile, first);
+        Assert.Same(first, repeated);
+        Assert.True(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                productId,
+                "BAGGIE",
+                out ProductPackagingContentProfileRegistration? registration));
+        Assert.NotNull(registration);
+        Assert.Same(profile, registration.Profile);
+    }
+
+    [Fact]
+    public void SameProductCanRegisterIndependentPackagingProfiles()
+    {
+        string productId = CreateProductId();
+        ProductPackagingContentProfile baggie = CreateProfile();
+        ProductPackagingContentProfile jar = CreateProfile();
+
+        ProductPackagingContentProfileRegistry.Register(
+            "examplemod",
+            productId,
+            "baggie",
+            baggie);
+        ProductPackagingContentProfileRegistry.Register(
+            "examplemod",
+            productId,
+            "jar",
+            jar);
+
+        Assert.True(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                productId,
+                "baggie",
+                out ProductPackagingContentProfileRegistration? baggieRegistration));
+        Assert.True(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                productId,
+                "jar",
+                out ProductPackagingContentProfileRegistration? jarRegistration));
+        Assert.Same(baggie, baggieRegistration!.Profile);
+        Assert.Same(jar, jarRegistration!.Profile);
+    }
+
+    [Fact]
+    public void UnregisteredPairPreservesNativeFallback()
+    {
+        ProductPackagingContentProfileRegistry.Register(
+            "examplemod",
+            CreateProductId(),
+            "baggie",
+            CreateProfile());
+
+        Assert.False(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                CreateProductId(),
+                "jar",
+                out _));
+    }
+
+    [Fact]
+    public void ConflictingOwnerReportsThePair()
+    {
+        string productId = CreateProductId();
+        ProductPackagingContentProfileRegistry.Register(
+            "first-mod",
+            productId,
+            "jar",
+            CreateProfile());
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    ProductPackagingContentProfileRegistry.Register(
+                        "second-mod",
+                        productId.ToUpperInvariant(),
+                        "JAR",
+                        CreateProfile()));
+
+        Assert.Contains(productId, exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("jar", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("first-mod", exception.Message);
+        Assert.Contains("second-mod", exception.Message);
+    }
+
+    [Fact]
+    public void SameOwnerCannotSilentlyReplaceAProfile()
+    {
+        string productId = CreateProductId();
+        ProductPackagingContentProfileRegistry.Register(
+            "examplemod",
+            productId,
+            "jar",
+            CreateProfile());
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () =>
+                    ProductPackagingContentProfileRegistry.Register(
+                        "examplemod",
+                        productId,
+                        "jar",
+                        CreateProfile()));
+
+        Assert.Contains("another profile", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void PackagingIdMustNotBeEmpty(string packagingId)
+    {
+        Assert.Throws<ArgumentException>(
+            () =>
+                ProductPackagingContentProfileRegistry.Register(
+                    "examplemod",
+                    CreateProductId(),
+                    packagingId,
+                    CreateProfile()));
+    }
+
+    [Fact]
+    public void RegistrationTrimsOwnerProductAndPackagingIds()
+    {
+        string productId = CreateProductId();
+        ProductPackagingContentProfile profile = CreateProfile();
+
+        ProductPackagingContentProfileRegistry.Register(
+            " examplemod ",
+            $" {productId} ",
+            " jar ",
+            profile);
+
+        Assert.True(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                productId,
+                "jar",
+                out ProductPackagingContentProfileRegistration? registration));
+        Assert.Equal("examplemod", registration!.OwnerId);
+        Assert.Equal(productId, registration.Key.ProductId);
+        Assert.Equal("jar", registration.Key.PackagingId);
+    }
+
+    [Theory]
+    [InlineData(null, "s1api-tests:product", "baggie", "ownerId")]
+    [InlineData("", "s1api-tests:product", "baggie", "ownerId")]
+    [InlineData("owner", null, "baggie", "productId")]
+    [InlineData("owner", "", "baggie", "productId")]
+    [InlineData("owner", "not-namespaced", "baggie", "productId")]
+    [InlineData("owner", "s1api-tests:product", null, "packagingId")]
+    public void InvalidRegistrationInputsAreRejected(
+        string? ownerId,
+        string? productId,
+        string? packagingId,
+        string parameterName)
+    {
+        ArgumentException exception =
+            Assert.ThrowsAny<ArgumentException>(
+                () =>
+                    ProductPackagingContentProfileRegistry.Register(
+                        ownerId!,
+                        productId!,
+                        packagingId!,
+                        CreateProfile()));
+
+        Assert.Equal(parameterName, exception.ParamName);
+    }
+
+    [Fact]
+    public void NullProfileIsRejected()
+    {
+        ArgumentNullException exception =
+            Assert.Throws<ArgumentNullException>(
+                () =>
+                    ProductPackagingContentProfileRegistry.Register(
+                        "examplemod",
+                        CreateProductId(),
+                        "baggie",
+                        null!));
+
+        Assert.Equal("profile", exception.ParamName);
+    }
+
+    private static ProductPackagingContentProfile CreateProfile()
+    {
+        return new ProductPackagingContentProfileBuilder()
+            .WithContent(() => null)
+            .Build();
+    }
+
+    private static string CreateProductId()
+    {
+        return $"s1api-tests:{Guid.NewGuid():N}";
+    }
+}

--- a/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
@@ -1,0 +1,95 @@
+using S1API.Products;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductPackagingContentProfileTests
+{
+    [Fact]
+    public void NullContentProviderIsRejected()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .WithContent(null!));
+    }
+
+    [Fact]
+    public void ContentProviderIsRequired()
+    {
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductPackagingContentProfileBuilder().Build());
+
+        Assert.Contains("content provider", exception.Message);
+    }
+
+    [Fact]
+    public void EmptyPlacementsPreserveOneAuthoredContentTransform()
+    {
+        Func<GameObject?> provider = () => null;
+
+        ProductPackagingContentProfile profile =
+            new ProductPackagingContentProfileBuilder()
+                .WithContent(provider)
+                .Build();
+
+        Assert.Same(provider, profile.ContentProvider);
+        Assert.Empty(profile.Placements);
+    }
+
+    [Fact]
+    public void BuildSnapshotsOrderedPlacementsAcrossBuilderReuse()
+    {
+        ProductPresentationTransform first = CreatePlacementWithoutUnityRuntime();
+        ProductPresentationTransform second = CreatePlacementWithoutUnityRuntime();
+        var builder =
+            new ProductPackagingContentProfileBuilder()
+                .WithContent(() => null)
+                .AddPlacement(first);
+        ProductPackagingContentProfile profile = builder.Build();
+
+        builder.AddPlacement(second);
+        ProductPackagingContentProfile repeated = builder.Build();
+
+        Assert.Equal(new[] { first }, profile.Placements);
+        Assert.Equal(new[] { first, second }, repeated.Placements);
+    }
+
+    [Fact]
+    public void NullPlacementIsRejected()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .AddPlacement(null!));
+    }
+
+    [Fact]
+    public void NullPlacementArrayIsRejected()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .AddPlacements(null!));
+    }
+
+    [Fact]
+    public void NullPlacementInsideArrayIsRejected()
+    {
+        ProductPresentationTransform valid = CreatePlacementWithoutUnityRuntime();
+
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .AddPlacements(valid, null!));
+    }
+
+    private static ProductPresentationTransform CreatePlacementWithoutUnityRuntime()
+    {
+        return
+            (ProductPresentationTransform)RuntimeHelpers.GetUninitializedObject(
+                typeof(ProductPresentationTransform));
+    }
+}

--- a/S1API.Tests/Products/ProductPackagingContentRuntimeContractTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentRuntimeContractTests.cs
@@ -1,0 +1,52 @@
+using S1API.Internal.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductPackagingContentRuntimeContractTests
+{
+    [Fact]
+    public void OwnedRootIdentityIsCaseInsensitiveForTheRegisteredPair()
+    {
+        string first =
+            ProductPackagingContentRuntime.GetGeneratedRootNameForTesting(
+                "example.mod:heart-pill",
+                "baggie");
+        string repeated =
+            ProductPackagingContentRuntime.GetGeneratedRootNameForTesting(
+                "EXAMPLE.MOD:HEART-PILL",
+                "BAGGIE");
+
+        Assert.Equal(first, repeated);
+        Assert.StartsWith("S1API_PackagingContent_", first);
+        Assert.DoesNotContain("/", first);
+    }
+
+    [Fact]
+    public void OwnedRootIdentityIncludesProductAndPackaging()
+    {
+        string baggie =
+            ProductPackagingContentRuntime.GetGeneratedRootNameForTesting(
+                "example.mod:heart-pill",
+                "baggie");
+        string jar =
+            ProductPackagingContentRuntime.GetGeneratedRootNameForTesting(
+                "example.mod:heart-pill",
+                "jar");
+        string otherProduct =
+            ProductPackagingContentRuntime.GetGeneratedRootNameForTesting(
+                "example.mod:other-pill",
+                "baggie");
+
+        Assert.NotEqual(baggie, jar);
+        Assert.NotEqual(baggie, otherProduct);
+    }
+
+    [Fact]
+    public void SceneResetLeavesNoGeneratedIconEntries()
+    {
+        ProductPackagingContentRuntime.ResetForSceneChange();
+
+        Assert.Equal(0, ProductPackagingContentRuntime.CachedIconCountForTesting);
+        Assert.True(ProductPackagingContentRuntime.GeneratedIconWorkComplete);
+    }
+}

--- a/S1API/Internal/Patches/LoadingScreenPatches.cs
+++ b/S1API/Internal/Patches/LoadingScreenPatches.cs
@@ -194,6 +194,7 @@ namespace S1API.Internal.Patches
             }
 
             while ((!CustomProductPresentationRuntime.GeneratedIconWorkComplete ||
+                    !ProductPackagingContentRuntime.GeneratedIconWorkComplete ||
                     (waitForMugshots &&
                      !NPCAppearance.MugshotsProcessingComplete)) &&
                    timer < TIMEOUT)
@@ -212,7 +213,7 @@ namespace S1API.Internal.Patches
                     $"Rendered icon generation timeout reached after {TIMEOUT}s. " +
                     $"{remaining} NPCs may have incomplete portraits; " +
                     $"product icons complete: " +
-                    $"{CustomProductPresentationRuntime.GeneratedIconWorkComplete}.");
+                    $"{CustomProductPresentationRuntime.GeneratedIconWorkComplete && ProductPackagingContentRuntime.GeneratedIconWorkComplete}.");
             }
             
             CloseLoadingScreenDirectly(loadingScreen);

--- a/S1API/Internal/Patches/ProductPackagingContentPatches.cs
+++ b/S1API/Internal/Patches/ProductPackagingContentPatches.cs
@@ -1,0 +1,128 @@
+using System;
+using HarmonyLib;
+using S1API.Internal.Products;
+using UnityEngine;
+#if IL2CPPMELON
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1DevUtilities = ScheduleOne.DevUtilities;
+using S1Product = ScheduleOne.Product;
+#endif
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Routes registered custom product/package pairs around native drug-type visuals.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class ProductPackagingContentPatches
+    {
+        [HarmonyPatch(
+            typeof(S1Product.MultiTypeVisualsSetter),
+            nameof(S1Product.MultiTypeVisualsSetter.ApplyVisuals),
+            new Type[] { typeof(S1Product.ProductItemInstance) })]
+        [HarmonyPrefix]
+        private static bool ApplyVisualsPrefix(
+            S1Product.MultiTypeVisualsSetter __instance,
+            S1Product.ProductItemInstance itemInstance)
+        {
+            if (ProductPackagingContentRuntime.IsNativeIconFallbackActive)
+                return true;
+
+            return !ProductPackagingContentRuntime.TryApply(
+                __instance,
+                itemInstance);
+        }
+
+        [HarmonyPatch(
+            typeof(S1Product.ProductIconManager),
+            nameof(S1Product.ProductIconManager.GenerateIcons))]
+        [HarmonyPrefix]
+        private static void GenerateIconsPrefix()
+        {
+            ProductPackagingContentRuntime.BeginNativeIconBatch();
+        }
+
+        [HarmonyPatch(
+            typeof(S1Product.ProductIconManager),
+            nameof(S1Product.ProductIconManager.GenerateIcons))]
+        [HarmonyFinalizer]
+        private static Exception? GenerateIconsFinalizer(Exception? __exception)
+        {
+            ProductPackagingContentRuntime.EndNativeIconBatch();
+            return __exception;
+        }
+
+        [HarmonyPatch(
+            typeof(S1DevUtilities.IconGenerator),
+            nameof(S1DevUtilities.IconGenerator.GeneratePackagingIcon))]
+        [HarmonyPrefix]
+        private static bool GeneratePackagingIconPrefix(
+            S1DevUtilities.IconGenerator __instance,
+            string packagingID,
+            string productID,
+            ref Texture2D __result,
+            ref bool __state)
+        {
+            if (ProductPackagingContentRuntime
+                .TryDeferNativeBatchPackagingIcon(packagingID, productID))
+            {
+                __state = true;
+                return true;
+            }
+
+            if (!ProductPackagingContentRuntime.TryGeneratePackagingIcon(
+                    __instance,
+                    packagingID,
+                    productID,
+                    out Texture2D? texture))
+            {
+                return true;
+            }
+
+            __result = texture!;
+            return false;
+        }
+
+        [HarmonyPatch(
+            typeof(S1DevUtilities.IconGenerator),
+            nameof(S1DevUtilities.IconGenerator.GeneratePackagingIcon))]
+        [HarmonyFinalizer]
+        private static Exception? GeneratePackagingIconFinalizer(
+            bool __state,
+            Exception? __exception)
+        {
+            if (__state)
+                ProductPackagingContentRuntime.EndNativeIconFallback();
+            return __exception;
+        }
+
+        [HarmonyPatch(
+            typeof(S1Product.ProductIconManager),
+            nameof(S1Product.ProductIconManager.GetIcon),
+            new Type[]
+            {
+                typeof(string),
+                typeof(string),
+                typeof(bool)
+            })]
+        [HarmonyPrefix]
+        private static bool GetIconPrefix(
+            string productID,
+            string packagingID,
+            ref Sprite __result)
+        {
+            if (!ProductPackagingContentRuntime.TryGetPackagingIcon(
+                    productID,
+                    packagingID,
+                    out Sprite? icon))
+            {
+                return true;
+            }
+
+            __result = icon!;
+            return false;
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductPackagingContentProfileRegistration.cs
+++ b/S1API/Internal/Products/ProductPackagingContentProfileRegistration.cs
@@ -1,0 +1,65 @@
+using System;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal readonly struct ProductPackagingContentKey :
+        IEquatable<ProductPackagingContentKey>
+    {
+        internal ProductPackagingContentKey(string productId, string packagingId)
+        {
+            ProductId = productId;
+            PackagingId = packagingId;
+        }
+
+        internal string ProductId { get; }
+
+        internal string PackagingId { get; }
+
+        public bool Equals(ProductPackagingContentKey other)
+        {
+            return string.Equals(
+                       ProductId,
+                       other.ProductId,
+                       StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(
+                       PackagingId,
+                       other.PackagingId,
+                       StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ProductPackagingContentKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return
+                    (StringComparer.OrdinalIgnoreCase.GetHashCode(ProductId) * 397) ^
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(PackagingId);
+            }
+        }
+    }
+
+    internal sealed class ProductPackagingContentProfileRegistration
+    {
+        internal ProductPackagingContentProfileRegistration(
+            string ownerId,
+            ProductPackagingContentKey key,
+            ProductPackagingContentProfile profile)
+        {
+            OwnerId = ownerId;
+            Key = key;
+            Profile = profile;
+        }
+
+        internal string OwnerId { get; }
+
+        internal ProductPackagingContentKey Key { get; }
+
+        internal ProductPackagingContentProfile Profile { get; }
+    }
+}

--- a/S1API/Internal/Products/ProductPackagingContentRuntime.cs
+++ b/S1API/Internal/Products/ProductPackagingContentRuntime.cs
@@ -1,0 +1,871 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using MelonLoader;
+using S1API.Products;
+using S1API.Rendering;
+using UnityEngine;
+using UnityEngine.Rendering;
+using Object = UnityEngine.Object;
+#if IL2CPPMELON
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1DevUtilities = ScheduleOne.DevUtilities;
+using S1Product = ScheduleOne.Product;
+#endif
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Replaces native type-switched package contents on individual runtime objects.
+    /// </summary>
+    internal static class ProductPackagingContentRuntime
+    {
+        private const string GeneratedRootNamePrefix =
+            "S1API_PackagingContent_";
+        private static readonly object IconGate = new object();
+        private static readonly object IconQueueGate = new object();
+        private static readonly object FailureGate = new object();
+        private static readonly Dictionary<
+            ProductPackagingContentKey,
+            GeneratedPackagingIcon> GeneratedIcons =
+                new Dictionary<
+                    ProductPackagingContentKey,
+                    GeneratedPackagingIcon>();
+        private static readonly HashSet<string> LoggedFailures =
+            new HashSet<string>(StringComparer.Ordinal);
+        private static readonly Queue<ProductPackagingContentProfileRegistration>
+            GeneratedIconQueue =
+                new Queue<ProductPackagingContentProfileRegistration>();
+        private static readonly HashSet<ProductPackagingContentKey>
+            QueuedGeneratedIcons =
+                new HashSet<ProductPackagingContentKey>();
+        private static int _iconGeneratorInstanceId;
+        private static int _iconQueueGeneration;
+        private static bool _isProcessingGeneratedIcons;
+        private static int _nativeIconBatchDepth;
+        private static int _nativeIconFallbackDepth;
+
+        private sealed class GeneratedPackagingIcon
+        {
+            internal GeneratedPackagingIcon(Texture2D texture, Sprite icon)
+            {
+                Texture = texture;
+                Icon = icon;
+            }
+
+            internal Texture2D Texture { get; }
+
+            internal Sprite Icon { get; }
+        }
+
+        internal static bool TryApply(
+            S1Product.MultiTypeVisualsSetter setter,
+            S1Product.ProductItemInstance product)
+        {
+            if (setter == null)
+                return false;
+
+            if (product == null ||
+                string.IsNullOrWhiteSpace(product.PackagingID) ||
+                !ProductPackagingContentProfileRegistry.TryResolve(
+                    product.ID,
+                    product.PackagingID,
+                    out ProductPackagingContentProfileRegistration? registration) ||
+                registration == null)
+            {
+                RemoveOwnedRoots(setter.transform, null);
+                return false;
+            }
+
+            string expectedRootName = GetGeneratedRootName(registration.Key);
+            Transform? existing =
+                FindOwnedRoot(setter.transform, expectedRootName);
+            RemoveOwnedRoots(setter.transform, existing);
+
+            if (existing != null)
+            {
+                if (!TryDisableNativeVisuals(setter, registration, "runtime visual"))
+                {
+                    DestroyOwnedRoot(existing.gameObject);
+                    return false;
+                }
+
+                existing.gameObject.SetActive(true);
+                return true;
+            }
+
+            if (!TryCreateContentRoot(
+                    setter.transform,
+                    registration,
+                    expectedRootName,
+                    out GameObject? generatedRoot))
+            {
+                return false;
+            }
+
+            if (!TryDisableNativeVisuals(
+                    setter,
+                    registration,
+                    "runtime visual"))
+            {
+                DestroyOwnedRoot(generatedRoot!);
+                return false;
+            }
+
+            generatedRoot!.SetActive(true);
+            return true;
+        }
+
+        internal static bool TryGeneratePackagingIcon(
+            S1DevUtilities.IconGenerator generator,
+            string packagingId,
+            string productId,
+            out Texture2D? texture)
+        {
+            texture = null;
+            if (generator == null ||
+                string.IsNullOrWhiteSpace(productId) ||
+                string.IsNullOrWhiteSpace(packagingId) ||
+                !ProductPackagingContentProfileRegistry.TryResolve(
+                    productId,
+                    packagingId,
+                    out ProductPackagingContentProfileRegistration? registration) ||
+                registration == null)
+            {
+                return false;
+            }
+
+            lock (IconGate)
+            {
+                return TryGeneratePackagingIconCore(
+                    generator,
+                    registration,
+                    out texture);
+            }
+        }
+
+        internal static void BeginNativeIconBatch()
+        {
+            _nativeIconBatchDepth++;
+        }
+
+        internal static void EndNativeIconBatch()
+        {
+            if (_nativeIconBatchDepth > 0)
+                _nativeIconBatchDepth--;
+        }
+
+        internal static bool TryDeferNativeBatchPackagingIcon(
+            string packagingId,
+            string productId)
+        {
+            if (_nativeIconBatchDepth <= 0 ||
+                string.IsNullOrWhiteSpace(productId) ||
+                string.IsNullOrWhiteSpace(packagingId) ||
+                !ProductPackagingContentProfileRegistry.TryResolve(
+                    productId,
+                    packagingId,
+                    out ProductPackagingContentProfileRegistration? registration) ||
+                registration == null)
+            {
+                return false;
+            }
+
+            QueueGeneratedIcon(registration);
+            _nativeIconFallbackDepth++;
+            return true;
+        }
+
+        internal static void EndNativeIconFallback()
+        {
+            if (_nativeIconFallbackDepth > 0)
+                _nativeIconFallbackDepth--;
+        }
+
+        internal static bool IsNativeIconFallbackActive =>
+            _nativeIconFallbackDepth > 0;
+
+        internal static bool TryGetPackagingIcon(
+            string productId,
+            string packagingId,
+            out Sprite? icon)
+        {
+            icon = null;
+            if (string.IsNullOrWhiteSpace(productId) ||
+                string.IsNullOrWhiteSpace(packagingId) ||
+                !ProductPackagingContentProfileRegistry.TryResolve(
+                    productId,
+                    packagingId,
+                    out ProductPackagingContentProfileRegistration? registration) ||
+                registration == null)
+            {
+                return false;
+            }
+
+            S1DevUtilities.IconGenerator generator;
+            try
+            {
+                generator = IconFactory.S1IconGenerator;
+            }
+            catch
+            {
+                return false;
+            }
+
+            if (generator == null)
+                return false;
+
+            lock (IconGate)
+            {
+                EnsureIconCacheMatches(generator);
+                if (GeneratedIcons.TryGetValue(
+                        registration.Key,
+                        out GeneratedPackagingIcon? existing))
+                {
+                    if (existing.Icon != null && existing.Texture != null)
+                    {
+                        icon = existing.Icon;
+                        return true;
+                    }
+
+                    DestroyGeneratedIcon(existing);
+                    GeneratedIcons.Remove(registration.Key);
+                }
+            }
+
+            QueueGeneratedIcon(registration);
+            return false;
+        }
+
+        internal static void ResetForSceneChange()
+        {
+            lock (IconGate)
+            {
+                DestroyGeneratedIcons();
+                _iconGeneratorInstanceId = 0;
+            }
+
+            lock (IconQueueGate)
+            {
+                _iconQueueGeneration++;
+                GeneratedIconQueue.Clear();
+                QueuedGeneratedIcons.Clear();
+                _isProcessingGeneratedIcons = false;
+            }
+
+            _nativeIconBatchDepth = 0;
+            _nativeIconFallbackDepth = 0;
+
+            lock (FailureGate)
+                LoggedFailures.Clear();
+        }
+
+        internal static bool GeneratedIconWorkComplete
+        {
+            get
+            {
+                lock (IconQueueGate)
+                {
+                    return !_isProcessingGeneratedIcons &&
+                           GeneratedIconQueue.Count == 0;
+                }
+            }
+        }
+
+        internal static int CachedIconCountForTesting
+        {
+            get
+            {
+                lock (IconGate)
+                    return GeneratedIcons.Count;
+            }
+        }
+
+        internal static string GetGeneratedRootNameForTesting(
+            string productId,
+            string packagingId)
+        {
+            return GetGeneratedRootName(
+                new ProductPackagingContentKey(productId, packagingId));
+        }
+
+        private static bool TryGeneratePackagingIconCore(
+            S1DevUtilities.IconGenerator generator,
+            ProductPackagingContentProfileRegistration registration,
+            out Texture2D? texture)
+        {
+            texture = null;
+            Transform? shellSource =
+                FindPackagingShell(generator, registration.Key.PackagingId);
+            if (shellSource == null)
+            {
+                LogFailureOnce(
+                    registration,
+                    "composite icon",
+                    "the active native icon rig has no matching packaging shell");
+                return false;
+            }
+
+            bool? mainContainerWasActive =
+                generator.MainContainer != null
+                    ? generator.MainContainer.gameObject.activeSelf
+                    : null;
+            bool? itemContainerWasActive =
+                generator.ItemContainer != null
+                    ? generator.ItemContainer.gameObject.activeSelf
+                    : null;
+            AmbientMode originalAmbientMode = RenderSettings.ambientMode;
+            Color originalAmbientLight = RenderSettings.ambientLight;
+            Color originalAmbientSkyColor = RenderSettings.ambientSkyColor;
+            Color originalAmbientEquatorColor = RenderSettings.ambientEquatorColor;
+            Color originalAmbientGroundColor = RenderSettings.ambientGroundColor;
+            GameObject? shell = null;
+
+            try
+            {
+                shell =
+                    Object.Instantiate(
+                        shellSource.gameObject,
+                        shellSource.parent,
+                        worldPositionStays: false);
+                S1Product.MultiTypeVisualsSetter setter =
+                    shell.GetComponentInChildren<
+                        S1Product.MultiTypeVisualsSetter>(true);
+                if (setter == null)
+                {
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        "the matching native shell has no content anchor");
+                    return false;
+                }
+
+                if (!TryCreateContentRoot(
+                        setter.transform,
+                        registration,
+                        GetGeneratedRootName(registration.Key),
+                        out GameObject? generatedRoot))
+                {
+                    return false;
+                }
+
+                if (!TryDisableNativeVisuals(
+                        setter,
+                        registration,
+                        "composite icon"))
+                {
+                    return false;
+                }
+
+                int iconLayer = setter.gameObject.layer;
+                S1DevUtilities.LayerUtility.SetLayerRecursively(
+                    generatedRoot!,
+                    iconLayer);
+                generatedRoot!.SetActive(true);
+                shell.SetActive(true);
+                texture = generator.GetTexture(setter.transform.parent);
+                if (texture == null)
+                {
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        "the native icon renderer returned no texture");
+                    return false;
+                }
+
+                if (!IconFactory.HasVisibleContent(texture))
+                {
+                    Object.Destroy(texture);
+                    texture = null;
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        "the native icon renderer returned no visible pixels");
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception exception)
+            {
+                if (texture != null)
+                {
+                    Object.Destroy(texture);
+                    texture = null;
+                }
+
+                LogFailureOnce(
+                    registration,
+                    "composite icon",
+                    exception.Message);
+                return false;
+            }
+            finally
+            {
+                if (shell != null)
+                {
+                    shell.SetActive(false);
+                    Object.Destroy(shell);
+                }
+                if (mainContainerWasActive.HasValue &&
+                    generator.MainContainer != null)
+                {
+                    generator.MainContainer.gameObject.SetActive(
+                        mainContainerWasActive.Value);
+                }
+
+                if (itemContainerWasActive.HasValue &&
+                    generator.ItemContainer != null)
+                {
+                    generator.ItemContainer.gameObject.SetActive(
+                        itemContainerWasActive.Value);
+                }
+
+                RenderSettings.ambientMode = originalAmbientMode;
+                RenderSettings.ambientLight = originalAmbientLight;
+                RenderSettings.ambientSkyColor = originalAmbientSkyColor;
+                RenderSettings.ambientEquatorColor =
+                    originalAmbientEquatorColor;
+                RenderSettings.ambientGroundColor =
+                    originalAmbientGroundColor;
+            }
+        }
+
+        private static void QueueGeneratedIcon(
+            ProductPackagingContentProfileRegistration registration)
+        {
+            bool startProcessor = false;
+            int generation;
+            lock (IconQueueGate)
+            {
+                if (!QueuedGeneratedIcons.Add(registration.Key))
+                    return;
+
+                GeneratedIconQueue.Enqueue(registration);
+                generation = _iconQueueGeneration;
+                if (!_isProcessingGeneratedIcons)
+                {
+                    _isProcessingGeneratedIcons = true;
+                    startProcessor = true;
+                }
+            }
+
+            if (startProcessor)
+            {
+                try
+                {
+                    MelonCoroutines.Start(
+                        ProcessGeneratedIconQueue(generation));
+                }
+                catch (Exception exception)
+                {
+                    lock (IconQueueGate)
+                    {
+                        if (generation == _iconQueueGeneration)
+                        {
+                            GeneratedIconQueue.Clear();
+                            QueuedGeneratedIcons.Clear();
+                            _isProcessingGeneratedIcons = false;
+                        }
+                    }
+
+                    LogFailureOnce(
+                        registration,
+                        "composite icon queue",
+                        exception.Message);
+                }
+            }
+        }
+
+        private static IEnumerator ProcessGeneratedIconQueue(int generation)
+        {
+            while (true)
+            {
+                ProductPackagingContentProfileRegistration? registration;
+                lock (IconQueueGate)
+                {
+                    if (generation != _iconQueueGeneration)
+                        yield break;
+
+                    if (GeneratedIconQueue.Count == 0)
+                    {
+                        _isProcessingGeneratedIcons = false;
+                        yield break;
+                    }
+
+                    registration = GeneratedIconQueue.Dequeue();
+                }
+
+                const int readinessFrames = 300;
+                int readinessFrame = 0;
+                while (!IconFactory.IsItemIconGeneratorReady &&
+                       readinessFrame < readinessFrames)
+                {
+                    readinessFrame++;
+                    yield return null;
+                }
+
+                if (generation != _iconQueueGeneration)
+                    yield break;
+
+                if (!IconFactory.IsItemIconGeneratorReady)
+                {
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        "the native item-icon rendering rig did not become ready");
+                    CompleteQueuedIcon(registration.Key, generation);
+                    continue;
+                }
+
+                yield return null;
+                yield return new WaitForEndOfFrame();
+
+                if (generation != _iconQueueGeneration)
+                    yield break;
+
+                try
+                {
+                    S1DevUtilities.IconGenerator generator =
+                        IconFactory.S1IconGenerator;
+                    lock (IconGate)
+                    {
+                        EnsureIconCacheMatches(generator);
+                        if (!GeneratedIcons.ContainsKey(registration.Key) &&
+                            TryGeneratePackagingIconCore(
+                                generator,
+                                registration,
+                                out Texture2D? texture) &&
+                            texture != null)
+                        {
+                            TryCacheGeneratedIcon(registration, texture);
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        exception.Message);
+                }
+                finally
+                {
+                    CompleteQueuedIcon(registration.Key, generation);
+                }
+
+                // RuntimePreviewGenerator uses a shared render rig. Give its
+                // temporary model a frame to leave the rig before the next pair.
+                yield return null;
+            }
+        }
+
+        private static void CompleteQueuedIcon(
+            ProductPackagingContentKey key,
+            int generation)
+        {
+            lock (IconQueueGate)
+            {
+                if (generation == _iconQueueGeneration)
+                    QueuedGeneratedIcons.Remove(key);
+            }
+        }
+
+        private static bool TryCacheGeneratedIcon(
+            ProductPackagingContentProfileRegistration registration,
+            Texture2D texture)
+        {
+            Sprite? generated = null;
+            try
+            {
+                texture.Apply();
+                generated =
+                    Sprite.Create(
+                        texture,
+                        new Rect(0f, 0f, texture.width, texture.height),
+                        new Vector2(0.5f, 0.5f));
+                if (generated == null)
+                {
+                    Object.Destroy(texture);
+                    LogFailureOnce(
+                        registration,
+                        "composite icon",
+                        "the rendered texture could not be converted to a sprite");
+                    return false;
+                }
+
+                generated.name =
+                    $"{registration.Key.ProductId}_" +
+                    $"{registration.Key.PackagingId}_S1API";
+                GeneratedIcons.Add(
+                    registration.Key,
+                    new GeneratedPackagingIcon(texture, generated));
+                return true;
+            }
+            catch (Exception exception)
+            {
+                if (generated != null)
+                    Object.Destroy(generated);
+                Object.Destroy(texture);
+                LogFailureOnce(
+                    registration,
+                    "composite icon",
+                    exception.Message);
+                return false;
+            }
+        }
+
+        private static Transform? FindPackagingShell(
+            S1DevUtilities.IconGenerator generator,
+            string packagingId)
+        {
+            if (generator.Visuals == null)
+                return null;
+
+            for (int i = 0; i < generator.Visuals.Count; i++)
+            {
+                var visuals = generator.Visuals[i];
+                if (visuals != null &&
+                    string.Equals(
+                        visuals.PackagingID,
+                        packagingId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return visuals.TopLevelTransform;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryCreateContentRoot(
+            Transform parent,
+            ProductPackagingContentProfileRegistration registration,
+            string rootName,
+            out GameObject? generatedRoot)
+        {
+            generatedRoot = new GameObject(rootName);
+            generatedRoot.transform.SetParent(parent, false);
+            generatedRoot.SetActive(false);
+
+            GameObject? source;
+            try
+            {
+                source = registration.Profile.ContentProvider();
+            }
+            catch (Exception exception)
+            {
+                LogFailureOnce(
+                    registration,
+                    "content provider",
+                    exception.Message);
+                DestroyOwnedRoot(generatedRoot);
+                generatedRoot = null;
+                return false;
+            }
+
+            if (source == null)
+            {
+                LogFailureOnce(
+                    registration,
+                    "content provider",
+                    "the provider returned null");
+                DestroyOwnedRoot(generatedRoot);
+                generatedRoot = null;
+                return false;
+            }
+
+            try
+            {
+                if (registration.Profile.Placements.Count == 0)
+                {
+                    AddContentClone(source, generatedRoot.transform, null);
+                    return true;
+                }
+
+                for (int i = 0; i < registration.Profile.Placements.Count; i++)
+                {
+                    AddContentClone(
+                        source,
+                        generatedRoot.transform,
+                        registration.Profile.Placements[i]);
+                }
+
+                return true;
+            }
+            catch (Exception exception)
+            {
+                LogFailureOnce(
+                    registration,
+                    "content composition",
+                    exception.Message);
+                DestroyOwnedRoot(generatedRoot);
+                generatedRoot = null;
+                return false;
+            }
+        }
+
+        private static void AddContentClone(
+            GameObject source,
+            Transform parent,
+            ProductPresentationTransform? placement)
+        {
+            Vector3 authoredPosition = source.transform.localPosition;
+            Quaternion authoredRotation = source.transform.localRotation;
+            Vector3 authoredScale = source.transform.localScale;
+            GameObject content = Object.Instantiate(source);
+            content.transform.SetParent(parent, false);
+            if (placement != null)
+            {
+                placement.ApplyTo(content.transform);
+            }
+            else
+            {
+                content.transform.localPosition = authoredPosition;
+                content.transform.localRotation = authoredRotation;
+                content.transform.localScale = authoredScale;
+            }
+
+            content.SetActive(true);
+        }
+
+        private static bool TryDisableNativeVisuals(
+            S1Product.MultiTypeVisualsSetter setter,
+            ProductPackagingContentProfileRegistration registration,
+            string operation)
+        {
+            try
+            {
+                setter.WeedVisuals?.ResetVisuals();
+                setter.MethVisuals?.ResetVisuals();
+                setter.CocaineVisuals?.ResetVisuals();
+                setter.ShroomVisuals?.ResetVisuals();
+                return true;
+            }
+            catch (Exception exception)
+            {
+                LogFailureOnce(registration, operation, exception.Message);
+                return false;
+            }
+        }
+
+        private static Transform? FindOwnedRoot(
+            Transform parent,
+            string expectedName)
+        {
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                Transform child = parent.GetChild(i);
+                if (string.Equals(
+                        child.name,
+                        expectedName,
+                        StringComparison.Ordinal))
+                {
+                    return child;
+                }
+            }
+
+            return null;
+        }
+
+        private static void RemoveOwnedRoots(
+            Transform parent,
+            Transform? retainedRoot)
+        {
+            for (int i = parent.childCount - 1; i >= 0; i--)
+            {
+                Transform child = parent.GetChild(i);
+                if (child == retainedRoot ||
+                    !child.name.StartsWith(
+                        GeneratedRootNamePrefix,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                DestroyOwnedRoot(child.gameObject);
+            }
+        }
+
+        private static void DestroyOwnedRoot(GameObject root)
+        {
+            if (root == null)
+                return;
+
+            root.SetActive(false);
+            Object.Destroy(root);
+        }
+
+        private static string GetGeneratedRootName(
+            ProductPackagingContentKey key)
+        {
+            string identity =
+                key.ProductId.ToUpperInvariant() + "\0" +
+                key.PackagingId.ToUpperInvariant();
+            const ulong offset = 14695981039346656037UL;
+            const ulong prime = 1099511628211UL;
+            ulong hash = offset;
+            for (int i = 0; i < identity.Length; i++)
+            {
+                char value = identity[i];
+                hash ^= (byte)value;
+                hash *= prime;
+                hash ^= (byte)(value >> 8);
+                hash *= prime;
+            }
+
+            return GeneratedRootNamePrefix + hash.ToString("X16");
+        }
+
+        private static void EnsureIconCacheMatches(
+            S1DevUtilities.IconGenerator generator)
+        {
+            int generatorInstanceId = generator.GetInstanceID();
+            if (_iconGeneratorInstanceId == generatorInstanceId)
+                return;
+
+            DestroyGeneratedIcons();
+            _iconGeneratorInstanceId = generatorInstanceId;
+        }
+
+        private static void DestroyGeneratedIcons()
+        {
+            foreach (GeneratedPackagingIcon generated in GeneratedIcons.Values)
+                DestroyGeneratedIcon(generated);
+            GeneratedIcons.Clear();
+        }
+
+        private static void DestroyGeneratedIcon(
+            GeneratedPackagingIcon generated)
+        {
+            if (generated.Icon != null)
+                Object.Destroy(generated.Icon);
+            if (generated.Texture != null)
+                Object.Destroy(generated.Texture);
+        }
+
+        private static void LogFailureOnce(
+            ProductPackagingContentProfileRegistration registration,
+            string operation,
+            string reason)
+        {
+            string failureKey =
+                registration.Key.ProductId.ToUpperInvariant() + "\0" +
+                registration.Key.PackagingId.ToUpperInvariant() + "\0" +
+                operation;
+            lock (FailureGate)
+            {
+                if (!LoggedFailures.Add(failureKey))
+                    return;
+            }
+
+            MelonLogger.Warning(
+                $"[ProductPackagingContentProfile] {operation} for product " +
+                $"'{registration.Key.ProductId}' and packaging " +
+                $"'{registration.Key.PackagingId}' failed: {reason}. " +
+                "Preserving the native presentation fallback.");
+        }
+    }
+}

--- a/S1API/Products/ProductPackagingContentProfile.cs
+++ b/S1API/Products/ProductPackagingContentProfile.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Describes mod-owned product content rendered inside one packaging type.
+    /// </summary>
+    /// <remarks>
+    /// S1API clones the provider's object for every configured placement. The game-owned
+    /// packaging shell remains unchanged and assets are not transmitted to other peers.
+    /// </remarks>
+    public sealed class ProductPackagingContentProfile
+    {
+        internal ProductPackagingContentProfile(
+            Func<GameObject?> contentProvider,
+            IReadOnlyList<ProductPresentationTransform> placements)
+        {
+            ContentProvider = contentProvider;
+            Placements = placements;
+        }
+
+        internal Func<GameObject?> ContentProvider { get; }
+
+        internal IReadOnlyList<ProductPresentationTransform> Placements { get; }
+    }
+}

--- a/S1API/Products/ProductPackagingContentProfileBuilder.cs
+++ b/S1API/Products/ProductPackagingContentProfileBuilder.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Builds an immutable product packaging-content profile.
+    /// </summary>
+    public sealed class ProductPackagingContentProfileBuilder
+    {
+        private readonly List<ProductPresentationTransform> _placements =
+            new List<ProductPresentationTransform>();
+        private Func<GameObject?>? _contentProvider;
+
+        /// <summary>
+        /// Sets the reusable mod-owned content prefab source.
+        /// </summary>
+        /// <param name="provider">A provider that returns a reusable prefab source.</param>
+        /// <returns>This builder.</returns>
+        public ProductPackagingContentProfileBuilder WithContent(
+            Func<GameObject?> provider)
+        {
+            _contentProvider =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds one explicit placement for a clone of the content prefab.
+        /// </summary>
+        /// <param name="placement">The clone's local transform inside the packaging shell.</param>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// When no placements are added, S1API creates one clone and preserves the transform
+        /// authored by the provider.
+        /// </remarks>
+        public ProductPackagingContentProfileBuilder AddPlacement(
+            ProductPresentationTransform placement)
+        {
+            _placements.Add(
+                placement ?? throw new ArgumentNullException(nameof(placement)));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds explicit placements for repeated clones of the content prefab.
+        /// </summary>
+        /// <param name="placements">The clones' local transforms inside the packaging shell.</param>
+        /// <returns>This builder.</returns>
+        public ProductPackagingContentProfileBuilder AddPlacements(
+            params ProductPresentationTransform[] placements)
+        {
+            if (placements == null)
+                throw new ArgumentNullException(nameof(placements));
+
+            for (int i = 0; i < placements.Length; i++)
+                AddPlacement(placements[i]);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Creates an immutable packaging-content profile snapshot.
+        /// </summary>
+        /// <returns>The packaging-content profile.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when no content provider is configured.
+        /// </exception>
+        public ProductPackagingContentProfile Build()
+        {
+            if (_contentProvider == null)
+            {
+                throw new InvalidOperationException(
+                    "A packaging content provider must be configured before Build().");
+            }
+
+            return new ProductPackagingContentProfile(
+                _contentProvider,
+                new List<ProductPresentationTransform>(_placements).AsReadOnly());
+        }
+    }
+}

--- a/S1API/Products/ProductPackagingContentProfileRegistry.cs
+++ b/S1API/Products/ProductPackagingContentProfileRegistry.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Registers process-lifetime packaging-content profiles by product and packaging ID.
+    /// </summary>
+    /// <remarks>
+    /// Keys are case-insensitive. Registration does not transmit assets; every participating
+    /// peer must register matching product definitions and profiles locally.
+    /// </remarks>
+    public static class ProductPackagingContentProfileRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<ProductPackagingContentKey,
+            ProductPackagingContentProfileRegistration> Registrations =
+                new Dictionary<ProductPackagingContentKey,
+                    ProductPackagingContentProfileRegistration>();
+
+        /// <summary>
+        /// Registers content for one stable product and packaging pair.
+        /// </summary>
+        /// <param name="ownerId">The stable ID of the owning mod.</param>
+        /// <param name="productId">The stable, namespaced custom product ID.</param>
+        /// <param name="packagingId">The packaging definition ID, such as <c>baggie</c>.</param>
+        /// <param name="profile">The immutable packaging-content profile.</param>
+        /// <returns>The retained profile.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when an argument is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when an ID is empty or <paramref name="productId"/> is not namespaced.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the product/packaging pair has a conflicting owner or profile.
+        /// </exception>
+        public static ProductPackagingContentProfile Register(
+            string ownerId,
+            string productId,
+            string packagingId,
+            ProductPackagingContentProfile profile)
+        {
+            string normalizedOwnerId = NormalizeRequired(ownerId, nameof(ownerId));
+            string normalizedProductId =
+                ProductKindId.Normalize(productId, nameof(productId));
+            string normalizedPackagingId =
+                NormalizeRequired(packagingId, nameof(packagingId));
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+
+            var key =
+                new ProductPackagingContentKey(
+                    normalizedProductId,
+                    normalizedPackagingId);
+            lock (Gate)
+            {
+                if (Registrations.TryGetValue(
+                        key,
+                        out ProductPackagingContentProfileRegistration? existing))
+                {
+                    if (!string.Equals(
+                            existing.OwnerId,
+                            normalizedOwnerId,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Packaging content for product '{normalizedProductId}' and " +
+                            $"packaging '{normalizedPackagingId}' is already owned by " +
+                            $"'{existing.OwnerId}' and cannot be registered by " +
+                            $"'{normalizedOwnerId}'. Registration keys are case-insensitive.");
+                    }
+
+                    if (!ReferenceEquals(existing.Profile, profile))
+                    {
+                        throw new InvalidOperationException(
+                            $"Packaging content for product '{normalizedProductId}' and " +
+                            $"packaging '{normalizedPackagingId}' is already registered by " +
+                            "this owner with another profile. Reuse the original profile.");
+                    }
+
+                    return existing.Profile;
+                }
+
+                Registrations.Add(
+                    key,
+                    new ProductPackagingContentProfileRegistration(
+                        normalizedOwnerId,
+                        key,
+                        profile));
+                return profile;
+            }
+        }
+
+        internal static bool TryResolve(
+            string productId,
+            string packagingId,
+            out ProductPackagingContentProfileRegistration? registration)
+        {
+            var key = new ProductPackagingContentKey(productId, packagingId);
+            lock (Gate)
+                return Registrations.TryGetValue(key, out registration);
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+                Registrations.Clear();
+            ProductPackagingContentRuntime.ResetForSceneChange();
+        }
+
+        private static string NormalizeRequired(string value, string parameterName)
+        {
+            if (value == null)
+                throw new ArgumentNullException(parameterName);
+
+            string normalized = value.Trim();
+            if (normalized.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Value cannot be empty or whitespace.",
+                    parameterName);
+            }
+
+            return normalized;
+        }
+    }
+}

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -5,6 +5,7 @@ using S1API.Internal;
 using S1API.Internal.Diagnostics;
 using S1API.Internal.Entities;
 using S1API.Internal.Lifecycle;
+using S1API.Internal.Products;
 using S1API.Lifecycle;
 using S1API.Map;
 
@@ -30,6 +31,7 @@ namespace S1API
 
         public override void OnDeinitializeMelon()
         {
+            ProductPackagingContentRuntime.ResetForSceneChange();
             CutsceneManager.Deinitialize();
             MapPOIManager.RemoveAll();
             UnityExceptionTraceHook.Remove();
@@ -60,6 +62,7 @@ namespace S1API
 
             if (sceneName == "Main" || sceneName == "Tutorial")
             {
+                ProductPackagingContentRuntime.ResetForSceneChange();
                 MapPOIManager.ResetForSceneChange();
             }
 

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -185,7 +185,7 @@ through a complete render frame, and rejects transparent cold-start captures.
 The loading screen stays open until queued product icons complete or reach the
 bounded retry timeout. `MugshotGenerator` remains reserved for avatar/accessory
 previews. The generated icon is the loose inventory icon only.
-`ProductIconManager` packaging combinations are intentionally unchanged.
+Filled packaging uses the separate packaging-content API below.
 
 Automatic icon fitting targets 72% of the native thumbnail camera by default.
 Adjust the framing or preserve the authored scale with the additive overload:
@@ -220,6 +220,76 @@ restoration.
 Presentation profiles affect only generic custom products registered with
 `CustomProductDefinitionBuilder`. Vanilla definitions, native-family builders,
 and legacy custom registrations are not modified.
+
+## Filled packaging contents and composite icons
+
+`ProductPackagingContentProfile` supplies the mod-owned content rendered inside
+one game-owned packaging shell. Profiles are keyed by both product ID and
+packaging ID, so a baggie and jar can use different counts and transforms:
+
+```csharp
+var pillInBaggie =
+    new ProductPackagingContentProfileBuilder()
+        .WithContent(() => pillVisualPrefab)
+        .AddPlacement(
+            new ProductPresentationTransform(
+                new Vector3(0f, 0.01f, 0f),
+                Vector3.zero,
+                Vector3.one))
+        .Build();
+
+ProductPackagingContentProfileRegistry.Register(
+    ownerId: "example.mod",
+    productId: "example.mod:products/focus-tablet",
+    packagingId: "baggie",
+    profile: pillInBaggie);
+
+var pillsInJar =
+    new ProductPackagingContentProfileBuilder()
+        .WithContent(() => pillVisualPrefab)
+        .AddPlacements(
+            jarPlacement1,
+            jarPlacement2,
+            jarPlacement3,
+            jarPlacement4,
+            jarPlacement5)
+        .Build();
+
+ProductPackagingContentProfileRegistry.Register(
+    ownerId: "example.mod",
+    productId: "example.mod:products/focus-tablet",
+    packagingId: "jar",
+    profile: pillsInJar);
+```
+
+Each placement creates one clone of the provider's prefab. If no placements are
+specified, S1API creates one clone and preserves its authored local transform.
+The same composite is used for filled stored items, equipped items, and the
+packaged inventory icon.
+
+S1API applies content to individual runtime objects and temporary icon-shell
+clones. It does not mutate the shared vanilla `PackagingDefinition` prefabs.
+Unregistered product/packaging pairs continue through the native visual and icon
+paths unchanged. If a registered provider fails or returns `null`, S1API removes
+any partial owned objects and preserves that same native fallback.
+
+Generated composite icons are single-flight and cached once per registered pair
+for the active `Main` or `Tutorial` scene. S1API owns both the generated
+`Sprite` and `Texture2D`; it destroys them when that scene unloads and recreates
+them lazily after a later load. Repeated calls reuse the scene cache and never
+append entries to the game's serialized icon list.
+
+Requests made through `ProductIconManager` enter a serialized render queue.
+S1API preserves the native fallback for the current frame, waits for the shared
+icon rig to settle, and then renders one registered product/packaging pair at a
+time. Later lookups use the cached composite. This prevents adjacent baggie,
+jar, or other packaging captures from appearing together during a render
+transition.
+
+Functional packing stations already parent real `FunctionalProduct` instances
+into their game-owned packaging objects, so this profile intentionally does not
+replace that interaction. Custom packaging definitions, packaging asset
+networking, and extra packaging save data remain outside this API.
 
 ## Loose and packaged instances
 
@@ -286,8 +356,8 @@ Not supported:
 
 - mixing, generated variants, native family conversion, or production-station
   recipes;
-- packaged contents, composite package icons, or packaging-content save data;
-- custom packaging definitions or Product Manager UI categories;
+- custom packaging definitions, packaging asset networking, additional
+  packaging-content save data, or Product Manager UI categories;
 - definition transfer to a peer without the defining mod; or
 - recovery of a saved custom item after its mod or stable definition ID is
   removed.


### PR DESCRIPTION
Closes #102.

## Summary

- add pair-scoped `ProductPackagingContentProfile` builder and registry APIs for mod-owned content providers and repeated local-transform placements
- compose registered content into filled stored/equipped package instances without mutating shared vanilla packaging prefabs
- render packaged inventory composites from cloned native shells through a serialized, frame-settled queue, with scene-owned sprite/texture caching and cleanup
- preserve deterministic native fallback for unregistered pairs and provider/render failures
- document the API and the shared icon/mugshot render-rig lifecycle rule

## Compatibility

- **Public API:** additive only. Adds the sealed `ProductPackagingContentProfile` and `ProductPackagingContentProfileBuilder` types plus the static `ProductPackagingContentProfileRegistry`. Existing public/protected symbols and signatures are unchanged.
- **Source and binary:** unchanged for existing callers. New builder parameters and representative named-argument syntax are covered by focused compile/contract tests.
- **Behavior:** opt-in per case-insensitive `(product ID, packaging ID)` pair. Existing products, packaging IDs, defaults, registration ordering, and vanilla presentation paths remain unchanged. Provider, composition, or render failures remove partial owned objects and continue through native fallback.
- **Save and network:** unchanged. Existing product and `PackagingID` data remain the durable identity; this change adds no save descriptor, payload, manifest, or asset-transfer behavior.
- **Runtime:** Mono and IL2CPP use the same lifecycle. Temporary render shells, cached sprites/textures, and queued work are cleared on icon-generator replacement, scene unload, and mod deinitialization.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — 0 warnings, 0 errors
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 170 passed
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` — 0 warnings, 0 errors
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 163 passed
- `docfx docfx.json` from `S1API/` — succeeded with 4 existing unresolved assembly-reference warnings and 0 errors
- documentation coverage — 81.07% (2,853/3,519; minimum 80%)
- Mono in-game create and fresh-process reload: two `Main` loads each; baggie stored/equipped with one heart pill; jar stored/equipped with ten heart pills; 25 idempotent applications; 25 repeated icon lookups per pair; vanilla fallback; cache replacement after scene unload; save restoration
- IL2CPP in-game create and fresh-process reload: the same two-load, placement, repetition, fallback, cache-lifetime, and save-restoration matrix passed
- inspected generated baggie/jar captures in both runtimes. The final local validation uses the mod-owned heartpill model with a larger baggie pill and ten jar pills shifted upward so every pill remains inside the native jar silhouette.

## Notes

The heartpill source/model, local smoke mod and runner, isolated game installs, game/AssetRipper exports, generated assemblies, saves, screenshots, logs, and runtime evidence remain local and ignored.

Custom packaging definitions, asset networking, save descriptors, multiplayer manifests, and mixing remain out of scope.

<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/189154c0-3e8f-427b-a890-48b332eb7c0a" />

<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/2ed1cb8c-39d5-4735-820e-0695664eb455" />