### PR TITLE
feat(products): persist custom product descriptors

### DIFF
--- a/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
@@ -58,6 +58,50 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
     }
 
     [Fact]
+    public void SaveDescriptorsAreStableScalarSnapshotsOrderedByProductId()
+    {
+        string secondId = "examplemod:zeta-save";
+        string firstId = "examplemod:alpha-save";
+        CustomProductDefinitionMetadata metadata = CreateMetadata(firstId);
+        CustomProductDefinitionRegistry.Register(
+            "examplemod", secondId, "Zeta", 80f, CreateDefinition(), metadata,
+            new CustomProductSaveDescriptorData
+            {
+                ProductId = secondId,
+                OwnerId = "examplemod",
+                ProductName = "Zeta",
+                Description = "scalar",
+                InitialPrice = 80f,
+                ProductKindId = "examplemod:kind",
+                RepresentationTemplateId = "weed",
+                ProviderId = "examplemod:provider",
+                ProviderVersion = 1,
+                ProviderData = "v1"
+            });
+        CustomProductDefinitionRegistry.Register(
+            "examplemod", firstId, "Alpha", 50f, CreateDefinition(), metadata,
+            new CustomProductSaveDescriptorData
+            {
+                ProductId = firstId,
+                OwnerId = "examplemod",
+                ProductName = "Alpha",
+                Description = "scalar",
+                InitialPrice = 50f,
+                ProductKindId = "examplemod:kind",
+                RepresentationTemplateId = "weed"
+            });
+
+        CustomProductSaveDescriptorData[] descriptors =
+            CustomProductDefinitionRegistry.GetSaveDescriptors();
+
+        Assert.Equal(new[] { firstId, secondId }, descriptors.Select(item => item.ProductId));
+        Assert.Equal("examplemod:provider", descriptors[1].ProviderId);
+        Assert.Equal("v1", descriptors[1].ProviderData);
+        Assert.DoesNotContain(descriptors, item => item.GetType().GetFields()
+            .Any(field => typeof(UnityEngine.Object).IsAssignableFrom(field.FieldType)));
+    }
+
+    [Fact]
     public void ConflictingOwnerFailsWithActionableIdentity()
     {
         string productId = CreateProductId();

--- a/S1API.Tests/Products/CustomProductSaveApiCompileFixture.cs
+++ b/S1API.Tests/Products/CustomProductSaveApiCompileFixture.cs
@@ -1,0 +1,26 @@
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+internal static class CustomProductSaveApiCompileFixture
+{
+    internal static CustomProductDefinition CompileProviderCaller(
+        CustomProductDefinitionBuilder builder)
+    {
+        return builder
+            .WithSaveProvider("example:focus-tablet", providerVersion: 1, providerData: "v1")
+            .Build();
+    }
+
+    private sealed class Provider : ICustomProductSaveProvider
+    {
+        public string ProviderId => "example:focus-tablet";
+        public int MaximumDescriptorVersion => 1;
+        public CustomProductDefinitionBuilder? Restore(CustomProductSaveDescriptor descriptor) => null;
+    }
+
+    internal static void CompileRegistryCaller()
+    {
+        _ = CustomProductSaveProviderRegistry.Register(new Provider());
+    }
+}

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -136,6 +136,30 @@ public sealed class ProductApiCompatibilityTests
     }
 
     [Fact]
