### PR TITLE
feat(products): add product-kind Product Manager metadata

### DIFF
--- a/S1API.Tests/Products/CustomProductPresentationRuntimeContractTests.cs
+++ b/S1API.Tests/Products/CustomProductPresentationRuntimeContractTests.cs
@@ -1,0 +1,21 @@
+using S1API.Internal.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductPresentationRuntimeContractTests
+{
+    [Fact]
+    public void EmptyNativeCaptureRetriesButNormalizationFailureIsTerminal()
+    {
+        Assert.Equal(
+            CustomProductPresentationRuntime.GeneratedIconAttemptResult.Retry,
+            CustomProductPresentationRuntime
+                .GetGeneratedTextureFailureResult(
+                    rendererProducedTexture: false));
+        Assert.Equal(
+            CustomProductPresentationRuntime.GeneratedIconAttemptResult.Failure,
+            CustomProductPresentationRuntime
+                .GetGeneratedTextureFailureResult(
+                    rendererProducedTexture: true));
+    }
+}

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -290,6 +290,65 @@ public sealed class ProductApiCompatibilityTests
         Assert.Equal(typeof(ProductPresentationProfile), registerKind.ReturnType);
     }
 
+    [Fact]
+    public void ProductKindMetadataApiIsAdditiveAndKeepsOptInDefaults()
+    {
+        Assert.True(typeof(ProductKindMetadata).IsSealed);
+        Assert.True(typeof(ProductKindMetadataBuilder).IsSealed);
+        Assert.True(typeof(ProductKindMetadataRegistry).IsAbstract);
+        Assert.True(typeof(ProductKindMetadataRegistry).IsSealed);
+
+        Assert.Equal(
+            typeof(ProductKind),
+            typeof(ProductKindMetadata)
+                .GetProperty(nameof(ProductKindMetadata.ProductKind))!
+                .PropertyType);
+        Assert.Equal(
+            typeof(UnityEngine.Color),
+            typeof(ProductKindMetadata)
+                .GetProperty(nameof(ProductKindMetadata.Color))!
+                .PropertyType);
+        Assert.Equal(
+            typeof(UnityEngine.Sprite),
+            typeof(ProductKindMetadata)
+                .GetProperty(nameof(ProductKindMetadata.Icon))!
+                .PropertyType);
+        Assert.Equal(
+            typeof(IReadOnlyList<string>),
+            typeof(ProductKindMetadata)
+                .GetProperty(nameof(ProductKindMetadata.SearchAliases))!
+                .PropertyType);
+
+        var visibility = typeof(ProductKindMetadataBuilder).GetMethod(
+            nameof(ProductKindMetadataBuilder.WithProductManagerVisibility),
+            new[] { typeof(bool) });
+        Assert.NotNull(visibility);
+        Assert.Equal(
+            typeof(ProductKindMetadataBuilder),
+            visibility.ReturnType);
+        AssertSingleOptionalParameter(visibility, "visible", true);
+
+        Assert.Equal(
+            new[] { "productKind" },
+            typeof(ProductKindMetadataBuilder)
+                .GetConstructors()
+                .Single()
+                .GetParameters()
+                .Select(parameter => parameter.Name));
+        Assert.NotNull(
+            typeof(ProductKindMetadataRegistry).GetMethod(
+                nameof(ProductKindMetadataRegistry.Get),
+                new[] { typeof(string) }));
+        Assert.NotNull(
+            typeof(ProductKindMetadataRegistry).GetMethod(
+                nameof(ProductKindMetadataRegistry.Get),
+                new[] { typeof(ProductKind) }));
+        Assert.NotNull(
+            typeof(ProductKindMetadata).GetMethod(
+                nameof(ProductKindMetadata.MatchesSearch),
+                new[] { typeof(string) }));
+    }
+
     private static void AssertObsoleteCompatibilityShim(
         System.Reflection.MemberInfo member,
         string expectedMessage)

--- a/S1API.Tests/Products/ProductKindMetadataApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductKindMetadataApiCompileFixture.cs
@@ -1,0 +1,41 @@
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+internal static class ProductKindMetadataApiCompileFixture
+{
+    internal static bool RepresentativeCallerCompiles(
+        ProductKind productKind,
+        Sprite icon,
+        string query)
+    {
+        ProductKindMetadata metadata =
+            new ProductKindMetadataBuilder(productKind)
+                .WithDisplayName("MDMA")
+                .WithColor(new Color(0.84f, 0.24f, 0.72f))
+                .WithIcon(icon)
+                .WithSortOrder(50)
+                .WithSearchAliases("ecstasy", "molly")
+                .WithProductManagerVisibility()
+                .Build();
+
+        ProductKindMetadata? byKind =
+            ProductKindMetadataRegistry.Get(productKind);
+        ProductKindMetadata? byId =
+            ProductKindMetadataRegistry.Get(productKind.Id);
+        bool foundByKind =
+            ProductKindMetadataRegistry.TryGet(productKind, out _);
+        bool foundById =
+            ProductKindMetadataRegistry.TryGet(productKind.Id, out _);
+        IReadOnlyCollection<ProductKindMetadata> all =
+            ProductKindMetadataRegistry.All;
+
+        return metadata.MatchesSearch(query)
+               && byKind == metadata
+               && byId == metadata
+               && foundByKind
+               && foundById
+               && all.Contains(metadata);
+    }
+}

--- a/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
+++ b/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
@@ -13,10 +13,16 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
     public ProductKindMetadataRegistryTests()
     {
         ProductKindMetadataRegistrationRegistry.ResetForTesting(_runtimeAdapter);
+#if IL2CPPMELON
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(_ => false);
+#endif
     }
 
     public void Dispose()
     {
+#if IL2CPPMELON
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(null);
+#endif
         ProductKindMetadataRegistrationRegistry.RestoreRuntimeAdapterForTesting();
     }
 
@@ -227,6 +233,78 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
     }
 
     [Fact]