+    public void CustomProductSaveProviderApiIsAdditiveAndVersioned()
+    {
+        var providerMethod = typeof(CustomProductDefinitionBuilder).GetMethod(
+            nameof(CustomProductDefinitionBuilder.WithSaveProvider),
+            new[] { typeof(string), typeof(int), typeof(string) });
+        var register = typeof(CustomProductSaveProviderRegistry).GetMethod(
+            nameof(CustomProductSaveProviderRegistry.Register),
+            new[] { typeof(ICustomProductSaveProvider) });
+
+        Assert.NotNull(providerMethod);
+        Assert.Equal(typeof(CustomProductDefinitionBuilder), providerMethod.ReturnType);
+        Assert.Equal(new[] { "providerId", "providerVersion", "providerData" },
+            providerMethod.GetParameters().Select(parameter => parameter.Name));
+        var providerData = providerMethod.GetParameters()[2];
+        Assert.Equal("providerData", providerData.Name);
+        Assert.True(providerData.HasDefaultValue);
+        Assert.Equal(string.Empty, providerData.DefaultValue);
+        Assert.NotNull(register);
+        Assert.Equal(typeof(ICustomProductSaveProvider), register.ReturnType);
+        Assert.Equal(typeof(int), typeof(CustomProductSaveDescriptor)
+            .GetProperty(nameof(CustomProductSaveDescriptor.FormatVersion))!.PropertyType);
+    }
+
+    [Fact]
     public void ProductPresentationProfileApiIsAdditiveAndRuntimeAgnostic()
     {
         Assert.True(typeof(ProductPresentationProfile).IsSealed);

--- a/S1API/Internal/Patches/CustomProductSavePatches.cs
+++ b/S1API/Internal/Patches/CustomProductSavePatches.cs
@@ -1,0 +1,32 @@
+#if IL2CPPMELON
+using S1Persistence = Il2CppScheduleOne.Persistence;
+#elif MONOMELON
+using S1Persistence = ScheduleOne.Persistence;
+#endif
+
+using System;
+using HarmonyLib;
+using S1API.Internal.Products;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>INTERNAL: Persists custom-product descriptors outside vanilla product data.</summary>
+    [HarmonyPatch]
+    internal static class CustomProductSavePatches
+    {
+        [HarmonyPatch(typeof(S1Persistence.SaveManager), "Save", new Type[] { typeof(string) })]
+        [HarmonyPostfix]
+        private static void SavePostfix(string saveFolderPath)
+        {
+            try { CustomProductSavePersistence.Save(saveFolderPath); }
+            catch (Exception exception) { MelonLoader.MelonLogger.Warning("[CustomProductSave] save failed: " + exception.Message); }
+        }
+
+        [HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.QueueLoadRequest))]
+        [HarmonyPrefix]
+        private static void RestorePrefix()
+        {
+            CustomProductSavePersistence.RestoreBeforeBaseLoaders(S1Persistence.LoadManager.Instance);
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductDefinitionRegistration.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistration.cs
@@ -34,7 +34,8 @@ namespace S1API.Internal.Products
             string productName,
             float initialPrice,
             S1Product.ProductDefinition definition,
-            CustomProductDefinitionMetadata? metadata)
+            CustomProductDefinitionMetadata? metadata,
+            CustomProductSaveDescriptorData? saveDescriptor = null)
         {
             OwnerId = ownerId;
             ProductId = productId;
@@ -42,6 +43,7 @@ namespace S1API.Internal.Products
             InitialPrice = initialPrice;
             Definition = definition;
             Metadata = metadata;
+            SaveDescriptor = saveDescriptor;
         }
 
         internal string OwnerId { get; }
@@ -55,6 +57,8 @@ namespace S1API.Internal.Products
         internal S1Product.ProductDefinition Definition { get; }
 
         internal CustomProductDefinitionMetadata? Metadata { get; }
+
+        internal CustomProductSaveDescriptorData? SaveDescriptor { get; }
 
         internal CustomProductPresentationState? PresentationState { get; set; }
     }

--- a/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
@@ -61,6 +61,18 @@ namespace S1API.Internal.Products
             S1Product.ProductDefinition definition,
             CustomProductDefinitionMetadata? metadata)
         {
+            return Register(ownerId, productId, productName, initialPrice, definition, metadata, null);
+        }
+
+        internal static S1Product.ProductDefinition Register(
+            string ownerId,
+            string productId,
+            string productName,
+            float initialPrice,
+            S1Product.ProductDefinition definition,
+            CustomProductDefinitionMetadata? metadata,
+            CustomProductSaveDescriptorData? saveDescriptor)
+        {
             string normalizedOwnerId = NormalizeRequired(ownerId, nameof(ownerId));
             string normalizedProductId = NormalizeRequired(productId, nameof(productId));
             string normalizedProductName = NormalizeRequired(productName, nameof(productName));
@@ -108,7 +120,8 @@ namespace S1API.Internal.Products
                             normalizedProductName,
                             initialPrice,
                             definition,
-                            metadata);
+                            metadata,
+                            saveDescriptor);
                         Registrations.Add(normalizedProductId, registration);
                         added = true;
                     }