+    public void AliasOrderIsPartOfRegistrationEquivalence()
+    {
+        ProductKind kind = CreateKind();
+        ProductKindMetadata first = new ProductKindMetadataBuilder(kind)
+            .WithDisplayName("Ecstasy")
+            .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+            .WithSearchAliases("ecstasy", "molly")
+            .Build();
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductKindMetadataBuilder(kind)
+                    .WithDisplayName("Ecstasy")
+                    .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+                    .WithSearchAliases("molly", "ecstasy")
+                    .Build());
+
+        Assert.Contains(kind.Id, exception.Message);
+        Assert.Equal(
+            new[] { "ecstasy", "molly" },
+            first.SearchAliases);
+        Assert.Same(first, ProductKindMetadataRegistry.Get(kind));
+    }
+
+    [Fact]
+    public void NativeMetadataFallbackSetMatchesVerifiedDormantTypes()
+    {
+        DrugType[] fallbackTypes = Enum.GetValues<DrugType>()
+            .Where(ProductKindNativeMetadataTypes.RequiresFallback)
+            .ToArray();
+
+        Assert.Equal(
+            new[] { DrugType.MDMA, DrugType.Heroin },
+            fallbackTypes);
+        Assert.False(
+            ProductKindNativeMetadataTypes.RequiresFallback(
+                DrugType.Marijuana));
+    }
+
+    [Fact]
+    public void IconValidationUsesUnityLifetimeSemantics()
+    {
+        ProductKind kind = CreateKind();
+        Sprite liveIcon = CreateSprite();
+
+        Assert.False(ProductKindIconLifetime.IsNullOrDestroyed(liveIcon));
+        Assert.True(ProductKindIconLifetime.IsNullOrDestroyed(null));
+
+#if MONOMELON
+        Sprite destroyedIcon =
+            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+        Assert.True(ProductKindIconLifetime.IsNullOrDestroyed(destroyedIcon));
+        Assert.Throws<ArgumentNullException>(
+            () => new ProductKindMetadataBuilder(kind)
+                .WithIcon(destroyedIcon));
+
+        var builder = new ProductKindMetadataBuilder(kind)
+            .WithDisplayName("MDMA")
+            .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+            .WithIcon(liveIcon)
+            .WithProductManagerVisibility();
+        SetCachedPointer(liveIcon, IntPtr.Zero);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+#else
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(_ => true);
+        Assert.True(ProductKindIconLifetime.IsNullOrDestroyed(liveIcon));
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(_ => false);
+#endif
+    }
+
+    [Fact]
     public void RegistrySnapshotsAreOrderedAndIsolated()
     {
         ProductKindMetadata later = new ProductKindMetadataBuilder(CreateKind())
@@ -259,12 +337,14 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
     public void LifecycleReappliesOneDeduplicatedSnapshot()
     {
         ProductKindMetadata first = new ProductKindMetadataBuilder(CreateKind())
-            .WithDisplayName("First")
+            .WithDisplayName("Zulu")
             .WithColor(CreateColor(1f, 0f, 0f))
+            .WithSortOrder(20)
             .Build();
         ProductKindMetadata second = new ProductKindMetadataBuilder(CreateKind())
-            .WithDisplayName("Second")
+            .WithDisplayName("Alpha")
             .WithColor(CreateColor(0f, 0f, 1f))
+            .WithSortOrder(-10)
             .Build();
 
         ProductKindMetadataRegistrationRegistry.InvokePreLoadForTesting();
@@ -272,19 +352,18 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
 
         Assert.Equal(4, _runtimeAdapter.Applications.Count);
         Assert.Equal(new[] { first }, _runtimeAdapter.Applications[0]);
-        Assert.Equal(2, _runtimeAdapter.Applications[1].Count);
-        Assert.Equal(2, _runtimeAdapter.Applications[2].Count);
-        Assert.Equal(2, _runtimeAdapter.Applications[3].Count);
         Assert.All(
             _runtimeAdapter.Applications.Skip(1),
             application => Assert.Equal(
-                2,
+                new[] { second, first },
+                application));
+        Assert.All(
+            _runtimeAdapter.Applications.Skip(1),
+            application => Assert.Equal(
+                application.Count,
                 application.Select(item => item.ProductKind.Id)
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .Count()));
-        Assert.Contains(
-            _runtimeAdapter.Applications[3],
-            metadata => metadata == second);
     }
 
     [Fact]
@@ -326,8 +405,25 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
 
     private static Sprite CreateSprite()
     {
-        return (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+        var sprite =
+            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+#if MONOMELON
+        SetCachedPointer(sprite, new IntPtr(1));
+#endif
+        return sprite;
     }
+
+#if MONOMELON
+    private static void SetCachedPointer(Sprite sprite, IntPtr pointer)
+    {
+        typeof(UnityEngine.Object)
+            .GetField(
+                "m_CachedPtr",
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(sprite, pointer);
+    }
+#endif
 
     private static Color CreateColor(float red, float green, float blue)
     {

--- a/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
+++ b/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
@@ -1,0 +1,362 @@
+using System.Runtime.CompilerServices;
+using S1API.Internal.Products;
+using S1API.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+[Collection(CustomProductRegistryCollection.Name)]
+public sealed class ProductKindMetadataRegistryTests : IDisposable
+{
+    private readonly FakeRuntimeAdapter _runtimeAdapter = new();
+
+    public ProductKindMetadataRegistryTests()
+    {
+        ProductKindMetadataRegistrationRegistry.ResetForTesting(_runtimeAdapter);
+    }
+
+    public void Dispose()
+    {
+        ProductKindMetadataRegistrationRegistry.RestoreRuntimeAdapterForTesting();
+    }
+
+    [Fact]
+    public void BuilderRequiresDisplayNameAndColor()
+    {
+        ProductKind kind = CreateKind();
+
+        Assert.Throws<InvalidOperationException>(
+            () => new ProductKindMetadataBuilder(kind).Build());
+        Assert.Throws<InvalidOperationException>(
+            () => new ProductKindMetadataBuilder(kind)
+                .WithDisplayName("MDMA")
+                .Build());
+        Assert.Throws<InvalidOperationException>(
+            () => new ProductKindMetadataBuilder(kind)
+                .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+                .Build());
+    }
+
+    [Fact]
+    public void HiddenMetadataUsesCompatibleOptInDefaults()
+    {
+        ProductKind kind = CreateKind();
+        ProductKindMetadata metadata = new ProductKindMetadataBuilder(kind)
+            .WithDisplayName("Dormant")
+            .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+            .Build();
+
+        Assert.False(metadata.IsVisibleInProductManager);
+        Assert.Null(metadata.Icon);
+        Assert.Equal(0, metadata.SortOrder);
+        Assert.Empty(metadata.SearchAliases);
+    }
+
+    [Fact]
+    public void VisibleMetadataRequiresCompatibilityTypeAndIcon()
+    {
+        ProductKind withoutMapping =
+            new ProductKindBuilder(CreateId()).Build();
+        ProductKind withMapping = CreateKind();
+
+        InvalidOperationException missingMapping =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductKindMetadataBuilder(withoutMapping)
+                    .WithDisplayName("MDMA")
+                    .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+                    .WithIcon(CreateSprite())
+                    .WithProductManagerVisibility()
+                    .Build());
+        InvalidOperationException missingIcon =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductKindMetadataBuilder(withMapping)
+                    .WithDisplayName("MDMA")
+                    .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+                    .WithProductManagerVisibility()
+                    .Build());
+
+        Assert.Contains("compatibility drug type", missingMapping.Message);
+        Assert.Contains("icon", missingIcon.Message);
+    }
+
+    [Fact]
+    public void InputValidationRejectsNullEmptyAndNonFiniteValues()
+    {
+        ProductKind kind = CreateKind();
+        var builder = new ProductKindMetadataBuilder(kind);
+
+        Assert.Throws<ArgumentNullException>(() => builder.WithDisplayName(null!));
+        Assert.Throws<ArgumentException>(() => builder.WithDisplayName("  "));
+        Assert.Throws<ArgumentNullException>(() => builder.WithIcon(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => builder.WithSearchAliases(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => builder.WithSearchAliases("valid", null!));
+        Assert.Throws<ArgumentException>(
+            () => builder.WithSearchAliases("valid", "  "));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithColor(CreateColor(float.NaN, 0f, 0f)));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithColor(
+                CreateColor(0f, float.PositiveInfinity, 0f)));
+    }
+
+    [Fact]
+    public void EquivalentRegistrationIsCaseInsensitiveAndIdempotent()
+    {
+        string id = CreateId();
+        ProductKind firstKind = new ProductKindBuilder(id)
+            .WithCompatibilityDrugType(DrugType.MDMA)
+            .Build();
+        ProductKind secondKind = new ProductKindBuilder(id.ToUpperInvariant())
+            .WithCompatibilityDrugType(DrugType.MDMA)
+            .Build();
+        Sprite icon = CreateSprite();
+
+        ProductKindMetadata first = CreateVisibleMetadata(
+            firstKind,
+            icon,
+            "MDMA",
+            CreateColor(0.8f, 0.2f, 0.7f));
+        ProductKindMetadata repeated = CreateVisibleMetadata(
+            secondKind,
+            icon,
+            "MDMA",
+            CreateColor(0.8f, 0.2f, 0.7f));
+
+        Assert.Same(first, repeated);
+        Assert.Same(first, ProductKindMetadataRegistry.Get(id.ToUpperInvariant()));
+        Assert.True(
+            ProductKindMetadataRegistry.TryGet(secondKind, out ProductKindMetadata? found));
+        Assert.Same(first, found);
+        Assert.Equal(2, _runtimeAdapter.Applications.Count);
+    }
+
+    [Fact]
+    public void ConflictingRegistrationDoesNotReplaceExistingMetadata()
+    {
+        ProductKind kind = CreateKind();
+        Sprite icon = CreateSprite();
+        ProductKindMetadata first = CreateVisibleMetadata(
+            kind,
+            icon,
+            "MDMA",
+            CreateColor(0.8f, 0.2f, 0.7f));
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductKindMetadataBuilder(kind)
+                    .WithDisplayName("Changed")
+                    .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+                    .WithIcon(icon)
+                    .WithProductManagerVisibility()
+                    .Build());
+
+        Assert.Contains(kind.Id, exception.Message);
+        Assert.Contains("case-insensitive", exception.Message);
+        Assert.Same(first, ProductKindMetadataRegistry.Get(kind));
+    }
+
+    [Fact]
+    public void DormantNativeTypeConflictsAreRejectedBeforeRuntimeOrderMatters()
+    {
+        ProductKind firstKind = CreateKind(DrugType.Heroin);
+        ProductKind secondKind = CreateKind(DrugType.Heroin);
+        CreateVisibleMetadata(
+            firstKind,
+            CreateSprite(),
+            "Heroin",
+            CreateColor(0.5f, 0.5f, 0.5f));
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => CreateVisibleMetadata(
+                    secondKind,
+                    CreateSprite(),
+                    "Opioid",
+                    CreateColor(1f, 0f, 0f)));
+
+        Assert.Contains(nameof(DrugType.Heroin), exception.Message);
+        Assert.Contains(firstKind.Id, exception.Message);
+        Assert.Contains(secondKind.Id, exception.Message);
+    }
+
+    [Fact]
+    public void ExistingVanillaCompatibilityTypeCanBackDistinctLogicalSections()
+    {
+        ProductKind firstKind = CreateKind(DrugType.Marijuana);
+        ProductKind secondKind = CreateKind(DrugType.Marijuana);
+
+        ProductKindMetadata first = CreateVisibleMetadata(
+            firstKind,
+            CreateSprite(),
+            "Flower",
+            CreateColor(0f, 1f, 0f));
+        ProductKindMetadata second = CreateVisibleMetadata(
+            secondKind,
+            CreateSprite(),
+            "Concentrates",
+            CreateColor(1f, 1f, 0f));
+
+        Assert.Same(first, ProductKindMetadataRegistry.Get(firstKind));
+        Assert.Same(second, ProductKindMetadataRegistry.Get(secondKind));
+    }
+
+    [Fact]
+    public void AliasesAreNormalizedImmutableAndSearchable()
+    {
+        ProductKind kind = CreateKind();
+        ProductKindMetadata metadata = new ProductKindMetadataBuilder(kind)
+            .WithDisplayName("Ecstasy")
+            .WithColor(CreateColor(0.8f, 0.2f, 0.7f))
+            .WithSearchAliases(" MDMA ", "Molly", "molly")
+            .Build();
+
+        Assert.Equal(new[] { "MDMA", "Molly" }, metadata.SearchAliases);
+        Assert.True(metadata.MatchesSearch("ecst"));
+        Assert.True(metadata.MatchesSearch("mdma"));
+        Assert.True(metadata.MatchesSearch(kind.Id));
+        Assert.True(metadata.MatchesSearch("  "));
+        Assert.False(metadata.MatchesSearch("cannabis"));
+        Assert.Throws<ArgumentNullException>(() => metadata.MatchesSearch(null!));
+
+        ICollection<string> aliases =
+            Assert.IsAssignableFrom<ICollection<string>>(metadata.SearchAliases);
+        Assert.True(aliases.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => aliases.Add("tablet"));
+    }
+
+    [Fact]
+    public void RegistrySnapshotsAreOrderedAndIsolated()
+    {
+        ProductKindMetadata later = new ProductKindMetadataBuilder(CreateKind())
+            .WithDisplayName("Zulu")
+            .WithColor(CreateColor(1f, 0f, 0f))
+            .WithSortOrder(20)
+            .Build();
+        IReadOnlyCollection<ProductKindMetadata> before =
+            ProductKindMetadataRegistry.All;
+        ProductKindMetadata earlier = new ProductKindMetadataBuilder(CreateKind())
+            .WithDisplayName("Alpha")
+            .WithColor(CreateColor(0f, 0f, 1f))
+            .WithSortOrder(-10)
+            .Build();
+
+        Assert.DoesNotContain(before, metadata => metadata == earlier);
+        ProductKindMetadata[] relevant = ProductKindMetadataRegistry.All
+            .Where(metadata => metadata == later || metadata == earlier)
+            .ToArray();
+        Assert.Equal(new[] { earlier, later }, relevant);
+
+        ICollection<ProductKindMetadata> snapshot =
+            Assert.IsAssignableFrom<ICollection<ProductKindMetadata>>(
+                ProductKindMetadataRegistry.All);
+        Assert.True(snapshot.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => snapshot.Add(earlier));
+    }
+
+    [Fact]
+    public void LifecycleReappliesOneDeduplicatedSnapshot()
+    {
+        ProductKindMetadata first = new ProductKindMetadataBuilder(CreateKind())
+            .WithDisplayName("First")
+            .WithColor(CreateColor(1f, 0f, 0f))
+            .Build();
+        ProductKindMetadata second = new ProductKindMetadataBuilder(CreateKind())
+            .WithDisplayName("Second")
+            .WithColor(CreateColor(0f, 0f, 1f))
+            .Build();
+
+        ProductKindMetadataRegistrationRegistry.InvokePreLoadForTesting();
+        ProductKindMetadataRegistrationRegistry.InvokeLoadCompleteForTesting();
+
+        Assert.Equal(4, _runtimeAdapter.Applications.Count);
+        Assert.Equal(new[] { first }, _runtimeAdapter.Applications[0]);
+        Assert.Equal(2, _runtimeAdapter.Applications[1].Count);
+        Assert.Equal(2, _runtimeAdapter.Applications[2].Count);
+        Assert.Equal(2, _runtimeAdapter.Applications[3].Count);
+        Assert.All(
+            _runtimeAdapter.Applications.Skip(1),
+            application => Assert.Equal(
+                2,
+                application.Select(item => item.ProductKind.Id)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count()));
+        Assert.Contains(
+            _runtimeAdapter.Applications[3],
+            metadata => metadata == second);
+    }
+
+    [Fact]
+    public void RuntimeFailureDoesNotLoseProcessLifetimeRegistration()
+    {
+        _runtimeAdapter.Exception = new InvalidOperationException("runtime unavailable");
+        ProductKind kind = CreateKind();
+
+        ProductKindMetadata registered = new ProductKindMetadataBuilder(kind)
+            .WithDisplayName("Deferred")
+            .WithColor(CreateColor(0f, 1f, 1f))
+            .Build();
+
+        Assert.Same(registered, ProductKindMetadataRegistry.Get(kind));
+        Assert.Single(ProductKindMetadataRegistry.All);
+    }
+
+    private static ProductKindMetadata CreateVisibleMetadata(
+        ProductKind kind,
+        Sprite icon,
+        string displayName,
+        Color color)
+    {
+        return new ProductKindMetadataBuilder(kind)
+            .WithDisplayName(displayName)
+            .WithColor(color)
+            .WithIcon(icon)
+            .WithSearchAliases(displayName)
+            .WithProductManagerVisibility()
+            .Build();
+    }
+
+    private static ProductKind CreateKind(DrugType drugType = DrugType.Marijuana)
+    {
+        return new ProductKindBuilder(CreateId())
+            .WithCompatibilityDrugType(drugType)
+            .Build();
+    }
+
+    private static Sprite CreateSprite()
+    {
+        return (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+    }
+
+    private static Color CreateColor(float red, float green, float blue)
+    {
+        Color color = default;
+        color.r = red;
+        color.g = green;
+        color.b = blue;
+        color.a = 1f;
+        return color;
+    }
+
+    private static string CreateId()
+    {
+        return $"s1api-tests:{Guid.NewGuid():N}";
+    }
+
+    private sealed class FakeRuntimeAdapter :
+        IProductKindMetadataRuntimeAdapter
+    {
+        internal List<IReadOnlyList<ProductKindMetadata>> Applications { get; } =
+            new();
+
+        internal Exception? Exception { get; set; }
+
+        public void Apply(IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            Applications.Add(metadata.ToArray());
+            if (Exception != null)
+                throw Exception;
+        }
+    }
+}

--- a/S1API.Tests/Products/ProductManagerUiRuntimeContractTests.cs
+++ b/S1API.Tests/Products/ProductManagerUiRuntimeContractTests.cs
@@ -1,0 +1,102 @@
+using System.Runtime.CompilerServices;
+using S1API.Internal.Products;
+using UnityEngine;
+
+namespace S1API.Tests.Products;
+
+[Collection(CustomProductRegistryCollection.Name)]
+public sealed class ProductManagerUiRuntimeContractTests : IDisposable
+{
+    public ProductManagerUiRuntimeContractTests()
+    {
+#if IL2CPPMELON
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(_ => false);
+#endif
+    }
+
+    public void Dispose()
+    {
+#if IL2CPPMELON
+        ProductKindIconLifetime.SetUnityNullEvaluatorForTesting(null);
+#endif
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    public void ContainerReconciliationRunsOnlyForMissingVisibleSections(
+        bool isVisible,
+        bool hasContainer,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ProductManagerUiRuntime.RequiresContainerReconciliation(
+                isVisible,
+                hasContainer));
+    }
+
+    [Fact]
+    public void FavouriteRemovalIsNeverBlockedByCreationVisibility()
+    {
+        Assert.True(ProductManagerUiRuntime.AllowFavouriteRemoval());
+    }
+
+    [Theory]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void StaleFavouriteSlotsArePurged(
+        bool hasEntry,
+        bool hasDefinition,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ProductManagerUiRuntime.ShouldPurgeFavouriteEntry(
+                hasEntry,
+                hasDefinition));
+    }
+
+    [Fact]
+    public void MissingSectionIconClearsClonedSpriteAndUsesNeutralTint()
+    {
+        ProductManagerUiRuntime.SectionIconState state =
+            ProductManagerUiRuntime.CreateSectionIconState(null);
+
+        Assert.Null(state.Sprite);
+        AssertNeutralTint(state.Tint);
+    }
+
+    [Fact]
+    public void LiveSectionIconUsesTheRegisteredSpriteAndNeutralTint()
+    {
+        Sprite sprite =
+            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+#if MONOMELON
+        typeof(UnityEngine.Object)
+            .GetField(
+                "m_CachedPtr",
+                System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(sprite, new IntPtr(1));
+#endif
+
+        ProductManagerUiRuntime.SectionIconState state =
+            ProductManagerUiRuntime.CreateSectionIconState(sprite);
+
+        Assert.Same(sprite, state.Sprite);
+        AssertNeutralTint(state.Tint);
+    }
+
+    private static void AssertNeutralTint(Color tint)
+    {
+        Assert.Equal(1f, tint.r);
+        Assert.Equal(1f, tint.g);
+        Assert.Equal(1f, tint.b);
+        Assert.Equal(1f, tint.a);
+    }
+}

--- a/S1API/Internal/Patches/ProductManagerUiPatches.cs
+++ b/S1API/Internal/Patches/ProductManagerUiPatches.cs
@@ -91,7 +91,7 @@ namespace S1API.Internal.Patches
         {
             try
             {
-                return ProductManagerUiRuntime.AllowFavouriteEntry(definition);
+                return ProductManagerUiRuntime.AllowFavouriteRemoval();
             }
             catch (Exception exception)
             {

--- a/S1API/Internal/Patches/ProductManagerUiPatches.cs
+++ b/S1API/Internal/Patches/ProductManagerUiPatches.cs
@@ -1,0 +1,154 @@
+#if IL2CPPMELON
+using S1Product = Il2CppScheduleOne.Product;
+using S1ProductManagerUi = Il2CppScheduleOne.UI.Phone.ProductManagerApp;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+using S1ProductManagerUi = ScheduleOne.UI.Phone.ProductManagerApp;
+#endif
+
+using System;
+using HarmonyLib;
+using S1API.Internal.Products;
+using S1API.Logging;
+using S1API.Products;
+
+namespace S1API.Internal.Patches
+{
+    [HarmonyPatch]
+    internal static class ProductManagerUiPatches
+    {
+        private static readonly Log Logger = new Log("ProductManagerUiPatches");
+
+        [HarmonyPatch(
+            typeof(S1Product.PropertyUtility),
+            "Awake")]
+        [HarmonyPostfix]
+        private static void PropertyUtilityAwakePostfix()
+        {
+            ProductKindMetadataRegistrationRegistry.ApplyAll(
+                "PropertyUtility.Awake");
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            "Start")]
+        [HarmonyPrefix]
+        private static void ProductManagerStartPrefix(
+            S1ProductManagerUi.ProductManagerApp __instance)
+        {
+            SafeApply(__instance, "ProductManagerApp.Start");
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            nameof(S1ProductManagerUi.ProductManagerApp.CreateEntry))]
+        [HarmonyPrefix]
+        private static bool CreateEntryPrefix(
+            S1ProductManagerUi.ProductManagerApp __instance,
+            S1Product.ProductDefinition definition)
+        {
+            try
+            {
+                return ProductManagerUiRuntime.BeforeCreateEntry(
+                    __instance,
+                    definition);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Product Manager entry preparation failed for "
+                    + $"'{definition?.ID}': {exception}");
+                return true;
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            nameof(S1ProductManagerUi.ProductManagerApp.CreateEntry))]
+        [HarmonyPostfix]
+        private static void CreateEntryPostfix(
+            S1ProductManagerUi.ProductManagerApp __instance,
+            S1Product.ProductDefinition definition)
+        {
+            try
+            {
+                ProductManagerUiRuntime.AfterCreateEntry(__instance, definition);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Product Manager entry routing failed for "
+                    + $"'{definition?.ID}': {exception}");
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            "CreateFavouriteEntry")]
+        [HarmonyPrefix]
+        private static bool CreateFavouriteEntryPrefix(
+            S1Product.ProductDefinition definition)
+        {
+            try
+            {
+                return ProductManagerUiRuntime.AllowFavouriteEntry(definition);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Product Manager favourite preparation failed for "
+                    + $"'{definition?.ID}': {exception}");
+                return true;
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            "RemoveFavouriteEntry")]
+        [HarmonyPrefix]
+        private static bool RemoveFavouriteEntryPrefix(
+            S1Product.ProductDefinition definition)
+        {
+            try
+            {
+                return ProductManagerUiRuntime.AllowFavouriteEntry(definition);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Product Manager favourite removal failed for "
+                    + $"'{definition?.ID}': {exception}");
+                return true;
+            }
+        }
+
+        [HarmonyPatch(
+            typeof(S1ProductManagerUi.ProductManagerApp),
+            nameof(S1ProductManagerUi.ProductManagerApp.SetOpen))]
+        [HarmonyPostfix]
+        private static void SetOpenPostfix(
+            S1ProductManagerUi.ProductManagerApp __instance)
+        {
+            SafeApply(__instance, "ProductManagerApp.SetOpen");
+        }
+
+        private static void SafeApply(
+            S1ProductManagerUi.ProductManagerApp app,
+            string phase)
+        {
+            try
+            {
+                ProductManagerUiRuntime.Apply(
+                    app,
+                    new System.Collections.Generic.List<ProductKindMetadata>(
+                        ProductKindMetadataRegistry.All));
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Product Manager metadata reconciliation failed during "
+                    + $"{phase}: {exception}");
+            }
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -58,7 +58,7 @@ namespace S1API.Internal.Products
             internal CustomProductPresentationState State { get; }
         }
 
-        private enum GeneratedIconAttemptResult
+        internal enum GeneratedIconAttemptResult
         {
             Success,
             Retry,
@@ -613,21 +613,26 @@ namespace S1API.Internal.Products
                         bakeSkinnedMeshes: true,
                         fitToCamera: profile.FitGeneratedIconToCamera,
                         cameraFill: profile.GeneratedIconCameraFill);
-                if (renderedTexture != null)
-                    texture =
-                        CreateUiTexture(
-                            renderedTexture,
-                            request.Product.ProductId);
+                if (renderedTexture == null)
+                {
+                    error = "the native renderer returned no visible pixels";
+                    return GetGeneratedTextureFailureResult(
+                        rendererProducedTexture: false);
+                }
+
+                if (!TryCreateUiTexture(
+                        renderedTexture,
+                        request.Product.ProductId,
+                        out texture,
+                        out error))
+                {
+                    return GetGeneratedTextureFailureResult(
+                        rendererProducedTexture: true);
+                }
             }
             finally
             {
                 Object.Destroy(model);
-            }
-
-            if (texture == null)
-            {
-                error = "the native renderer returned no visible pixels";
-                return GeneratedIconAttemptResult.Retry;
             }
 
             icon = global::S1API.Utils.ImageUtils.TextureToSprite(texture);
@@ -643,14 +648,30 @@ namespace S1API.Internal.Products
             return GeneratedIconAttemptResult.Failure;
         }
 