@@ -336,6 +349,28 @@ namespace S1API.Internal.Products
         internal static void InvokeLoadCompleteForTesting()
         {
             OnLoadComplete();
+        }
+
+        internal static bool IsRegistered(string productId)
+        {
+            lock (Gate)
+                return Registrations.ContainsKey(productId);
+        }
+
+        internal static CustomProductSaveDescriptorData[] GetSaveDescriptors()
+        {
+            lock (Gate)
+            {
+                var descriptors = new List<CustomProductSaveDescriptorData>();
+                foreach (CustomProductDefinitionRegistration registration in Registrations.Values)
+                {
+                    if (registration.SaveDescriptor == null)
+                        continue;
+                    descriptors.Add(registration.SaveDescriptor);
+                }
+                descriptors.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.ProductId, right.ProductId));
+                return descriptors.ToArray();
+            }
         }
 
         private static bool AreSameDefinition(

--- a/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
+++ b/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace S1API.Internal.Products
+{
+    [Serializable]
+    internal sealed class CustomProductSaveDescriptorData
+    {
+        public int FormatVersion = 1;
+        public string ProductId = string.Empty;
+        public string OwnerId = string.Empty;
+        public string ProductName = string.Empty;
+        public string Description = string.Empty;
+        public float InitialPrice;
+        public int LegalStatus;
+        public float BaseAddictiveness;
+        public int DefaultQuality;
+        public string ProductKindId = string.Empty;
+        public int CompatibilityDrugType;
+        public string RepresentationTemplateId = string.Empty;
+        public int PlayerEffectDurationSeconds;
+        public int NpcEffectDurationSeconds;
+        public string? ProviderId;
+        public int ProviderVersion;
+        public string ProviderData = string.Empty;
+    }
+
+    [Serializable]
+    internal sealed class CustomProductSaveFileData
+    {
+        public int FormatVersion = 1;
+        public CustomProductSaveDescriptorData[] Descriptors = Array.Empty<CustomProductSaveDescriptorData>();
+    }
+}

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -1,0 +1,203 @@
+#if IL2CPPMELON
+using S1Persistence = Il2CppScheduleOne.Persistence;
+using S1Product = Il2CppScheduleOne.Product;
+using S1Registry = Il2CppScheduleOne.Registry;
+using NativeEffect = Il2CppScheduleOne.Effects.Effect;
+using NativePackagingDefinition = Il2CppScheduleOne.Product.Packaging.PackagingDefinition;
+#elif MONOMELON
+using S1Persistence = ScheduleOne.Persistence;
+using S1Product = ScheduleOne.Product;
+using S1Registry = ScheduleOne.Registry;
+using NativeEffect = ScheduleOne.Effects.Effect;
+using NativePackagingDefinition = ScheduleOne.Product.Packaging.PackagingDefinition;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Owns custom-product descriptor persistence and early restoration.</summary>
+    internal static class CustomProductSavePersistence
+    {
+        internal const string RelativePath = "Modded/CustomProducts.json";
+        internal const int CurrentFormatVersion = 1;
+        internal const int MaximumDescriptorCount = 256;
+        internal const int MaximumStringLength = 4096;
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, ICustomProductSaveProvider> Providers =
+            new Dictionary<string, ICustomProductSaveProvider>(StringComparer.OrdinalIgnoreCase);
+        private static string? _restoredSaveFolder;
+
+        internal static ICustomProductSaveProvider RegisterProvider(ICustomProductSaveProvider provider)
+        {
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
+            string id = ProductKindId.Normalize(provider.ProviderId, nameof(provider.ProviderId));
+            if (provider.MaximumDescriptorVersion < 1)
+                throw new ArgumentOutOfRangeException(nameof(provider.MaximumDescriptorVersion));
+            lock (Gate)
+            {
+                if (Providers.TryGetValue(id, out ICustomProductSaveProvider? existing))
+                {
+                    if (!ReferenceEquals(existing, provider))
+                        throw new InvalidOperationException($"Custom-product save provider '{id}' is already registered.");
+                    return existing;
+                }
+                Providers.Add(id, provider);
+                return provider;
+            }
+        }
+
+        internal static void Save(string saveFolderPath)
+        {
+            CustomProductSaveDescriptorData[] descriptors = CustomProductDefinitionRegistry.GetSaveDescriptors();
+            string path = Path.Combine(saveFolderPath, "Modded", "CustomProducts.json");
+            // Do not delete a descriptor file when its content mod is absent. Keeping it makes a
+            // later reinstall recoverable and leaves vanilla-only saves untouched.
+            if (descriptors.Length == 0) return;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            string temporaryPath = path + ".tmp";
+            File.WriteAllText(temporaryPath, JsonConvert.SerializeObject(new CustomProductSaveFileData { Descriptors = descriptors }, Formatting.None));
+            if (File.Exists(path))
+                File.Replace(temporaryPath, path, null);
+            else
+                File.Move(temporaryPath, path);
+        }
+
+        internal static void RestoreBeforeBaseLoaders(S1Persistence.LoadManager loadManager)
+        {
+            if (loadManager == null || string.IsNullOrEmpty(loadManager.LoadedGameFolderPath)) return;
+            string saveFolder = loadManager.LoadedGameFolderPath;
+            if (string.Equals(_restoredSaveFolder, saveFolder, StringComparison.OrdinalIgnoreCase)) return;
+            _restoredSaveFolder = saveFolder;
+            try
+            {
+                string path = Path.Combine(loadManager.LoadedGameFolderPath, "Modded", "CustomProducts.json");
+                if (!File.Exists(path)) return;
+                CustomProductSaveFileData? file = JsonConvert.DeserializeObject<CustomProductSaveFileData>(File.ReadAllText(path));
+                if (file == null || file.FormatVersion != CurrentFormatVersion || file.Descriptors == null || file.Descriptors.Length > MaximumDescriptorCount)
+                {
+                    Warn("descriptor file is incompatible or exceeds the supported descriptor count; custom products were skipped");
+                    return;
+                }
+                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (CustomProductSaveDescriptorData data in file.Descriptors)
+                {
+                    if (!TryValidate(data, out CustomProductSaveDescriptor descriptor) || !seen.Add(descriptor.ProductId))
+                    {
+                        Warn("ignored an invalid or duplicate custom-product descriptor");
+                        continue;
+                    }
+                    RestoreOne(descriptor);
+                }
+            }
+            catch (Exception exception)
+            {
+                Warn("could not read custom-product descriptors; continuing without them: " + exception.Message);
+            }
+            finally { }
+        }
+
+        private static void RestoreOne(CustomProductSaveDescriptor descriptor)
+        {
+            if (CustomProductDefinitionRegistry.IsRegistered(descriptor.ProductId))
+                return;
+            if (string.IsNullOrEmpty(descriptor.ProviderId))
+            {
+                RestoreFallback(descriptor);
+                return;
+            }
+            ICustomProductSaveProvider? provider;
+            lock (Gate) Providers.TryGetValue(descriptor.ProviderId, out provider);
+            if (provider == null)
+            {
+                Warn($"custom product '{descriptor.ProductId}' requires provider '{descriptor.ProviderId}', which is not installed; it was skipped safely");
+                RestoreFallback(descriptor);
+                return;
+            }
+            if (descriptor.ProviderVersion > provider.MaximumDescriptorVersion)
+            {
+                Warn($"custom product '{descriptor.ProductId}' needs a newer '{descriptor.ProviderId}' provider; it was skipped safely");
+                RestoreFallback(descriptor);
+                return;
+            }
+            try
+            {
+                CustomProductDefinitionBuilder? builder = provider.Restore(descriptor);
+                if (builder != null)
+                {
+                    if (!string.Equals(builder.ProductId, descriptor.ProductId, StringComparison.OrdinalIgnoreCase))
+                        throw new InvalidOperationException("provider returned a different product ID; automatic renamed-ID migration is not supported");
+                    builder.Build();
+                }
+            }
+            catch (Exception exception)
+            {
+                Warn($"custom product '{descriptor.ProductId}' could not be reconstructed by '{descriptor.ProviderId}'; it was skipped safely: {exception.Message}");
+                RestoreFallback(descriptor);
+            }
+        }
+
+        private static void RestoreFallback(CustomProductSaveDescriptor descriptor)
+        {
+            try
+            {
+                CustomProductSaveDescriptorData data = descriptor.Data
+                    ?? throw new InvalidOperationException("descriptor has no internal scalar data");
+                S1Product.ProductDefinition? template = S1Registry.GetItem(data.RepresentationTemplateId) as S1Product.ProductDefinition;
+                if (template == null)
+                    throw new InvalidOperationException("the saved vanilla representation template is unavailable");
+                ProductKind kind = ProductKindRegistry.Register(new ProductKind(data.ProductKindId, (DrugType)data.CompatibilityDrugType));
+                var native = CustomProductDefinitionFactory.Create(
+                    data.ProductId, data.ProductName, data.Description, data.InitialPrice,
+                    (global::S1API.Items.LegalStatus)data.LegalStatus, data.BaseAddictiveness,
+                    data.PlayerEffectDurationSeconds, data.NpcEffectDurationSeconds,
+                    (DrugType)data.CompatibilityDrugType, new List<NativeEffect>(),
+                    new List<NativePackagingDefinition>(), template);
+                var metadata = new CustomProductDefinitionMetadata(kind, (Quality)data.DefaultQuality);
+                try
+                {
+                    CustomProductDefinitionRegistry.Register(data.OwnerId, data.ProductId, data.ProductName, data.InitialPrice, native, metadata, data);
+                    Warn($"custom product '{data.ProductId}' used S1API's asset-free fallback; reinstall '{descriptor.ProviderId ?? data.OwnerId}' to restore provider presentation and content");
+                }
+                catch
+                {
+                    CustomProductDefinitionFactory.Destroy(native);
+                    throw;
+                }
+            }
+            catch (Exception exception)
+            {
+                Warn($"custom product '{descriptor.ProductId}' fallback was unavailable; load continues safely: {exception.Message}");
+            }
+        }
+
+        private static bool TryValidate(CustomProductSaveDescriptorData? data, out CustomProductSaveDescriptor descriptor)
+        {
+            descriptor = null!;
+            if (data == null || data.FormatVersion != CurrentFormatVersion || data.ProviderVersion < 0 ||
+                !IsBounded(data.ProductId) || !IsBounded(data.OwnerId) || !IsBounded(data.ProviderData) ||
+                (data.ProviderId != null && !IsBounded(data.ProviderId))) return false;
+            try
+            {
+                string productId = ProductKindId.Normalize(data.ProductId, nameof(data.ProductId));
+                string ownerId = data.OwnerId.Trim();
+                string? providerId = data.ProviderId == null ? null : ProductKindId.Normalize(data.ProviderId, nameof(data.ProviderId));
+                if (!IsBounded(data.ProductName) || !IsBounded(data.Description) || !IsBounded(data.ProductKindId) || !IsBounded(data.RepresentationTemplateId) ||
+                    !float.IsFinite(data.InitialPrice) || !float.IsFinite(data.BaseAddictiveness) || data.InitialPrice < 1 ||
+                    data.BaseAddictiveness < 0 || data.BaseAddictiveness > 1 || data.PlayerEffectDurationSeconds < 0 || data.NpcEffectDurationSeconds < 0 ||
+                    !Enum.IsDefined(typeof(global::S1API.Items.LegalStatus), data.LegalStatus) || !Enum.IsDefined(typeof(Quality), data.DefaultQuality) || !Enum.IsDefined(typeof(DrugType), data.CompatibilityDrugType)) return false;
+                string kindId = ProductKindId.Normalize(data.ProductKindId, nameof(data.ProductKindId));
+                ProductKindId.Normalize(data.RepresentationTemplateId, nameof(data.RepresentationTemplateId));
+                descriptor = new CustomProductSaveDescriptor(data.FormatVersion, productId, ownerId, data.ProductName, data.Description, data.InitialPrice, kindId, providerId, data.ProviderVersion, data.ProviderData) { Data = data };
+                return true;
+            }
+            catch { return false; }
+        }
+        private static bool IsBounded(string? value) => value != null && value.Length <= MaximumStringLength;
+        private static void Warn(string message) { try { MelonLoader.MelonLogger.Warning("[CustomProductSave] " + message); } catch { } }
+    }
+}

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -71,8 +71,18 @@ namespace S1API.Internal.Products
         {
             if (loadManager == null || string.IsNullOrEmpty(loadManager.LoadedGameFolderPath)) return;
             string saveFolder = loadManager.LoadedGameFolderPath;
-            if (string.Equals(_restoredSaveFolder, saveFolder, StringComparison.OrdinalIgnoreCase)) return;
-            _restoredSaveFolder = saveFolder;
+            lock (Gate)
+            {
+                if (string.Equals(
+                        _restoredSaveFolder,
+                        saveFolder,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                _restoredSaveFolder = saveFolder;
+            }
             try
             {
                 string path = Path.Combine(loadManager.LoadedGameFolderPath, "Modded", "CustomProducts.json");
@@ -98,7 +108,6 @@ namespace S1API.Internal.Products
             {
                 Warn("could not read custom-product descriptors; continuing without them: " + exception.Message);
             }
-            finally { }
         }
 
         private static void RestoreOne(CustomProductSaveDescriptor descriptor)
@@ -132,6 +141,10 @@ namespace S1API.Internal.Products
                     if (!string.Equals(builder.ProductId, descriptor.ProductId, StringComparison.OrdinalIgnoreCase))
                         throw new InvalidOperationException("provider returned a different product ID; automatic renamed-ID migration is not supported");
                     builder.Build();
+                }
+                else
+                {
+                    RestoreFallback(descriptor);
                 }
             }
             catch (Exception exception)

--- a/S1API/Products/CustomProductDefinitionBuilder.cs
+++ b/S1API/Products/CustomProductDefinitionBuilder.cs
@@ -57,6 +57,12 @@ namespace S1API.Products
         private ProductDefinition? _representationTemplate;
         private int? _playerEffectDurationSeconds;
         private int? _npcEffectDurationSeconds;
+        private string? _saveProviderId;
+        private int _saveProviderVersion;
+        private string _saveProviderData = string.Empty;
+
+        /// <summary>Gets the stable product ID this builder will create.</summary>
+        public string ProductId => _id;
         private CustomProductDefinition? _builtDefinition;
 
         /// <summary>
@@ -304,6 +310,32 @@ namespace S1API.Products
         }
 
         /// <summary>
+        /// Associates this definition with a process-registered provider that can recreate it on a
+        /// fresh-process save load.
+        /// </summary>
+        /// <param name="providerId">The stable, namespaced provider ID.</param>
+        /// <param name="providerVersion">The provider's non-negative scalar payload version.</param>
+        /// <param name="providerData">Bounded provider-owned scalar data; never pass assets or paths.</param>
+        /// <returns>This builder.</returns>
+        public CustomProductDefinitionBuilder WithSaveProvider(
+            string providerId,
+            int providerVersion,
+            string providerData = "")
+        {
+            EnsureMutable();
+            if (providerVersion < 0)
+                throw new ArgumentOutOfRangeException(nameof(providerVersion));
+            if (providerData == null)
+                throw new ArgumentNullException(nameof(providerData));
+            if (providerData.Length > CustomProductSavePersistence.MaximumStringLength)
+                throw new ArgumentOutOfRangeException(nameof(providerData));
+            _saveProviderId = ProductKindId.Normalize(providerId, nameof(providerId));
+            _saveProviderVersion = providerVersion;
+            _saveProviderData = providerData;
+            return this;
+        }
+
+        /// <summary>
         /// Builds and registers the generic product through S1API's process-lifetime custom-product
         /// lifecycle registry.
         /// </summary>