-        private static Texture2D? CreateUiTexture(
-            Texture2D renderedTexture,
-            string productId)
+        internal static GeneratedIconAttemptResult
+            GetGeneratedTextureFailureResult(bool rendererProducedTexture)
         {
-            Texture2D? uiTexture = null;
+            return rendererProducedTexture
+                ? GeneratedIconAttemptResult.Failure
+                : GeneratedIconAttemptResult.Retry;
+        }
+
+        private static bool TryCreateUiTexture(
+            Texture2D renderedTexture,
+            string productId,
+            out Texture2D? uiTexture,
+            out string error)
+        {
+            uiTexture = null;
             try
             {
-                byte[] encoded = renderedTexture.EncodeToPNG();
+                byte[]? encoded = renderedTexture.EncodeToPNG();
+                if (encoded == null || encoded.Length == 0)
+                {
+                    error = "the generated texture could not be encoded as PNG";
+                    return false;
+                }
+
                 uiTexture =
                     new Texture2D(
                         2,
@@ -665,22 +686,24 @@ namespace S1API.Internal.Products
                 if (!uiTexture.LoadImage(encoded, markNonReadable: false))
                 {
                     Object.Destroy(uiTexture);
-                    return null;
+                    uiTexture = null;
+                    error =
+                        "the generated PNG could not be decoded into a UI texture";
+                    return false;
                 }
 
-                uiTexture.Apply(
-                    updateMipmaps: false,
-                    makeNoLongerReadable: false);
-                return uiTexture;
+                error = string.Empty;
+                return true;
             }
             catch (Exception exception)
             {
                 if (uiTexture != null)
                     Object.Destroy(uiTexture);
-                MelonLogger.Warning(
-                    $"[ProductPresentationProfile] Could not normalize generated icon "
-                    + $"texture for '{productId}': {exception.Message}");
-                return null;
+                uiTexture = null;
+                error =
+                    $"generated icon texture normalization failed: "
+                    + exception.Message;
+                return false;
             }
             finally
             {

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -606,13 +606,18 @@ namespace S1API.Internal.Products
                     model.transform,
                     profile,
                     ProductPresentationContext.Loose);
-                texture =
+                Texture2D? renderedTexture =
                     IconFactory.GenerateIcon(
                         model.transform,
                         profile.GeneratedIconSize,
                         bakeSkinnedMeshes: true,
                         fitToCamera: profile.FitGeneratedIconToCamera,
                         cameraFill: profile.GeneratedIconCameraFill);
+                if (renderedTexture != null)
+                    texture =
+                        CreateUiTexture(
+                            renderedTexture,
+                            request.Product.ProductId);
             }
             finally
             {
@@ -636,6 +641,51 @@ namespace S1API.Internal.Products
             texture = null;
             error = "the generated texture could not be converted to a sprite";
             return GeneratedIconAttemptResult.Failure;
+        }
+
+        private static Texture2D? CreateUiTexture(
+            Texture2D renderedTexture,
+            string productId)
+        {
+            Texture2D? uiTexture = null;
+            try
+            {
+                byte[] encoded = renderedTexture.EncodeToPNG();
+                uiTexture =
+                    new Texture2D(
+                        2,
+                        2,
+                        TextureFormat.RGBA32,
+                        mipChain: false)
+                    {
+                        name = $"S1API_ProductIcon_{productId}",
+                        filterMode = FilterMode.Bilinear,
+                        wrapMode = TextureWrapMode.Clamp
+                    };
+                if (!uiTexture.LoadImage(encoded, markNonReadable: false))
+                {
+                    Object.Destroy(uiTexture);
+                    return null;
+                }
+
+                uiTexture.Apply(
+                    updateMipmaps: false,
+                    makeNoLongerReadable: false);
+                return uiTexture;
+            }
+            catch (Exception exception)
+            {
+                if (uiTexture != null)
+                    Object.Destroy(uiTexture);
+                MelonLogger.Warning(
+                    $"[ProductPresentationProfile] Could not normalize generated icon "
+                    + $"texture for '{productId}': {exception.Message}");
+                return null;
+            }
+            finally
+            {
+                Object.Destroy(renderedTexture);
+            }
         }
 
         private static void LogGeneratedIconFailure(

--- a/S1API/Internal/Products/IProductKindMetadataRuntimeAdapter.cs
+++ b/S1API/Internal/Products/IProductKindMetadataRuntimeAdapter.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal interface IProductKindMetadataRuntimeAdapter
+    {
+        void Apply(IReadOnlyList<ProductKindMetadata> metadata);
+    }
+}

--- a/S1API/Internal/Products/ProductKindIconLifetime.cs
+++ b/S1API/Internal/Products/ProductKindIconLifetime.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+namespace S1API.Internal.Products
+{
+    internal static class ProductKindIconLifetime
+    {
+        private static Func<Sprite, bool> _unityNullEvaluator = IsUnityNull;
+
+        internal static bool IsNullOrDestroyed(Sprite? icon)
+        {
+            if (ReferenceEquals(icon, null))
+                return true;
+
+            return _unityNullEvaluator(icon);
+        }
+
+        internal static void SetUnityNullEvaluatorForTesting(
+            Func<Sprite, bool>? evaluator)
+        {
+            _unityNullEvaluator = evaluator ?? IsUnityNull;
+        }
+
+        private static bool IsUnityNull(Sprite icon) => icon == null;
+    }
+}

--- a/S1API/Internal/Products/ProductKindMetadataRegistrationRegistry.cs
+++ b/S1API/Internal/Products/ProductKindMetadataRegistrationRegistry.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using S1API.Lifecycle;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal static class ProductKindMetadataRegistrationRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly object ApplyGate = new object();
+        private static readonly Dictionary<string, ProductKindMetadata> Metadata =
+            new Dictionary<string, ProductKindMetadata>(StringComparer.OrdinalIgnoreCase);
+
+        private static IProductKindMetadataRuntimeAdapter _runtimeAdapter =
+            ProductKindMetadataRuntimeAdapter.Instance;
+        private static bool _hooked;
+
+        internal static IReadOnlyCollection<ProductKindMetadata> All
+        {
+            get
+            {
+                var snapshot = Snapshot();
+                Array.Sort(snapshot, Compare);
+                return Array.AsReadOnly(snapshot);
+            }
+        }
+
+        internal static bool TryGet(
+            string productKindId,
+            out ProductKindMetadata? metadata)
+        {
+            string normalizedId = ProductKindId.Normalize(productKindId, nameof(productKindId));
+            lock (Gate)
+                return Metadata.TryGetValue(normalizedId, out metadata);
+        }
+
+        internal static ProductKindMetadata Register(ProductKindMetadata metadata)
+        {
+            if (metadata == null)
+                throw new ArgumentNullException(nameof(metadata));
+
+            ProductKindMetadata registered;
+            lock (Gate)
+            {
+                if (Metadata.TryGetValue(metadata.ProductKind.Id, out ProductKindMetadata? existing))
+                {
+                    if (!existing.IsEquivalentTo(metadata))
+                        throw CreateConflict(existing, metadata);
+                    registered = existing;
+                }
+                else
+                {
+                    ValidateNativeMetadataCollision(metadata);
+                    Metadata.Add(metadata.ProductKind.Id, metadata);
+                    registered = metadata;
+                }
+
+                EnsureHooked();
+            }
+
+            ApplyAll("registration");
+            return registered;
+        }
+
+        internal static void ApplyAll(string phase)
+        {
+            lock (ApplyGate)
+            {
+                try
+                {
+                    _runtimeAdapter.Apply(Snapshot());
+                }
+                catch (Exception exception)
+                {
+                    try
+                    {
+                        MelonLoader.MelonLogger.Error(
+                            "[ProductKindMetadataRegistry] Failed to apply product-kind metadata "
+                            + $"during {phase}: {exception}");
+                    }
+                    catch (Exception)
+                    {
+                        // MelonLogger is not initialized in contract-test hosts.
+                    }
+                }
+            }
+        }
+
+        internal static void ResetForTesting(IProductKindMetadataRuntimeAdapter runtimeAdapter)
+        {
+            if (runtimeAdapter == null)
+                throw new ArgumentNullException(nameof(runtimeAdapter));
+
+            lock (ApplyGate)
+            {
+                lock (Gate)
+                {
+                    if (_hooked)
+                    {
+                        GameLifecycle.OnPreLoad -= OnPreLoad;
+                        GameLifecycle.OnLoadComplete -= OnLoadComplete;
+                    }
+
+                    Metadata.Clear();
+                    _runtimeAdapter = runtimeAdapter;
+                    _hooked = false;
+                }
+            }
+        }
+
+        internal static void RestoreRuntimeAdapterForTesting()
+        {
+            ResetForTesting(ProductKindMetadataRuntimeAdapter.Instance);
+        }
+
+        internal static void InvokePreLoadForTesting()
+        {
+            OnPreLoad();
+        }
+
+        internal static void InvokeLoadCompleteForTesting()
+        {
+            OnLoadComplete();
+        }
+
+        private static ProductKindMetadata[] Snapshot()
+        {
+            lock (Gate)
+            {
+                var snapshot = new ProductKindMetadata[Metadata.Count];
+                Metadata.Values.CopyTo(snapshot, 0);
+                return snapshot;
+            }
+        }
+
+        private static void EnsureHooked()
+        {
+            if (_hooked)
+                return;
+            GameLifecycle.OnPreLoad += OnPreLoad;
+            GameLifecycle.OnLoadComplete += OnLoadComplete;
+            _hooked = true;
+        }
+
+        private static void OnPreLoad()
+        {
+            ApplyAll("pre-load");
+        }
+
+        private static void OnLoadComplete()
+        {
+            ApplyAll("load-complete");
+        }
+
+        private static int Compare(ProductKindMetadata left, ProductKindMetadata right)
+        {
+            int order = left.SortOrder.CompareTo(right.SortOrder);
+            if (order != 0)
+                return order;
+            order = StringComparer.OrdinalIgnoreCase.Compare(left.DisplayName, right.DisplayName);
+            return order != 0
+                ? order
+                : StringComparer.OrdinalIgnoreCase.Compare(
+                    left.ProductKind.Id,
+                    right.ProductKind.Id);
+        }
+
+        private static void ValidateNativeMetadataCollision(ProductKindMetadata candidate)
+        {
+            DrugType? candidateType = candidate.ProductKind.CompatibilityDrugType;
+            if (candidateType != DrugType.MDMA && candidateType != DrugType.Heroin)
+                return;
+
+            foreach (ProductKindMetadata existing in Metadata.Values)
+            {
+                if (existing.ProductKind.CompatibilityDrugType != candidateType)
+                    continue;
+
+                if (!string.Equals(
+                        existing.DisplayName,
+                        candidate.DisplayName,
+                        StringComparison.Ordinal)
+                    || !existing.HasSameColor(candidate))
+                {
+                    throw new InvalidOperationException(
+                        $"Product kind '{candidate.ProductKind.Id}' conflicts with "
+                        + $"'{existing.ProductKind.Id}' for native compatibility drug type "
+                        + $"'{candidateType}'. Shared native types must use the same display "
+                        + "name and color so native-facing metadata remains deterministic.");
+                }
+            }
+        }
+
+        private static InvalidOperationException CreateConflict(
+            ProductKindMetadata existing,
+            ProductKindMetadata requested)
+        {
+            return new InvalidOperationException(
+                $"Product-kind metadata for '{requested.ProductKind.Id}' is already "
+                + $"registered as '{existing.DisplayName}' with different presentation "
+                + "or Product Manager behavior. Product-kind IDs are case-insensitive.");
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductKindMetadataRegistrationRegistry.cs
+++ b/S1API/Internal/Products/ProductKindMetadataRegistrationRegistry.cs
@@ -20,8 +20,7 @@ namespace S1API.Internal.Products
         {
             get
             {
-                var snapshot = Snapshot();
-                Array.Sort(snapshot, Compare);
+                ProductKindMetadata[] snapshot = OrderedSnapshot();
                 return Array.AsReadOnly(snapshot);
             }
         }
@@ -69,7 +68,7 @@ namespace S1API.Internal.Products
             {
                 try
                 {
-                    _runtimeAdapter.Apply(Snapshot());
+                    _runtimeAdapter.Apply(OrderedSnapshot());
                 }
                 catch (Exception exception)
                 {
@@ -134,6 +133,13 @@ namespace S1API.Internal.Products
             }
         }
 
+        private static ProductKindMetadata[] OrderedSnapshot()
+        {
+            ProductKindMetadata[] snapshot = Snapshot();
+            Array.Sort(snapshot, Compare);
+            return snapshot;
+        }
+
         private static void EnsureHooked()
         {
             if (_hooked)
@@ -169,8 +175,12 @@ namespace S1API.Internal.Products
         private static void ValidateNativeMetadataCollision(ProductKindMetadata candidate)
         {
             DrugType? candidateType = candidate.ProductKind.CompatibilityDrugType;
-            if (candidateType != DrugType.MDMA && candidateType != DrugType.Heroin)
+            if (!candidateType.HasValue
+                || !ProductKindNativeMetadataTypes.RequiresFallback(
+                    candidateType.Value))
+            {
                 return;
+            }
 
             foreach (ProductKindMetadata existing in Metadata.Values)
             {

--- a/S1API/Internal/Products/ProductKindMetadataRuntimeAdapter.cs
+++ b/S1API/Internal/Products/ProductKindMetadataRuntimeAdapter.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal sealed class ProductKindMetadataRuntimeAdapter :
+        IProductKindMetadataRuntimeAdapter
+    {
+        internal static readonly ProductKindMetadataRuntimeAdapter Instance =
+            new ProductKindMetadataRuntimeAdapter();
+
+        private ProductKindMetadataRuntimeAdapter()
+        {
+        }
+
+        public void Apply(IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            ProductKindNativeMetadataRuntime.Apply(metadata);
+            ProductManagerUiRuntime.ApplyCurrent(metadata);
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductKindNativeMetadataRuntime.cs
+++ b/S1API/Internal/Products/ProductKindNativeMetadataRuntime.cs
@@ -1,0 +1,58 @@
+#if IL2CPPMELON
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1DevUtilities = ScheduleOne.DevUtilities;
+using S1Product = ScheduleOne.Product;
+#endif
+
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal static class ProductKindNativeMetadataRuntime
+    {
+        internal static void Apply(IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            S1Product.PropertyUtility utility =
+                S1DevUtilities.Singleton<S1Product.PropertyUtility>.Instance;
+            if (utility == null || utility.DrugTypeDatas == null)
+                return;
+
+            for (int i = 0; i < metadata.Count; i++)
+            {
+                ProductKindMetadata item = metadata[i];
+                if (!item.ProductKind.CompatibilityDrugType.HasValue)
+                    continue;
+
+                S1Product.EDrugType nativeType =
+                    item.ProductKind.CompatibilityDrugType.Value.ToInternal();
+                if (Contains(utility, nativeType))
+                    continue;
+
+                utility.DrugTypeDatas.Add(new S1Product.PropertyUtility.DrugTypeData
+                {
+                    DrugType = nativeType,
+                    Name = item.DisplayName,
+                    Color = item.Color
+                });
+            }
+        }
+
+        private static bool Contains(
+            S1Product.PropertyUtility utility,
+            S1Product.EDrugType drugType)
+        {
+            for (int i = 0; i < utility.DrugTypeDatas.Count; i++)
+            {
+                S1Product.PropertyUtility.DrugTypeData data =
+                    utility.DrugTypeDatas[i];
+                if (data != null && data.DrugType == drugType)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductKindNativeMetadataRuntime.cs
+++ b/S1API/Internal/Products/ProductKindNativeMetadataRuntime.cs
@@ -26,8 +26,16 @@ namespace S1API.Internal.Products
                 if (!item.ProductKind.CompatibilityDrugType.HasValue)
                     continue;
 
+                DrugType compatibilityType =
+                    item.ProductKind.CompatibilityDrugType.Value;
+                if (!ProductKindNativeMetadataTypes.RequiresFallback(
+                        compatibilityType))
+                {
+                    continue;
+                }
+
                 S1Product.EDrugType nativeType =
-                    item.ProductKind.CompatibilityDrugType.Value.ToInternal();
+                    compatibilityType.ToInternal();
                 if (Contains(utility, nativeType))
                     continue;
 

--- a/S1API/Internal/Products/ProductKindNativeMetadataTypes.cs
+++ b/S1API/Internal/Products/ProductKindNativeMetadataTypes.cs
@@ -1,0 +1,16 @@
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// Identifies native enum values that have no serialized DrugTypeData row.
+    /// Update this list only after verifying both the native enum and serialized data.
+    /// </summary>
+    internal static class ProductKindNativeMetadataTypes
+    {
+        internal static bool RequiresFallback(DrugType drugType)
+        {
+            return drugType == DrugType.MDMA || drugType == DrugType.Heroin;
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductManagerUiRuntime.cs
+++ b/S1API/Internal/Products/ProductManagerUiRuntime.cs
@@ -27,6 +27,19 @@ namespace S1API.Internal.Products
 {
     internal static class ProductManagerUiRuntime
     {
+        internal readonly struct SectionIconState
+        {
+            internal SectionIconState(Sprite? sprite, Color tint)
+            {
+                Sprite = sprite;
+                Tint = tint;
+            }
+
+            internal Sprite? Sprite { get; }
+
+            internal Color Tint { get; }
+        }
+
         private const string ManagedNamePrefix = "S1API_ProductKind_";
         private static readonly Log Logger = new Log("ProductManagerUiRuntime");
 
@@ -57,10 +70,19 @@ namespace S1API.Internal.Products
             if (!TryResolveMetadata(definition, out ProductKindMetadata metadata))
                 return true;
 
-            Apply(app, SnapshotMetadata());
             if (!metadata.IsVisibleInProductManager)
                 return false;
 
+            bool hasContainer =
+                FindManagedContainer(app, metadata.ProductKind.Id) != null;
+            if (!RequiresContainerReconciliation(
+                    metadata.IsVisibleInProductManager,
+                    hasContainer))
+            {
+                return true;
+            }
+
+            EnsureContainers(app, SnapshotMetadata());
             if (FindManagedContainer(app, metadata.ProductKind.Id) != null)
                 return true;
 
@@ -86,6 +108,39 @@ namespace S1API.Internal.Products
         {
             return !TryResolveMetadata(definition, out ProductKindMetadata metadata)
                    || metadata.IsVisibleInProductManager;
+        }
+
+        internal static bool AllowFavouriteRemoval()
+        {
+            return true;
+        }
+
+        internal static bool RequiresContainerReconciliation(
+            bool isVisible,
+            bool hasContainer)
+        {
+            return isVisible && !hasContainer;
+        }
+
+        internal static bool ShouldPurgeFavouriteEntry(
+            bool hasEntry,
+            bool hasDefinition)
+        {
+            return !hasEntry || !hasDefinition;
+        }
+
+        internal static SectionIconState CreateSectionIconState(Sprite? sprite)
+        {
+            Sprite? liveSprite =
+                ProductKindIconLifetime.IsNullOrDestroyed(sprite)
+                    ? null
+                    : sprite;
+            Color neutralTint = default;
+            neutralTint.r = 1f;
+            neutralTint.g = 1f;
+            neutralTint.b = 1f;
+            neutralTint.a = 1f;
+            return new SectionIconState(liveSprite, neutralTint);
         }
 
         private static IReadOnlyList<ProductKindMetadata> SnapshotMetadata()
@@ -254,10 +309,12 @@ namespace S1API.Internal.Products
                 arrow.color = metadata.Color;
 
             Image? icon = FindImage(container, "Image");
-            if (icon != null && metadata.Icon != null)
+            if (icon != null)
             {
-                icon.sprite = metadata.Icon;
-                icon.color = Color.white;
+                SectionIconState iconState =
+                    CreateSectionIconState(metadata.Icon);
+                icon.sprite = iconState.Sprite;
+                icon.color = iconState.Tint;
             }
         }
 
@@ -302,10 +359,21 @@ namespace S1API.Internal.Products
             for (int i = favourites.Count - 1; i >= 0; i--)
             {
                 S1Product.ProductEntry entry = favourites[i];
-                if (entry == null
-                    || entry.Definition == null
-                    || !TryResolveMetadata(
-                        entry.Definition,
+                bool hasEntry = entry != null;
+                bool hasDefinition =
+                    hasEntry && entry!.Definition != null;
+                if (ShouldPurgeFavouriteEntry(hasEntry, hasDefinition))
+                {
+                    favourites.RemoveAt(i);
+                    if (hasEntry)
+                        entry!.Destroy();
+                    continue;
+                }
+
+                S1Product.ProductDefinition definition =
+                    entry!.Definition!;
+                if (!TryResolveMetadata(
+                        definition,
                         out ProductKindMetadata metadata))
                 {
                     continue;

--- a/S1API/Internal/Products/ProductManagerUiRuntime.cs
+++ b/S1API/Internal/Products/ProductManagerUiRuntime.cs
@@ -1,0 +1,582 @@
+#if IL2CPPMELON
+using NativeProductEntryList =
+    Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Product.ProductEntry>;
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
+using S1Product = Il2CppScheduleOne.Product;
+using S1ProductManagerUi = Il2CppScheduleOne.UI.Phone.ProductManagerApp;
+using S1Root = Il2CppScheduleOne;
+#elif MONOMELON
+using NativeProductEntryList =
+    System.Collections.Generic.List<ScheduleOne.Product.ProductEntry>;
+using S1DevUtilities = ScheduleOne.DevUtilities;
+using S1Product = ScheduleOne.Product;
+using S1ProductManagerUi = ScheduleOne.UI.Phone.ProductManagerApp;
+using S1Root = ScheduleOne;
+#endif
+
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Utils;
+using S1API.Logging;
+using S1API.Products;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityObject = UnityEngine.Object;
+
+namespace S1API.Internal.Products
+{
+    internal static class ProductManagerUiRuntime
+    {
+        private const string ManagedNamePrefix = "S1API_ProductKind_";
+        private static readonly Log Logger = new Log("ProductManagerUiRuntime");
+
+        internal static void ApplyCurrent(IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            S1ProductManagerUi.ProductManagerApp app =
+                S1DevUtilities.PlayerSingleton<
+                    S1ProductManagerUi.ProductManagerApp>.Instance;
+            if (app != null)
+                Apply(app, metadata);
+        }
+
+        internal static void Apply(
+            S1ProductManagerUi.ProductManagerApp app,
+            IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            if (app == null || app.ProductTypeContainers == null)
+                return;
+
+            EnsureContainers(app, metadata);
+            ReconcileEntries(app);
+        }
+
+        internal static bool BeforeCreateEntry(
+            S1ProductManagerUi.ProductManagerApp app,
+            S1Product.ProductDefinition definition)
+        {
+            if (!TryResolveMetadata(definition, out ProductKindMetadata metadata))
+                return true;
+
+            Apply(app, SnapshotMetadata());
+            if (!metadata.IsVisibleInProductManager)
+                return false;
+
+            if (FindManagedContainer(app, metadata.ProductKind.Id) != null)
+                return true;
+
+            Logger.Error(
+                $"Skipped Product Manager entry '{definition.ID}' because the "
+                + $"section for product kind '{metadata.ProductKind.Id}' could not be created.");
+            return false;
+        }
+
+        internal static void AfterCreateEntry(
+            S1ProductManagerUi.ProductManagerApp app,
+            S1Product.ProductDefinition definition)
+        {
+            if (TryResolveMetadata(definition, out ProductKindMetadata metadata)
+                && metadata.IsVisibleInProductManager)
+            {
+                RouteEntry(app, definition, metadata);
+            }
+        }
+
+        internal static bool AllowFavouriteEntry(
+            S1Product.ProductDefinition definition)
+        {
+            return !TryResolveMetadata(definition, out ProductKindMetadata metadata)
+                   || metadata.IsVisibleInProductManager;
+        }
+
+        private static IReadOnlyList<ProductKindMetadata> SnapshotMetadata()
+        {
+            var result = new List<ProductKindMetadata>(
+                ProductKindMetadataRegistry.All);
+            return result.AsReadOnly();
+        }
+
+        private static void EnsureContainers(
+            S1ProductManagerUi.ProductManagerApp app,
+            IReadOnlyList<ProductKindMetadata> metadata)
+        {
+            var desired = new List<ProductKindMetadata>();
+            var desiredIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < metadata.Count; i++)
+            {
+                ProductKindMetadata item = metadata[i];
+                if (item.IsVisibleInProductManager
+                    && item.ProductKind.CompatibilityDrugType.HasValue)
+                {
+                    desired.Add(item);
+                    desiredIds.Add(item.ProductKind.Id);
+                }
+            }
+
+            desired.Sort(CompareMetadata);
+            var existing = new Dictionary<
+                string,
+                S1ProductManagerUi.ProductTypeContainer>(
+                    StringComparer.OrdinalIgnoreCase);
+
+            for (int i = app.ProductTypeContainers.Count - 1; i >= 0; i--)
+            {
+                S1ProductManagerUi.ProductTypeContainer container =
+                    app.ProductTypeContainers[i];
+                if (!TryGetManagedId(container, out string? productKindId))
+                    continue;
+
+                if (!desiredIds.Contains(productKindId)
+                    || existing.ContainsKey(productKindId))
+                {
+                    app.ProductTypeContainers.RemoveAt(i);
+                    DestroyManagedContainer(app, container);
+                    continue;
+                }
+
+                existing.Add(productKindId, container);
+            }
+
+            for (int i = 0; i < desired.Count; i++)
+            {
+                ProductKindMetadata item = desired[i];
+                if (!existing.TryGetValue(
+                        item.ProductKind.Id,
+                        out S1ProductManagerUi.ProductTypeContainer? container))
+                {
+                    container = CreateContainer(app, item);
+                    if (container == null)
+                        continue;
+                    existing.Add(item.ProductKind.Id, container);
+                }
+
+                ConfigureContainer(container, item);
+            }
+
+            for (int i = app.ProductTypeContainers.Count - 1; i >= 0; i--)
+            {
+                if (TryGetManagedId(app.ProductTypeContainers[i], out _))
+                    app.ProductTypeContainers.RemoveAt(i);
+            }
+
+            for (int i = 0; i < desired.Count; i++)
+            {
+                if (!existing.TryGetValue(
+                        desired[i].ProductKind.Id,
+                        out S1ProductManagerUi.ProductTypeContainer? container))
+                {
+                    continue;
+                }
+
+                app.ProductTypeContainers.Add(container);
+                container.transform.SetAsLastSibling();
+            }
+        }
+
+        private static S1ProductManagerUi.ProductTypeContainer? CreateContainer(
+            S1ProductManagerUi.ProductManagerApp app,
+            ProductKindMetadata metadata)
+        {
+            S1ProductManagerUi.ProductTypeContainer? template = null;
+            for (int i = 0; i < app.ProductTypeContainers.Count; i++)
+            {
+                S1ProductManagerUi.ProductTypeContainer candidate =
+                    app.ProductTypeContainers[i];
+                if (!TryGetManagedId(candidate, out _))
+                {
+                    template = candidate;
+                    break;
+                }
+            }
+
+            if (template == null)
+            {
+                Logger.Error(
+                    $"Could not create Product Manager section '{metadata.ProductKind.Id}': "
+                    + "no vanilla product-type container is available as a template.");
+                return null;
+            }
+
+            GameObject clone = UnityObject.Instantiate(
+                template.gameObject,
+                template.transform.parent);
+            clone.SetActive(false);
+            clone.name = ManagedNamePrefix + metadata.ProductKind.Id;
+
+            S1ProductManagerUi.ProductTypeContainer? container =
+                clone.GetComponent<S1ProductManagerUi.ProductTypeContainer>();
+            if (container == null)
+            {
+                UnityObject.DestroyImmediate(clone);
+                return null;
+            }
+
+            ClearChildren(container.Enteries);
+            ConfigureContainer(container, metadata);
+
+            S1Root.UIScreen? screen = GetScreen(app);
+            S1Root.UIPanel? panel = clone.GetComponent<S1Root.UIPanel>();
+            if (screen == null || panel == null)
+            {
+                Logger.Error(
+                    $"Could not create Product Manager section '{metadata.ProductKind.Id}': "
+                    + "the cloned UI panel or owning screen is unavailable.");
+                UnityObject.DestroyImmediate(clone);
+                return null;
+            }
+
+            screen.AddPanel(panel);
+            clone.SetActive(true);
+            container.RefreshNoneDisplay();
+            return container;
+        }
+
+        private static void ConfigureContainer(
+            S1ProductManagerUi.ProductTypeContainer container,
+            ProductKindMetadata metadata)
+        {
+            if (metadata.ProductKind.CompatibilityDrugType.HasValue)
+            {
+                ReflectionUtils.TrySetFieldOrProperty(
+                    container,
+                    "_drugType",
+                    metadata.ProductKind.CompatibilityDrugType.Value.ToInternal());
+            }
+
+            Text? title = FindText(container, "Title");
+            if (title != null)
+            {
+                title.text = metadata.DisplayName;
+                title.color = metadata.Color;
+            }
+
+            Image? arrow = FindImage(container, "Arrow");
+            if (arrow != null)
+                arrow.color = metadata.Color;
+
+            Image? icon = FindImage(container, "Image");
+            if (icon != null && metadata.Icon != null)
+            {
+                icon.sprite = metadata.Icon;
+                icon.color = Color.white;
+            }
+        }
+
+        private static void ReconcileEntries(
+            S1ProductManagerUi.ProductManagerApp app)
+        {
+            NativeProductEntryList? entries =
+                ReflectionUtils.TryGetFieldOrProperty(app, "entries")
+                    as NativeProductEntryList;
+            if (entries != null)
+            {
+                var definitions = new List<S1Product.ProductDefinition>();
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    S1Product.ProductEntry entry = entries[i];
+                    if (entry != null && entry.Definition != null)
+                        definitions.Add(entry.Definition);
+                }
+
+                for (int i = 0; i < definitions.Count; i++)
+                {
+                    if (!TryResolveMetadata(
+                            definitions[i],
+                            out ProductKindMetadata metadata))
+                    {
+                        continue;
+                    }
+
+                    if (metadata.IsVisibleInProductManager)
+                        RouteEntry(app, definitions[i], metadata);
+                    else
+                        RemoveEntries(entries, definitions[i]);
+                }
+            }
+
+            NativeProductEntryList? favourites =
+                ReflectionUtils.TryGetFieldOrProperty(app, "favouriteEntries")
+                    as NativeProductEntryList;
+            if (favourites == null)
+                return;
+
+            for (int i = favourites.Count - 1; i >= 0; i--)
+            {
+                S1Product.ProductEntry entry = favourites[i];
+                if (entry == null
+                    || entry.Definition == null
+                    || !TryResolveMetadata(
+                        entry.Definition,
+                        out ProductKindMetadata metadata))
+                {
+                    continue;
+                }
+
+                if (metadata.IsVisibleInProductManager)
+                {
+                    RefreshEntryIcon(entry);
+                    continue;
+                }
+
+                favourites.RemoveAt(i);
+                entry.Destroy();
+            }
+
+            app.FavouritesContainer?.RefreshNoneDisplay();
+        }
+
+        private static void RouteEntry(
+            S1ProductManagerUi.ProductManagerApp app,
+            S1Product.ProductDefinition definition,
+            ProductKindMetadata metadata)
+        {
+            S1ProductManagerUi.ProductTypeContainer? target =
+                FindManagedContainer(app, metadata.ProductKind.Id);
+            if (target == null)
+                return;
+
+            NativeProductEntryList? entries =
+                ReflectionUtils.TryGetFieldOrProperty(app, "entries")
+                    as NativeProductEntryList;
+            if (entries == null)
+                return;
+
+            S1Product.ProductEntry? retained = null;
+            for (int i = 0; i < entries.Count; i++)
+            {
+                S1Product.ProductEntry entry = entries[i];
+                if (entry == null
+                    || entry.Definition == null
+                    || !string.Equals(
+                        entry.Definition.ID,
+                        definition.ID,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (retained == null)
+                {
+                    retained = entry;
+                    continue;
+                }
+
+                entries.RemoveAt(i--);
+                entry.Destroy();
+            }
+
+            if (retained != null && retained.transform.parent != target.Enteries)
+                retained.transform.SetParent(target.Enteries, false);
+            if (retained != null)
+                RefreshEntryIcon(retained);
+
+            RefreshContainers(app);
+        }
+
+        private static void RefreshEntryIcon(
+            S1Product.ProductEntry entry)
+        {
+            if (entry.Icon != null
+                && entry.Definition != null
+                && entry.Definition.Icon != null
+                && !ReferenceEquals(entry.Icon.sprite, entry.Definition.Icon))
+            {
+                entry.Icon.sprite = entry.Definition.Icon;
+            }
+        }
+
+        private static void RemoveEntries(
+            NativeProductEntryList entries,
+            S1Product.ProductDefinition definition)
+        {
+            for (int i = entries.Count - 1; i >= 0; i--)
+            {
+                S1Product.ProductEntry entry = entries[i];
+                if (entry == null
+                    || entry.Definition == null
+                    || !string.Equals(
+                        entry.Definition.ID,
+                        definition.ID,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                entries.RemoveAt(i);
+                entry.Destroy();
+            }
+        }
+
+        private static void RefreshContainers(
+            S1ProductManagerUi.ProductManagerApp app)
+        {
+            for (int i = 0; i < app.ProductTypeContainers.Count; i++)
+                app.ProductTypeContainers[i]?.RefreshNoneDisplay();
+        }
+
+        private static bool TryResolveMetadata(
+            S1Product.ProductDefinition definition,
+            out ProductKindMetadata metadata)
+        {
+            metadata = null!;
+            if (!CustomProductDefinitionRegistry.TryGetMetadata(
+                    definition,
+                    out CustomProductDefinitionMetadata? definitionMetadata)
+                || definitionMetadata == null
+                || !ProductKindMetadataRegistry.TryGet(
+                    definitionMetadata.ProductKind,
+                    out ProductKindMetadata? resolved)
+                || resolved == null)
+            {
+                return false;
+            }
+
+            metadata = resolved;
+            return true;
+        }
+
+        private static S1ProductManagerUi.ProductTypeContainer?
+            FindManagedContainer(
+                S1ProductManagerUi.ProductManagerApp app,
+                string productKindId)
+        {
+            for (int i = 0; i < app.ProductTypeContainers.Count; i++)
+            {
+                S1ProductManagerUi.ProductTypeContainer candidate =
+                    app.ProductTypeContainers[i];
+                if (TryGetManagedId(candidate, out string? candidateId)
+                    && string.Equals(
+                        candidateId,
+                        productKindId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryGetManagedId(
+            S1ProductManagerUi.ProductTypeContainer? container,
+            out string productKindId)
+        {
+            productKindId = string.Empty;
+            if (container == null)
+                return false;
+
+            string name = container.gameObject.name;
+            if (name == null
+                || !name.StartsWith(ManagedNamePrefix, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            productKindId = name.Substring(ManagedNamePrefix.Length);
+            return productKindId.Length > 0;
+        }
+
+        private static void DestroyManagedContainer(
+            S1ProductManagerUi.ProductManagerApp app,
+            S1ProductManagerUi.ProductTypeContainer container)
+        {
+            NativeProductEntryList? entries =
+                ReflectionUtils.TryGetFieldOrProperty(app, "entries")
+                    as NativeProductEntryList;
+            if (entries != null)
+            {
+                for (int i = entries.Count - 1; i >= 0; i--)
+                {
+                    S1Product.ProductEntry entry = entries[i];
+                    if (entry == null
+                        || !entry.transform.IsChildOf(container.transform))
+                    {
+                        continue;
+                    }
+
+                    entries.RemoveAt(i);
+                    entry.Destroy();
+                }
+            }
+
+            S1Root.UIScreen? screen = GetScreen(app);
+            S1Root.UIPanel? panel = container.GetComponent<S1Root.UIPanel>();
+            if (screen != null && panel != null)
+                screen.RemovePanel(panel);
+
+            container.gameObject.SetActive(false);
+            UnityObject.DestroyImmediate(container.gameObject);
+        }
+
+        private static S1Root.UIScreen? GetScreen(
+            S1ProductManagerUi.ProductManagerApp app)
+        {
+            return ReflectionUtils.TryGetFieldOrProperty(app, "_screen")
+                as S1Root.UIScreen;
+        }
+
+        private static void ClearChildren(Transform parent)
+        {
+            for (int i = parent.childCount - 1; i >= 0; i--)
+            {
+                GameObject child = parent.GetChild(i).gameObject;
+                child.SetActive(false);
+                UnityObject.DestroyImmediate(child);
+            }
+        }
+
+        private static Text? FindText(
+            S1ProductManagerUi.ProductTypeContainer container,
+            string name)
+        {
+            var components = container.GetComponentsInChildren<Text>(true);
+            for (int i = 0; i < components.Length; i++)
+            {
+                if (string.Equals(
+                        components[i].gameObject.name,
+                        name,
+                        StringComparison.Ordinal))
+                {
+                    return components[i];
+                }
+            }
+
+            return null;
+        }
+
+        private static Image? FindImage(
+            S1ProductManagerUi.ProductTypeContainer container,
+            string name)
+        {
+            var components = container.GetComponentsInChildren<Image>(true);
+            for (int i = 0; i < components.Length; i++)
+            {
+                if (string.Equals(
+                        components[i].gameObject.name,
+                        name,
+                        StringComparison.Ordinal))
+                {
+                    return components[i];
+                }
+            }
+
+            return null;
+        }
+
+        private static int CompareMetadata(
+            ProductKindMetadata left,
+            ProductKindMetadata right)
+        {
+            int order = left.SortOrder.CompareTo(right.SortOrder);
+            if (order != 0)
+                return order;
+            order = StringComparer.OrdinalIgnoreCase.Compare(
+                left.DisplayName,
+                right.DisplayName);
+            return order != 0
+                ? order
+                : StringComparer.OrdinalIgnoreCase.Compare(
+                    left.ProductKind.Id,
+                    right.ProductKind.Id);
+        }
+    }
+}

--- a/S1API/Products/ProductKindMetadata.cs
+++ b/S1API/Products/ProductKindMetadata.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Describes the presentation and Product Manager behavior of a logical product kind.
+    /// </summary>
+    /// <remarks>
+    /// Metadata is immutable and is registered separately from product definitions,
+    /// discovery, and listing state.
+    /// </remarks>
+    public sealed class ProductKindMetadata
+    {
+        private readonly IReadOnlyList<string> _searchAliases;
+
+        /// <summary>
+        /// Gets the logical product kind described by this metadata.
+        /// </summary>
+        public ProductKind ProductKind { get; }
+
+        /// <summary>
+        /// Gets the user-facing product-kind name.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the color used for native metadata and Product Manager presentation.
+        /// </summary>
+        public Color Color { get; }
+
+        /// <summary>
+        /// Gets the optional icon used by a visible Product Manager section.
+        /// </summary>
+        public Sprite? Icon { get; }
+
+        /// <summary>
+        /// Gets the relative order of this product kind among custom Product Manager sections.
+        /// </summary>
+        public int SortOrder { get; }
+
+        /// <summary>
+        /// Gets the additional case-insensitive terms that identify this product kind.
+        /// </summary>
+        public IReadOnlyList<string> SearchAliases => _searchAliases;
+
+        /// <summary>
+        /// Gets whether custom products of this kind are shown in the Product Manager.
+        /// </summary>
+        public bool IsVisibleInProductManager { get; }
+
+        internal ProductKindMetadata(
+            ProductKind productKind,
+            string displayName,
+            Color color,
+            Sprite? icon,
+            int sortOrder,
+            IReadOnlyList<string> searchAliases,
+            bool isVisibleInProductManager)
+        {
+            ProductKind = productKind;
+            DisplayName = displayName;
+            Color = color;
+            Icon = icon;
+            SortOrder = sortOrder;
+            _searchAliases = searchAliases;
+            IsVisibleInProductManager = isVisibleInProductManager;
+        }
+
+        /// <summary>
+        /// Determines whether a search term matches this metadata's identifier,
+        /// display name, or aliases.
+        /// </summary>
+        /// <param name="searchTerm">The term to match.</param>
+        /// <returns><see langword="true"/> when any searchable value contains the term.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="searchTerm"/> is <see langword="null"/>.
+        /// </exception>
+        public bool MatchesSearch(string searchTerm)
+        {
+            if (searchTerm == null)
+                throw new ArgumentNullException(nameof(searchTerm));
+
+            string normalized = searchTerm.Trim();
+            if (normalized.Length == 0)
+                return true;
+
+            if (Contains(ProductKind.Id, normalized) || Contains(DisplayName, normalized))
+                return true;
+
+            for (int i = 0; i < _searchAliases.Count; i++)
+            {
+                if (Contains(_searchAliases[i], normalized))
+                    return true;
+            }
+
+            return false;
+        }
+
+        internal bool IsEquivalentTo(ProductKindMetadata other)
+        {
+            if (!ProductKind.IsEquivalentTo(other.ProductKind)
+                || !string.Equals(DisplayName, other.DisplayName, StringComparison.Ordinal)
+                || !HasSameColor(other)
+                || !ReferenceEquals(Icon, other.Icon)
+                || SortOrder != other.SortOrder
+                || IsVisibleInProductManager != other.IsVisibleInProductManager
+                || _searchAliases.Count != other._searchAliases.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < _searchAliases.Count; i++)
+            {
+                if (!string.Equals(
+                        _searchAliases[i],
+                        other._searchAliases[i],
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal bool HasSameColor(ProductKindMetadata other)
+        {
+            return Color.r.Equals(other.Color.r)
+                   && Color.g.Equals(other.Color.g)
+                   && Color.b.Equals(other.Color.b)
+                   && Color.a.Equals(other.Color.a);
+        }
+
+        private static bool Contains(string value, string searchTerm)
+        {
+            return value.IndexOf(searchTerm, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+}

--- a/S1API/Products/ProductKindMetadata.cs
+++ b/S1API/Products/ProductKindMetadata.cs
@@ -41,8 +41,13 @@ namespace S1API.Products
         public int SortOrder { get; }
 
         /// <summary>
-        /// Gets the additional case-insensitive terms that identify this product kind.
+        /// Gets the additional case-insensitive terms that identify this product kind,
+        /// in registration order.
         /// </summary>
+        /// <remarks>
+        /// Alias order is preserved as part of the immutable metadata snapshot and
+        /// therefore participates in duplicate-registration equivalence.
+        /// </remarks>
         public IReadOnlyList<string> SearchAliases => _searchAliases;
 
         /// <summary>

--- a/S1API/Products/ProductKindMetadataBuilder.cs
+++ b/S1API/Products/ProductKindMetadataBuilder.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Products;
+using UnityEngine;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Builds and registers immutable presentation metadata for a logical product kind.
+    /// </summary>
+    public sealed class ProductKindMetadataBuilder
+    {
+        private readonly ProductKind _productKind;
+        private string? _displayName;
+        private Color? _color;
+        private Sprite? _icon;
+        private int _sortOrder;
+        private readonly List<string> _searchAliases = new List<string>();
+        private bool _isVisibleInProductManager;
+
+        /// <summary>
+        /// Creates a metadata builder for a registered logical product kind.
+        /// </summary>
+        /// <param name="productKind">The logical product kind to describe.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKind"/> is <see langword="null"/>.
+        /// </exception>
+        public ProductKindMetadataBuilder(ProductKind productKind)
+        {
+            _productKind = productKind ?? throw new ArgumentNullException(nameof(productKind));
+        }
+
+        /// <summary>
+        /// Sets the user-facing product-kind name.
+        /// </summary>
+        /// <param name="displayName">The non-empty display name.</param>
+        /// <returns>This builder for method chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="displayName"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="displayName"/> is empty or whitespace.
+        /// </exception>
+        public ProductKindMetadataBuilder WithDisplayName(string displayName)
+        {
+            _displayName = NormalizeRequired(displayName, nameof(displayName));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the presentation color.
+        /// </summary>
+        /// <param name="color">A color with finite component values.</param>
+        /// <returns>This builder for method chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when any color component is not finite.
+        /// </exception>
+        public ProductKindMetadataBuilder WithColor(Color color)
+        {
+            if (!IsFinite(color.r)
+                || !IsFinite(color.g)
+                || !IsFinite(color.b)
+                || !IsFinite(color.a))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(color),
+                    color,
+                    "Product-kind color components must be finite values.");
+            }
+
+            _color = color;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the icon for a visible Product Manager section.
+        /// </summary>
+        /// <param name="icon">The section icon.</param>
+        /// <returns>This builder for method chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="icon"/> is <see langword="null"/>.
+        /// </exception>
+        public ProductKindMetadataBuilder WithIcon(Sprite icon)
+        {
+            _icon = icon ?? throw new ArgumentNullException(nameof(icon));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the relative order among custom Product Manager sections.
+        /// </summary>
+        /// <param name="sortOrder">The custom-section order; lower values appear first.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductKindMetadataBuilder WithSortOrder(int sortOrder)
+        {
+            _sortOrder = sortOrder;
+            return this;
+        }
+
+        /// <summary>
+        /// Replaces the additional case-insensitive search aliases.
+        /// </summary>
+        /// <param name="searchAliases">The aliases to use.</param>
+        /// <returns>This builder for method chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the array or any alias is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when an alias is empty or whitespace.
+        /// </exception>
+        public ProductKindMetadataBuilder WithSearchAliases(params string[] searchAliases)
+        {
+            if (searchAliases == null)
+                throw new ArgumentNullException(nameof(searchAliases));
+
+            var normalizedAliases = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < searchAliases.Length; i++)
+            {
+                string normalized =
+                    NormalizeRequired(searchAliases[i], nameof(searchAliases));
+                if (seen.Add(normalized))
+                    normalizedAliases.Add(normalized);
+            }
+
+            _searchAliases.Clear();
+            _searchAliases.AddRange(normalizedAliases);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether custom products of this kind appear in the Product Manager.
+        /// </summary>
+        /// <param name="visible">
+        /// <see langword="true"/> to create and maintain a Product Manager section;
+        /// otherwise <see langword="false"/>.
+        /// </param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductKindMetadataBuilder WithProductManagerVisibility(bool visible = true)
+        {
+            _isVisibleInProductManager = visible;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds and registers the configured metadata.
+        /// </summary>
+        /// <returns>
+        /// The newly registered metadata, or the existing instance for an equivalent registration.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when required metadata is missing, visible metadata lacks a compatibility
+        /// drug type or icon, or conflicting metadata is already registered.
+        /// </exception>
+        public ProductKindMetadata Build()
+        {
+            if (_displayName == null)
+                throw new InvalidOperationException("A product-kind display name is required.");
+            if (!_color.HasValue)
+                throw new InvalidOperationException("A product-kind color is required.");
+
+            if (_isVisibleInProductManager)
+            {
+                if (!_productKind.CompatibilityDrugType.HasValue)
+                {
+                    throw new InvalidOperationException(
+                        "A visible Product Manager section requires a compatibility drug type.");
+                }
+
+                if (ReferenceEquals(_icon, null))
+                {
+                    throw new InvalidOperationException(
+                        "A visible Product Manager section requires an icon.");
+                }
+            }
+
+            var metadata = new ProductKindMetadata(
+                _productKind,
+                _displayName,
+                _color.Value,
+                _icon,
+                _sortOrder,
+                new List<string>(_searchAliases).AsReadOnly(),
+                _isVisibleInProductManager);
+            return ProductKindMetadataRegistry.Register(metadata);
+        }
+
+        private static string NormalizeRequired(string value, string parameterName)
+        {
+            if (value == null)
+                throw new ArgumentNullException(parameterName);
+
+            string normalized = value.Trim();
+            if (normalized.Length == 0)
+                throw new ArgumentException("Value cannot be empty or whitespace.", parameterName);
+            return normalized;
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+    }
+}

--- a/S1API/Products/ProductKindMetadataBuilder.cs
+++ b/S1API/Products/ProductKindMetadataBuilder.cs
@@ -82,7 +82,10 @@ namespace S1API.Products
         /// </exception>
         public ProductKindMetadataBuilder WithIcon(Sprite icon)
         {
-            _icon = icon ?? throw new ArgumentNullException(nameof(icon));
+            if (ProductKindIconLifetime.IsNullOrDestroyed(icon))
+                throw new ArgumentNullException(nameof(icon));
+
+            _icon = icon;
             return this;
         }
 
@@ -108,6 +111,11 @@ namespace S1API.Products
         /// <exception cref="ArgumentException">
         /// Thrown when an alias is empty or whitespace.
         /// </exception>
+        /// <remarks>
+        /// Input order is preserved after case-insensitive deduplication. Because
+        /// aliases are exposed as an ordered immutable snapshot, changing their
+        /// order is a conflicting registration rather than an idempotent repeat.
+        /// </remarks>
         public ProductKindMetadataBuilder WithSearchAliases(params string[] searchAliases)
         {
             if (searchAliases == null)
@@ -167,7 +175,7 @@ namespace S1API.Products
                         "A visible Product Manager section requires a compatibility drug type.");
                 }
 
-                if (ReferenceEquals(_icon, null))
+                if (ProductKindIconLifetime.IsNullOrDestroyed(_icon))
                 {
                     throw new InvalidOperationException(
                         "A visible Product Manager section requires an icon.");

--- a/S1API/Products/ProductKindMetadataRegistry.cs
+++ b/S1API/Products/ProductKindMetadataRegistry.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Provides process-lifetime lookup access to registered product-kind metadata.
+    /// </summary>
+    public static class ProductKindMetadataRegistry
+    {
+        /// <summary>
+        /// Gets a read-only snapshot ordered by custom-section order, display name, and identifier.
+        /// </summary>
+        public static IReadOnlyCollection<ProductKindMetadata> All =>
+            ProductKindMetadataRegistrationRegistry.All;
+
+        /// <summary>
+        /// Gets registered metadata by product-kind identifier.
+        /// </summary>
+        /// <param name="productKindId">The stable, namespaced product-kind identifier.</param>
+        /// <returns>The metadata, or <see langword="null"/> when none is registered.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKindId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="productKindId"/> is not a valid namespaced identifier.
+        /// </exception>
+        public static ProductKindMetadata? Get(string productKindId)
+        {
+            TryGet(productKindId, out ProductKindMetadata? metadata);
+            return metadata;
+        }
+
+        /// <summary>
+        /// Gets registered metadata for a logical product kind.
+        /// </summary>
+        /// <param name="productKind">The logical product kind.</param>
+        /// <returns>The metadata, or <see langword="null"/> when none is registered.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKind"/> is <see langword="null"/>.
+        /// </exception>
+        public static ProductKindMetadata? Get(ProductKind productKind)
+        {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+            return Get(productKind.Id);
+        }
+
+        /// <summary>
+        /// Attempts to get registered metadata by product-kind identifier.
+        /// </summary>
+        /// <param name="productKindId">The stable, namespaced product-kind identifier.</param>
+        /// <param name="metadata">The metadata when found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when metadata is registered.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKindId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="productKindId"/> is not a valid namespaced identifier.
+        /// </exception>
+        public static bool TryGet(
+            string productKindId,
+            out ProductKindMetadata? metadata)
+        {
+            return ProductKindMetadataRegistrationRegistry.TryGet(productKindId, out metadata);
+        }
+
+        /// <summary>
+        /// Attempts to get registered metadata for a logical product kind.
+        /// </summary>
+        /// <param name="productKind">The logical product kind.</param>
+        /// <param name="metadata">The metadata when found; otherwise <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> when metadata is registered.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="productKind"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool TryGet(
+            ProductKind productKind,
+            out ProductKindMetadata? metadata)
+        {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+            return TryGet(productKind.Id, out metadata);
+        }
+
+        internal static ProductKindMetadata Register(ProductKindMetadata metadata)
+        {
+            return ProductKindMetadataRegistrationRegistry.Register(metadata);
+        }
+    }
+}

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -73,6 +73,11 @@ The compatibility drug type is required because the native generic
 logical kind into a native enum member, native family definition, or mixable
 product.
 
+To give the logical kind a Product Manager section, separately register
+[`ProductKindMetadata`](product-kinds.md#register-presentation-and-product-manager-metadata).
+This catalog metadata does not change definition construction, discovery, or
+listing.
+
 ## Builder contract and defaults
 
 - Product and product-kind IDs are durable, case-insensitive, and namespaced.
@@ -170,6 +175,14 @@ replacing only their family-specific visual setter. This keeps native storage
 footprints, station modules, draggable behavior, first-person equip behavior,
 and consumption wiring intact.
 
+For runtime-imported GLB sources, keep one reusable source active beneath a
+persistent root positioned outside the playable scene; providers should return
+that source rather than importing the model again. Ensure its child renderers
+are enabled. If a normal-mapped mesh has no tangent data, recalculate tangents
+once after import so the native icon lighting can shade it correctly. These are
+source-preparation requirements, not icon texture-import settings: generated
+icons are ordinary runtime `Sprite` objects with transparent backgrounds.
+
 The held context also creates a third-person `AvatarEquippable` under the
 deterministic resource path
 `S1API/ProductPresentation/{productId}/Held`. Every peer must register the same
@@ -186,6 +199,15 @@ The loading screen stays open until queued product icons complete or reach the
 bounded retry timeout. `MugshotGenerator` remains reserved for avatar/accessory
 previews. The generated icon is the loose inventory icon only.
 `ProductIconManager` packaging combinations are intentionally unchanged.
+Before creating the sprite, S1API copies the native preview capture into an
+RGBA32, non-mipmapped texture with bilinear filtering and clamp wrapping. This
+normalization is required for reliable `UnityEngine.UI.Image` rendering; using
+the native preview texture directly can appear as a solid gray rectangle even
+when exporting that texture produces a valid transparent PNG.
+Product Manager entries cache their sprite when initialized; S1API refreshes
+S1API-managed product and favourite entries after generated-icon completion.
+Mods should still register the presentation profile before building the
+definition so the generation request is queued during loading.
 
 Automatic icon fitting targets 72% of the native thumbnail camera by default.
 Adjust the framing or preserve the authored scale with the additive overload:
@@ -287,7 +309,7 @@ Not supported:
 - mixing, generated variants, native family conversion, or production-station
   recipes;
 - packaged contents, composite package icons, or packaging-content save data;
-- custom packaging definitions or Product Manager UI categories;
+- custom packaging definitions;
 - definition transfer to a peer without the defining mod; or
 - recovery of a saved custom item after its mod or stable definition ID is
   removed.
@@ -305,4 +327,8 @@ selects `CustomProductDefinition` only for definitions registered with the new
 builder metadata; all previous generic and native-family fallback behavior
 remains intact. Presentation-profile registration is opt-in, and definitions
 without a resolved profile keep the exact representation references selected by
-`WithRepresentationsFrom`.
+`WithRepresentationsFrom`. Product-kind metadata registration is also opt-in;
+it adds only native-facing presentation metadata and S1API-owned Product
+Manager sections. It does not change product IDs, definition serialization,
+save data, network payloads, discovery state, listing state, vanilla sections,
+or native enum values.

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -199,11 +199,15 @@ The loading screen stays open until queued product icons complete or reach the
 bounded retry timeout. `MugshotGenerator` remains reserved for avatar/accessory
 previews. The generated icon is the loose inventory icon only. Filled packaging
 uses the separate packaging-content API below.
-Before creating the sprite, S1API copies the native preview capture into an
-RGBA32, non-mipmapped texture with bilinear filtering and clamp wrapping. This
+Before creating the sprite, S1API round-trips the native preview capture
+through PNG into a non-mipmapped 32-bit alpha texture with bilinear filtering
+and clamp wrapping. On the target Unity 2022.3 runtime, PNG decoding produces
+an ARGB32 texture and uploads it without an additional `Apply()` call. This
 normalization is required for reliable `UnityEngine.UI.Image` rendering; using
 the native preview texture directly can appear as a solid gray rectangle even
-when exporting that texture produces a valid transparent PNG.
+when exporting that texture produces a valid transparent PNG. An empty native
+capture is retried, while a deterministic PNG normalization failure stops and
+preserves the template icon fallback.
 Product Manager entries cache their sprite when initialized; S1API refreshes
 S1API-managed product and favourite entries after generated-icon completion.
 Mods should still register the presentation profile before building the

--- a/S1API/docs/product-kinds.md
+++ b/S1API/docs/product-kinds.md
@@ -38,3 +38,88 @@ Registry snapshots and product kinds are read-only. Registrations remain availab
 Building the same case-insensitive ID with the same compatibility metadata returns the original `ProductKind`. Building that ID with different metadata throws an `InvalidOperationException` that identifies the conflict.
 
 This makes per-load setup calls safe when they repeat an equivalent registration while rejecting two mods that claim the same logical ID differently.
+
+## Register presentation and Product Manager metadata
+
+Product-kind identity and UI registration are separate. Register immutable
+metadata only when the kind needs a user-facing name, color, search aliases, or
+its own Product Manager section:
+
+```csharp
+using S1API.Products;
+using UnityEngine;
+
+Sprite mdmaIcon = LoadModOwnedMdmaIcon();
+
+ProductKindMetadata mdmaMetadata =
+    new ProductKindMetadataBuilder(mdma)
+        .WithDisplayName("MDMA")
+        .WithColor(new Color(0.84f, 0.24f, 0.72f))
+        .WithIcon(mdmaIcon)
+        .WithSortOrder(50)
+        .WithSearchAliases("ecstasy", "molly")
+        .WithProductManagerVisibility()
+        .Build();
+```
+
+Visible sections require both an icon and a compatibility drug type. S1API
+clones a native Product Manager section, replaces only its heading metadata,
+and keeps vanilla sections and their order unchanged. Custom sections are
+ordered by `SortOrder`, display name, then stable kind ID. Equivalent repeated
+registrations return the first immutable metadata instance; conflicting
+registrations fail without replacing it.
+
+When reusing a generated product icon for the section, register the product's
+`ProductPresentationProfile` before building its definition. Icon capture runs
+during loading and replaces the representation-template fallback on the native
+definition. Register `ProductKindMetadata` with that generated sprite after it
+becomes available; registering metadata does not itself queue or regenerate an
+icon. S1API then refreshes existing S1API-managed product and favourite entries
+from the definition's current icon.
+
+The generated sprite is available through the custom definition's `Icon`
+property after capture completes. If metadata setup runs earlier, retain the
+template icon reference and defer metadata registration until `Icon` is
+non-null and no longer that reference. Do not copy or reload the generated PNG:
+pass the generated `Sprite` instance directly to `WithIcon`.
+
+When the compatibility type has no serialized native metadata row, S1API adds
+the missing name and color without changing existing native rows. MDMA and
+heroin metadata that share a native compatibility type must agree on that
+native-facing name and color; logical kinds backed by an existing vanilla type
+may still use distinct custom section presentation.
+
+Product Manager sections are reconciled on registration, app startup and open,
+and save-load lifecycle transitions. Stale or duplicate S1API-owned sections
+are removed. Discovered entries are routed by logical `ProductKind`, including
+when multiple logical kinds share a compatibility type. Favourites remain in
+the native Favourites section, and listed state remains on each native entry.
+
+The current native Product Manager has category panels but no text-search
+control. Consumers can use `MatchesSearch` to match a kind ID, display name, or
+alias:
+
+```csharp
+IEnumerable<ProductKindMetadata> matches =
+    ProductKindMetadataRegistry.All.Where(metadata =>
+        metadata.MatchesSearch("molly"));
+```
+
+Omit `WithProductManagerVisibility()` to retain searchable metadata without
+showing custom products of that kind in Product Manager. Visibility does not
+discover or list a definition.
+
+## Keep definition and catalog actions explicit
+
+These operations remain separate:
+
+1. `ProductKindBuilder.Build()` registers logical identity.
+2. `ProductKindMetadataBuilder.Build()` registers optional presentation and
+   Product Manager behavior.
+3. `CustomProductDefinitionBuilder.Build()` constructs and registers a
+   definition.
+4. `CustomProductDefinition.Discover()` and `SetListed()` explicitly change
+   the authoritative catalog state after loading.
+
+Metadata registration does not create a product definition, discover it, list
+it, add it to a shop, or change save and network payloads.

--- a/S1API/docs/product-kinds.md
+++ b/S1API/docs/product-kinds.md
@@ -69,6 +69,12 @@ ordered by `SortOrder`, display name, then stable kind ID. Equivalent repeated
 registrations return the first immutable metadata instance; conflicting
 registrations fail without replacing it.
 
+Search aliases are case-insensitive for matching and deduplication, but their
+input order is preserved in `SearchAliases`. Because that ordered list is part
+of the immutable registration snapshot, repeating a kind with the same aliases
+in a different order is a conflicting registration. Keep registration calls
+deterministic across lifecycle paths and peers.
+
 When reusing a generated product icon for the section, register the product's
 `ProductPresentationProfile` before building its definition. Icon capture runs
 during loading and replaces the representation-template fallback on the native
@@ -82,6 +88,8 @@ property after capture completes. If metadata setup runs earlier, retain the
 template icon reference and defer metadata registration until `Icon` is
 non-null and no longer that reference. Do not copy or reload the generated PNG:
 pass the generated `Sprite` instance directly to `WithIcon`.
+The sprite must still be a live Unity object when metadata is built; destroyed
+sprites are rejected as missing icons.
 
 When the compatibility type has no serialized native metadata row, S1API adds
 the missing name and color without changing existing native rows. MDMA and

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -15,6 +15,7 @@ If you want customer preference configuration, see `S1API/docs/products-system.m
 - `S1API.Products.CustomProductItemCreator`: creates generic non-mixable product builders
 - `S1API.Products.CustomProductDefinitionBuilder`: validates and lifecycle-registers a fixed generic product
 - `S1API.Products.CustomProductDefinition`: typed wrapper for a registered generic custom product
+- `S1API.Products.ProductKindMetadata`: immutable logical-kind display, search, and Product Manager metadata
 - `S1API.Products.ProductKindMetadataBuilder`: configures logical-kind display, search, and Product Manager behavior
 - `S1API.Products.ProductKindMetadataRegistry`: looks up immutable logical-kind metadata
 - `S1API.Products.ProductPresentationProfileBuilder`: configures mod-owned loose presentation contexts

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -15,14 +15,17 @@ If you want customer preference configuration, see `S1API/docs/products-system.m
 - `S1API.Products.CustomProductItemCreator`: creates generic non-mixable product builders
 - `S1API.Products.CustomProductDefinitionBuilder`: validates and lifecycle-registers a fixed generic product
 - `S1API.Products.CustomProductDefinition`: typed wrapper for a registered generic custom product
+- `S1API.Products.ProductKindMetadataBuilder`: configures logical-kind display, search, and Product Manager behavior
+- `S1API.Products.ProductKindMetadataRegistry`: looks up immutable logical-kind metadata
 - `S1API.Products.ProductPresentationProfileBuilder`: configures mod-owned loose presentation contexts
 - `S1API.Products.ProductPresentationTransform`: overrides a cloned context visual's local transform
 - `S1API.Products.ProductPresentationProfileRegistry`: registers profiles by stable product ID or logical product kind
 - `S1API.Products.PackagingDefinition`: packaging definition wrapper
 - `S1API.Products.Quality`: API-safe quality enum
 
-For creation and lifecycle guidance, see [Native Weed Variants](weed-variants.md)
-and [Generic Custom Products](generic-custom-products.md).
+For creation and lifecycle guidance, see [Logical Product Kinds](product-kinds.md),
+[Native Weed Variants](weed-variants.md), and
+[Generic Custom Products](generic-custom-products.md).
 
 ## Getting product definitions
 


### PR DESCRIPTION
## Summary

- add immutable display name, color, icon, ordering, aliases, and opt-in Product Manager visibility metadata for logical product kinds
- supply missing native-facing metadata for dormant compatibility types without changing native enums or existing vanilla rows
- create, reconcile, remove, and order S1API-owned Product Manager sections; route discovered products and refresh listed/favourite entries by logical kind
- normalize generated product icon textures for reliable Unity UI rendering and document the MAPI/generated-icon workflow

Closes #103.

## Compatibility

- **Source:** additive public API only (`ProductKindMetadata`, builder, and registry); no existing public/protected member, parameter, default, or namespace changed.
- **Binary:** no existing signature, return type, generic constraint, virtual shape, field/property shape, or enum value changed. Reflection and compile-only fixtures freeze the new surface without replacing an old one.
- **Behavior:** metadata remains opt-in and hidden by default; existing product-kind construction, definition construction, discovery, listing, duplicate policy, and vanilla Product Manager sections are unchanged. Generated presentation icons retain their public behavior and are copied into an internal UI-safe RGBA32 texture before sprite creation.
- **Durable identity/save/network:** no native enum extension, product-kind ID rewrite, registry-key change, save representation, loader data, RPC, or network payload change. Metadata is process-lifetime local registration; every peer remains responsible for registering its own matching definitions/assets.
- Product creation, save/network synchronization, mixing, customer affinity, and packaging content remain out of scope.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — 0 warnings
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 157/157 passed
- matching Il2CppMelon restore/build — 0 warnings
- matching Il2CppMelon tests — 150/150 passed
- `docfx docfx.json` — passed with the repository's four unresolved external-assembly warnings
- API documentation coverage — 81.18% (2,869/3,534; minimum 80%)

### In-game validation

A local ignored smoke mod embedded `heartpill.glb`, loaded it through MAPI, reused it through an S1API product presentation profile, generated its icon through S1API's native icon-render queue, and registered an MDMA-like logical kind with that generated sprite. No smoke source, model, save, assembly, screenshot, log, or evidence is committed or uploaded.

MonoMelon and Il2CppMelon each passed one final full run with three inspected screenshots:

- missing MDMA native name/color metadata supplied without null failures or duplicate rows
- transparent pink heart-pill icon rendered in the custom section and Favourites
- logical product routed to `MDMA Tablets`, listed, favourited, and matched by `MDMA`, `ecstasy`, and `molly`
- app close/reopen retained the section and icon
- scene exit/reload restored discovery/listing/favourite routing and the generated icon
- exactly one S1API-owned section and one product/favourite entry after reopen and reload
- four vanilla sections retained their original order, metadata, entries, and icons

## Notes

The native Product Manager has category panels but no text-search control. `MatchesSearch` exposes kind ID, display-name, and alias matching for consumers; metadata registration does not discover or list products.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in metadata registration for custom product kinds, including names, colors, icons, ordering, visibility, and search aliases.
  * Added Product Manager sections for registered product kinds, with automatic entry and favourite routing.
  * Added case-insensitive product-kind lookup and search support.
  * Improved generated icons for reliable Product Manager display.

* **Documentation**
  * Added guidance for product-kind metadata, visibility, searchable aliases, icons, and custom product presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->