@@ -402,6 +434,25 @@ namespace S1API.Products
                 _defaultQuality,
                 packagingSnapshot,
                 _representationTemplate.S1ProductDefinition);
+            var saveDescriptor = new CustomProductSaveDescriptorData
+            {
+                ProductId = _id,
+                OwnerId = _ownerId,
+                ProductName = _name,
+                Description = _description,
+                InitialPrice = _productPrice,
+                LegalStatus = (int)_legalStatus,
+                BaseAddictiveness = _baseAddictiveness,
+                DefaultQuality = (int)_defaultQuality,
+                ProductKindId = _productKind.Id,
+                CompatibilityDrugType = (int)_productKind.CompatibilityDrugType.Value,
+                RepresentationTemplateId = _representationTemplate.ID,
+                PlayerEffectDurationSeconds = _playerEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.PlayerEffectDuration,
+                NpcEffectDurationSeconds = _npcEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.NPCEffectDuration,
+                ProviderId = _saveProviderId,
+                ProviderVersion = _saveProviderVersion,
+                ProviderData = _saveProviderData
+            };
             RegisterCreatedDefinition(
                 _ownerId,
                 _id,
@@ -409,6 +460,7 @@ namespace S1API.Products
                 _productPrice,
                 nativeDefinition,
                 metadata,
+                saveDescriptor,
                 CustomProductDefinitionFactory.Destroy);
 
             _builtDefinition =
@@ -425,6 +477,27 @@ namespace S1API.Products
             CustomProductDefinitionMetadata metadata,
             Action<S1Product.ProductDefinition> destroy)
         {
+            return RegisterCreatedDefinition(
+                ownerId,
+                productId,
+                productName,
+                initialPrice,
+                nativeDefinition,
+                metadata,
+                null,
+                destroy);
+        }
+
+        internal static S1Product.ProductDefinition RegisterCreatedDefinition(
+            string ownerId,
+            string productId,
+            string productName,
+            float initialPrice,
+            S1Product.ProductDefinition nativeDefinition,
+            CustomProductDefinitionMetadata metadata,
+            CustomProductSaveDescriptorData? saveDescriptor,
+            Action<S1Product.ProductDefinition> destroy)
+        {
             if (destroy == null)
                 throw new ArgumentNullException(nameof(destroy));
 
@@ -437,7 +510,8 @@ namespace S1API.Products
                         productName,
                         initialPrice,
                         nativeDefinition,
-                        metadata);
+                        metadata,
+                        saveDescriptor);
                 if (ReferenceEquals(registeredDefinition, nativeDefinition))
                     return registeredDefinition;
 

--- a/S1API/Products/CustomProductSaveDescriptor.cs
+++ b/S1API/Products/CustomProductSaveDescriptor.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Immutable scalar data used to recreate a generic custom product while loading a save.
+    /// </summary>
+    /// <remarks>
+    /// This descriptor deliberately contains no Unity objects, asset references, delegates, or
+    /// process-local references. A provider may use <see cref="ProviderData"/> to retain its own
+    /// bounded scalar configuration.
+    /// </remarks>
+    public sealed class CustomProductSaveDescriptor
+    {
+        /// <summary>Gets the S1API descriptor format version.</summary>
+        public int FormatVersion { get; }
+        /// <summary>Gets the stable custom product ID.</summary>
+        public string ProductId { get; }
+        /// <summary>Gets the product owner's stable ID.</summary>
+        public string OwnerId { get; }
+        /// <summary>Gets the saved display name.</summary>
+        public string ProductName { get; }
+        /// <summary>Gets the saved description.</summary>
+        public string Description { get; }
+        /// <summary>Gets the saved initial price.</summary>
+        public float InitialPrice { get; }
+        /// <summary>Gets the saved logical product-kind ID.</summary>
+        public string ProductKindId { get; }
+        /// <summary>Gets the optional content-provider ID.</summary>
+        public string? ProviderId { get; }
+        /// <summary>Gets the provider-specific descriptor version.</summary>
+        public int ProviderVersion { get; }
+        /// <summary>Gets the provider-owned scalar payload.</summary>
+        public string ProviderData { get; }
+
+        internal Internal.Products.CustomProductSaveDescriptorData? Data { get; set; }
+
+        /// <summary>
+        /// Initializes a descriptor supplied to a registered content provider.
+        /// </summary>
+        public CustomProductSaveDescriptor(
+            int formatVersion,
+            string productId,
+            string ownerId,
+            string productName,
+            string description,
+            float initialPrice,
+            string productKindId,
+            string? providerId,
+            int providerVersion,
+            string providerData)
+        {
+            FormatVersion = formatVersion;
+            ProductId = productId ?? throw new ArgumentNullException(nameof(productId));
+            OwnerId = ownerId ?? throw new ArgumentNullException(nameof(ownerId));
+            ProductName = productName ?? throw new ArgumentNullException(nameof(productName));
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+            InitialPrice = initialPrice;
+            ProductKindId = productKindId ?? throw new ArgumentNullException(nameof(productKindId));
+            ProviderId = providerId;
+            ProviderVersion = providerVersion;
+            ProviderData = providerData ?? throw new ArgumentNullException(nameof(providerData));
+        }
+    }
+
+    /// <summary>Reconstructs a custom product from a persisted scalar descriptor.</summary>
+    public interface ICustomProductSaveProvider
+    {
+        /// <summary>Gets the stable, namespaced provider ID.</summary>
+        string ProviderId { get; }
+        /// <summary>Gets the highest provider descriptor version this provider accepts.</summary>
+        int MaximumDescriptorVersion { get; }
+        /// <summary>Recreates and registers the descriptor's product.</summary>
+        /// <param name="descriptor">The validated scalar descriptor.</param>
+        /// <returns>A fully configured, unbuilt definition builder, or <see langword="null"/> to use S1API's safe fallback.</returns>
+        CustomProductDefinitionBuilder? Restore(CustomProductSaveDescriptor descriptor);
+    }
+}

--- a/S1API/Products/CustomProductSaveProviderRegistry.cs
+++ b/S1API/Products/CustomProductSaveProviderRegistry.cs
@@ -1,0 +1,15 @@
+using System;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>Registers process-lifetime providers for custom-product save descriptors.</summary>
+    public static class CustomProductSaveProviderRegistry
+    {
+        /// <summary>Registers a provider, or returns the existing equivalent provider.</summary>
+        public static ICustomProductSaveProvider Register(ICustomProductSaveProvider provider)
+        {
+            return CustomProductSavePersistence.RegisterProvider(provider);
+        }
+    }
+}

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -365,6 +365,50 @@ Pass `listForSale: true` to `Discover` only when discovery should also list the
 product. Shop inventory remains separate; call the existing
 `S1API.Shops.ShopManager` APIs explicitly after registration.
 
+## Save descriptors and missing-mod recovery
+
+Generic products are persisted separately at `Modded/CustomProducts.json`. The
+file is versioned and records only stable IDs and bounded scalar provider data;
+it never serializes Unity objects, prefab/asset references, textures, meshes,
+delegates, or paths. S1API reads it before the vanilla Product Manager loader,
+so the normal vanilla `ProductManager.json` restoration of discovery, listing,
+favourites, prices, and inventory product IDs can resolve the definition first.
+The provider recreates its logical kind, presentation/profile associations, and
+packaging-content provider associations from local mod resources. Generic products
+are never inserted into vanilla's four-family `createdProducts` arrays.
+
+For fresh-process recovery, register a provider during your mod's normal early
+initialization and associate it with each definition:
+
+```csharp
+sealed class FocusTabletProvider : ICustomProductSaveProvider
+{
+    public string ProviderId => "example:focus-tablet";
+    public int MaximumDescriptorVersion => 1;
+
+    public CustomProductDefinitionBuilder? Restore(CustomProductSaveDescriptor descriptor)
+    {
+        // Recreate the same builder, presentation profile, packaging-content profile,
+        // and ProductKind metadata from descriptor.ProviderData and local mod resources.
+        return CreateFocusTabletBuilder(descriptor.ProviderData);
+    }
+}
+
+CustomProductSaveProviderRegistry.Register(new FocusTabletProvider());
+
+// When initially creating the product:
+builder.WithSaveProvider("example:focus-tablet", providerVersion: 1, providerData: "v1");
+```
+
+Provider IDs are case-insensitive and must remain stable. S1API deterministically
+keeps the first descriptor for a case-insensitive product ID. A malformed,
+oversized, duplicate, or unknown-format descriptor is skipped. A missing provider,
+provider version that is too new, failed reconstruction, or returned renamed ID is
+also skipped with an actionable warning; loading continues and S1API never attempts
+an arbitrary ID migration. Reinstall the content mod/provider with the original
+stable ID to restore the product. These warnings intentionally contain IDs only,
+never local paths or personal data.
+
 ## Supported and unsupported behavior
 
 Supported in this milestone:
@@ -385,8 +429,8 @@ Not supported:
 - custom packaging definitions, packaging asset networking, additional
   packaging-content save data;
 - definition transfer to a peer without the defining mod; or
-- recovery of a saved custom item after its mod or stable definition ID is
-  removed.
+- automatic arbitrary renamed-ID migration or recovery of content assets from a
+  removed mod.
 
 Do not place a generic custom product in native mixing flows. The compatibility
 drug type only satisfies native product-item and save assumptions; S1API does


### PR DESCRIPTION
## Summary

- add versioned, bounded custom-product descriptors in Modded/CustomProducts.json
- restore descriptors before the native Product Manager loader through registered content providers, with scalar asset-free fallback recovery
- preserve vanilla product JSON and the native four-family createdProducts arrays; document deterministic duplicate, version, renamed-ID, and missing-provider handling

Closes #104.

## Compatibility

- Source: additive public descriptor/provider APIs and an additive builder method; existing signatures and defaults are unchanged.
- Binary: existing public members are untouched; new types and members are additive.
- Behavior: existing generic products retain their current lifecycle registrations. Descriptor writes are opt-in to generic definitions and never rewrite vanilla product data.
- Save: vanilla saves with no custom descriptors are unchanged. Descriptor writes are versioned and bounded; missing content preserves the descriptor and uses an asset-free fallback when possible.
- Network: unchanged. This PR does not add synchronization or manifests (#105).

## Testing

- Mono build passed with 0 warnings; canonical tests: 204 passed.
- IL2CPP build passed with 0 warnings; canonical tests: 197 passed.
- API documentation coverage: 81.31% (minimum 80%).

## Limitations

No multiplayer synchronization/manifests or mixing outputs are included. The local DocFX process generated the site but did not exit before the runner timeout. Fresh-process in-game save smoke automation remains to be run from an isolated disposable install before merge.