### PR TITLE
feat(networking): validate custom product manifests before player data

### DIFF
--- a/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
@@ -102,6 +102,80 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
     }
 
     [Fact]
+    public void ManifestSnapshotUsesCommittedDescriptorsWithoutReapplyingDefinitions()
+    {
+        string productId = CreateProductId();
+        CustomProductDefinitionMetadata metadata = CreateMetadata(productId);
+        CustomProductDefinitionRegistry.Register(
+            "examplemod",
+            productId,
+            "Manifest Product",
+            80f,
+            CreateDefinition(),
+            metadata,
+            new CustomProductSaveDescriptorData
+            {
+                ProductId = productId,
+                OwnerId = "examplemod",
+                ProductName = "Manifest Product",
+                Description = "scalar metadata",
+                InitialPrice = 80f,
+                ProductKindId = metadata.ProductKind.Id,
+                CompatibilityDrugType = (int)DrugType.MDMA,
+                RepresentationTemplateId = "weed",
+                ProviderId = "examplemod:provider",
+                ProviderVersion = 2,
+                ProviderData = "local-only-provider-data"
+            });
+        int applyCount = _runtimeAdapter.ApplyCount;
+
+        CustomProductManifestData first =
+            CustomProductDefinitionRegistry.CreateManifest();
+        CustomProductManifestData second =
+            CustomProductDefinitionRegistry.CreateManifest();
+
+        CustomProductManifestEntryData entry = Assert.Single(first.Entries);
+        Assert.Equal(productId, entry.ProductId);
+        Assert.Equal("examplemod:provider", entry.ProviderId);
+        Assert.Equal(2, entry.ProviderVersion);
+        Assert.Equal(first.CompatibilityHash, second.CompatibilityHash);
+        Assert.Equal(applyCount, _runtimeAdapter.ApplyCount);
+        Assert.DoesNotContain(
+            entry.GetType().GetFields(),
+            field => field.Name == "ProviderData");
+    }
+
+    [Fact]
+    public void FailedRegistrationDoesNotContaminateManifestSnapshot()
+    {
+        string productId = CreateProductId();
+        CustomProductDefinitionMetadata metadata = CreateMetadata(productId);
+        _runtimeAdapter.NextApplyException =
+            new InvalidOperationException("Native registration failed.");
+
+        Assert.Throws<InvalidOperationException>(
+            () => CustomProductDefinitionRegistry.Register(
+                "examplemod",
+                productId,
+                "Rejected Manifest Product",
+                50f,
+                CreateDefinition(),
+                metadata,
+                new CustomProductSaveDescriptorData
+                {
+                    ProductId = productId,
+                    OwnerId = "examplemod",
+                    ProductName = "Rejected Manifest Product",
+                    ProductKindId = metadata.ProductKind.Id,
+                    CompatibilityDrugType = (int)DrugType.MDMA,
+                    RepresentationTemplateId = "weed"
+                }));
+
+        Assert.Empty(CustomProductDefinitionRegistry.CreateManifest().Entries);
+        Assert.False(CustomProductDefinitionRegistry.IsRegistered(productId));
+    }
+
+    [Fact]
     public void ConflictingOwnerFailsWithActionableIdentity()
     {
         string productId = CreateProductId();

--- a/S1API.Tests/Products/CustomProductManifestClientGateTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestClientGateTests.cs
@@ -129,6 +129,31 @@ public sealed class CustomProductManifestClientGateTests
         Assert.True(finalizeCall > restoreCall);
     }
 
+    [Fact]
+    public void DeferredHostPlayerDataReplaysTheExactInterceptedOverload()
+    {
+        var target = new OverloadedPlayerDataReceiver();
+        MethodInfo selected = typeof(OverloadedPlayerDataReceiver).GetMethod(
+            nameof(OverloadedPlayerDataReceiver.ReceivePlayerData),
+            new[] { typeof(int) })!;
+        Type pendingType = typeof(CustomProductManifestRuntime).GetNestedType(
+            "PendingHostData",
+            BindingFlags.NonPublic)!;
+        object pending = Activator.CreateInstance(
+            pendingType,
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            args: new object[] { target, new object[] { 7 }, selected },
+            culture: null)!;
+
+        pendingType.GetMethod(
+            "Invoke",
+            BindingFlags.Instance | BindingFlags.NonPublic)!.Invoke(pending, null);
+
+        Assert.Equal(7, target.IntegerValue);
+        Assert.Null(target.StringValue);
+    }
+
     private static int FindMetadataToken(byte[] il, int token)
     {
         byte[] bytes = BitConverter.GetBytes(token);
@@ -142,5 +167,21 @@ public sealed class CustomProductManifestClientGateTests
         }
 
         return -1;
+    }
+
+    private sealed class OverloadedPlayerDataReceiver
+    {
+        internal int IntegerValue { get; private set; }
+        internal string? StringValue { get; private set; }
+
+        public void ReceivePlayerData(int value)
+        {
+            IntegerValue = value;
+        }
+
+        public void ReceivePlayerData(string value)
+        {
+            StringValue = value;
+        }
     }
 }

--- a/S1API.Tests/Products/CustomProductManifestClientGateTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestClientGateTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Reflection;
+using S1API.Internal.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductManifestClientGateTests
+{
+    [Fact]
+    public void PlayerDataRequestRunsOnlyAfterMatchingManifestIsAccepted()
+    {
+        var gate = new CustomProductManifestClientGate();
+        bool requested = false;
+        gate.Begin(requiresValidation: true);
+
+        Assert.False(gate.AuthorizePlayerDataRequest(() => requested = true));
+        Assert.False(requested);
+
+        CustomProductManifestAcceptance acceptance = gate.Accept(
+            new string('a', 64),
+            new string('a', 64),
+            out Action? deferred);
+
+        Assert.Equal(CustomProductManifestAcceptance.Accepted, acceptance);
+        Assert.NotNull(deferred);
+        Assert.False(requested);
+        deferred();
+        Assert.True(requested);
+        Assert.False(gate.IsWaiting);
+    }
+
+    [Fact]
+    public void IncompatibleManifestLeavesPlayerDataBlockedWithoutPartialState()
+    {
+        var gate = new CustomProductManifestClientGate();
+        bool requested = false;
+        gate.Begin(requiresValidation: true);
+        Assert.False(gate.AuthorizePlayerDataRequest(() => requested = true));
+
+        CustomProductManifestAcceptance acceptance = gate.Accept(
+            new string('a', 64),
+            new string('b', 64),
+            out Action? deferred);
+
+        Assert.Equal(CustomProductManifestAcceptance.Incompatible, acceptance);
+        Assert.Null(deferred);
+        Assert.False(requested);
+        Assert.True(gate.IsWaiting);
+
+        gate.End();
+        Assert.False(gate.IsWaiting);
+        Assert.True(gate.AuthorizePlayerDataRequest(() => requested = true));
+    }
+
+    [Fact]
+    public void ReconnectResetsDeferredStateAndDuplicateAcceptanceIsIdempotent()
+    {
+        var gate = new CustomProductManifestClientGate();
+        int firstSessionRequests = 0;
+        gate.Begin(requiresValidation: true);
+        Assert.False(gate.AuthorizePlayerDataRequest(() => firstSessionRequests++));
+        gate.End();
+
+        gate.Begin(requiresValidation: true);
+        Assert.False(gate.AuthorizePlayerDataRequest(() => { }));
+        Assert.Equal(
+            CustomProductManifestAcceptance.Accepted,
+            gate.Accept("hash", "hash", out Action? deferred));
+        Assert.NotNull(deferred);
+
+        Assert.Equal(
+            CustomProductManifestAcceptance.AlreadyAccepted,
+            gate.Accept("hash", "hash", out Action? duplicate));
+        Assert.Null(duplicate);
+        Assert.Equal(0, firstSessionRequests);
+    }
+
+    [Fact]
+    public void VanillaSessionBypassesManifestGate()
+    {
+        var gate = new CustomProductManifestClientGate();
+        gate.Begin(requiresValidation: false);
+
+        Assert.False(gate.IsWaiting);
+        Assert.True(gate.AuthorizePlayerDataRequest(() => { }));
+    }
+
+    [Fact]
+    public void RepeatedNativeRequestRetainsOnlyTheFirstDeferredCall()
+    {
+        var gate = new CustomProductManifestClientGate();
+        int first = 0;
+        int second = 0;
+        gate.Begin(requiresValidation: true);
+
+        Assert.False(gate.AuthorizePlayerDataRequest(() => first++));
+        Assert.False(gate.AuthorizePlayerDataRequest(() => second++));
+        Assert.Equal(
+            CustomProductManifestAcceptance.Accepted,
+            gate.Accept("hash", "hash", out Action? deferred));
+
+        deferred!();
+        Assert.Equal(1, first);
+        Assert.Equal(0, second);
+    }
+
+    [Fact]
+    public void DescriptorRestorePrecedesHostManifestFinalizationInTheSamePatch()
+    {
+        Assembly assembly = typeof(CustomProductManifestRuntime).Assembly;
+        Type patch = assembly.GetType(
+            "S1API.Internal.Patches.CustomProductSavePatches",
+            throwOnError: true)!;
+        MethodInfo prefix = patch.GetMethod(
+            "RestorePrefix",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        MethodInfo restore = typeof(CustomProductSavePersistence).GetMethod(
+            "RestoreBeforeBaseLoaders",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        MethodInfo finalize = typeof(CustomProductManifestRuntime).GetMethod(
+            "FinalizeHostManifestAfterDescriptorRestore",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        byte[] il = prefix.GetMethodBody()!.GetILAsByteArray()!;
+
+        int restoreCall = FindMetadataToken(il, restore.MetadataToken);
+        int finalizeCall = FindMetadataToken(il, finalize.MetadataToken);
+
+        Assert.True(restoreCall >= 0);
+        Assert.True(finalizeCall > restoreCall);
+    }
+
+    private static int FindMetadataToken(byte[] il, int token)
+    {
+        byte[] bytes = BitConverter.GetBytes(token);
+        for (int i = 0; i <= il.Length - bytes.Length; i++)
+        {
+            bool matches = true;
+            for (int offset = 0; offset < bytes.Length; offset++)
+                matches &= il[i + offset] == bytes[offset];
+            if (matches)
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/S1API.Tests/Products/CustomProductManifestDataTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestDataTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Linq;
+using S1API.Internal.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductManifestDataTests
+{
+    [Fact]
+    public void CanonicalManifestHashIsIndependentOfConstructionOrder()
+    {
+        CustomProductManifestEntryData first = CreateEntry("example:alpha");
+        CustomProductManifestEntryData second = CreateEntry("example:beta");
+
+        string left = CustomProductManifestData.ComputeManifestHash(
+            new[] { first, second });
+        string right = CustomProductManifestData.ComputeManifestHash(
+            new[] { second, first }.OrderBy(entry => entry.ProductId,
+                StringComparer.OrdinalIgnoreCase).ToArray());
+
+        Assert.Equal(left, right);
+    }
+
+    [Fact]
+    public void ManifestRejectsDuplicateAndNonCanonicalEntries()
+    {
+        CustomProductManifestEntryData first = CreateEntry("example:alpha");
+        CustomProductManifestEntryData duplicate = CreateEntry("EXAMPLE:ALPHA");
+        var manifest = new CustomProductManifestData
+        {
+            SessionId = new string('a', 32),
+            Entries = new[] { first, duplicate }
+        };
+        manifest.CompatibilityHash =
+            CustomProductManifestData.ComputeManifestHash(manifest.Entries);
+
+        Assert.False(CustomProductManifestData.TryValidate(manifest, out string failure));
+        Assert.Contains("duplicate", failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManifestRejectsUnsupportedVersionAndPayloadBounds()
+    {
+        var manifest = new CustomProductManifestData
+        {
+            ProtocolVersion = CustomProductManifestData.CurrentProtocolVersion + 1,
+            SessionId = new string('a', 32),
+            Entries = Array.Empty<CustomProductManifestEntryData>(),
+            CompatibilityHash = CustomProductManifestData.ComputeManifestHash(
+                Array.Empty<CustomProductManifestEntryData>())
+        };
+
+        Assert.False(CustomProductManifestData.TryValidate(manifest, out string failure));
+        Assert.Contains("protocol", failure, StringComparison.Ordinal);
+        Assert.False(CustomProductManifestData.TryDeserialize(
+            new string('x', CustomProductManifestData.MaximumPayloadLength + 1),
+            out _,
+            out string payloadFailure));
+        Assert.Contains("size", payloadFailure, StringComparison.Ordinal);
+
+        Assert.False(CustomProductManifestData.TryDeserialize(
+            new string('é', (CustomProductManifestData.MaximumPayloadLength / 2) + 1),
+            out _,
+            out string utf8PayloadFailure));
+        Assert.Contains("size", utf8PayloadFailure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManifestRejectsEntryCountAndUnsafeIdentifierBounds()
+    {
+        var tooManyEntries = new CustomProductManifestData
+        {
+            SessionId = new string('a', 32),
+            Entries = Enumerable.Range(
+                    0,
+                    CustomProductManifestData.MaximumEntryCount + 1)
+                .Select(index => CreateEntry("example:" + index))
+                .ToArray()
+        };
+        tooManyEntries.CompatibilityHash =
+            CustomProductManifestData.ComputeManifestHash(tooManyEntries.Entries);
+
+        Assert.False(CustomProductManifestData.TryValidate(
+            tooManyEntries,
+            out string countFailure));
+        Assert.Contains("entry count", countFailure, StringComparison.Ordinal);
+
+        CustomProductManifestEntryData unsafeEntry = CreateEntry("example:\nforged-log");
+        Assert.False(unsafeEntry.IsValid());
+
+        CustomProductManifestEntryData longIdentifier = CreateEntry(
+            new string('x', CustomProductManifestData.MaximumIdentifierLength + 1));
+        Assert.False(longIdentifier.IsValid());
+
+        CustomProductManifestEntryData excessivePackaging = CreateEntry("example:packaging");
+        excessivePackaging.PackagingIds = Enumerable.Range(
+                0,
+                CustomProductManifestData.MaximumPackagingCount + 1)
+            .Select(index => "package:" + index)
+            .ToArray();
+        Assert.False(excessivePackaging.IsValid());
+    }
+
+    [Fact]
+    public void StableIdentifierCasingDoesNotChangeCompatibilityHash()
+    {
+        CustomProductManifestEntryData lower = CreateEntry("example:alpha");
+        CustomProductManifestEntryData upper = CreateEntry("EXAMPLE:ALPHA");
+        upper.OwnerId = lower.OwnerId.ToUpperInvariant();
+        upper.ProductKindId = lower.ProductKindId.ToUpperInvariant();
+        upper.ProviderId = lower.ProviderId!.ToUpperInvariant();
+        upper.RepresentationTemplateId =
+            lower.RepresentationTemplateId.ToUpperInvariant();
+        upper.PresentationProfileId =
+            lower.PresentationProfileId.ToUpperInvariant();
+        upper.PackagingIds = lower.PackagingIds
+            .Select(value => value.ToUpperInvariant())
+            .ToArray();
+
+        Assert.Equal(
+            CustomProductManifestData.ComputeManifestHash(new[] { lower }),
+            CustomProductManifestData.ComputeManifestHash(new[] { upper }));
+    }
+
+    [Fact]
+    public void ManifestRejectsTamperedCompatibilityHash()
+    {
+        var manifest = new CustomProductManifestData
+        {
+            SessionId = new string('a', 32),
+            Entries = new[] { CreateEntry("example:alpha") },
+            CompatibilityHash = new string('0', 64)
+        };
+
+        Assert.False(CustomProductManifestData.TryValidate(manifest, out string failure));
+        Assert.Contains("compatibility hash", failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManifestEntryContainsNoProviderPayload()
+    {
+        string[] names = typeof(CustomProductManifestEntryData)
+            .GetFields()
+            .Select(field => field.Name)
+            .ToArray();
+
+        Assert.DoesNotContain("ProviderData", names);
+        Assert.Contains("ProviderId", names);
+        Assert.Contains("CompatibilityHash", names);
+    }
+
+    [Fact]
+    public void ManifestRejectsMalformedDuplicateAndUnknownJsonMembers()
+    {
+        Assert.False(CustomProductManifestData.TryDeserialize(
+            """{"ProtocolVersion":1,"ProtocolVersion":1}""",
+            out _,
+            out string duplicateFailure));
+        Assert.Contains("malformed", duplicateFailure, StringComparison.Ordinal);
+
+        Assert.False(CustomProductManifestData.TryDeserialize(
+            """{"Unexpected":"data"}""",
+            out _,
+            out string unknownFailure));
+        Assert.Contains("malformed", unknownFailure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManifestRejectsInvalidEntryScalars()
+    {
+        CustomProductManifestEntryData entry = CreateEntry("example:alpha");
+        entry.CompatibilityDrugType = int.MaxValue;
+        var manifest = new CustomProductManifestData
+        {
+            SessionId = new string('a', 32),
+            Entries = new[] { entry }
+        };
+        manifest.CompatibilityHash =
+            CustomProductManifestData.ComputeManifestHash(manifest.Entries);
+
+        Assert.False(CustomProductManifestData.TryValidate(manifest, out string failure));
+        Assert.Contains("invalid", failure, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("ProviderId")]
+    [InlineData("ProviderVersion")]
+    [InlineData("ProviderAvailable")]
+    [InlineData("DescriptorFormatVersion")]
+    [InlineData("PresentationProfileId")]
+    [InlineData("PackagingIds")]
+    public void CompatibilityHashChangesForCompatibilityRelevantMetadata(string field)
+    {
+        CustomProductManifestEntryData baseline = CreateEntry("example:alpha");
+        CustomProductManifestEntryData changed = CreateEntry("example:alpha");
+        switch (field)
+        {
+            case "ProviderId":
+                changed.ProviderId = "example:other-provider";
+                break;
+            case "ProviderVersion":
+                changed.ProviderVersion++;
+                break;
+            case "ProviderAvailable":
+                changed.ProviderAvailable = false;
+                break;
+            case "DescriptorFormatVersion":
+                changed.DescriptorFormatVersion++;
+                break;
+            case "PresentationProfileId":
+                changed.PresentationProfileId = "example:other-profile";
+                break;
+            case "PackagingIds":
+                changed.PackagingIds = new[] { "bag" };
+                break;
+        }
+
+        Assert.NotEqual(
+            CustomProductManifestData.ComputeManifestHash(new[] { baseline }),
+            CustomProductManifestData.ComputeManifestHash(new[] { changed }));
+    }
+
+    [Fact]
+    public void MismatchDiagnosticsIdentifyProviderWithoutExposingProviderData()
+    {
+        CustomProductManifestEntryData hostEntry = CreateEntry("example:alpha");
+        CustomProductManifestEntryData localEntry = CreateEntry("example:alpha");
+        localEntry.ProviderVersion++;
+        var host = new CustomProductManifestData { Entries = new[] { hostEntry } };
+        var local = new CustomProductManifestData { Entries = new[] { localEntry } };
+
+        string diagnostic =
+            CustomProductManifestData.DescribeCompatibilityMismatch(host, local);
+
+        Assert.Contains("provider", diagnostic, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("data", diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CustomProductManifestEntryData CreateEntry(string productId)
+    {
+        return new CustomProductManifestEntryData
+        {
+            ProductId = productId,
+            OwnerId = "example",
+            ProductKindId = "example:kind",
+            CompatibilityDrugType = 0,
+            DescriptorFormatVersion = 1,
+            ProviderId = "example:provider",
+            ProviderVersion = 1,
+            ProviderAvailable = true,
+            RepresentationTemplateId = "ogkush",
+            PresentationProfileId = "example:" + productId,
+            PackagingIds = new[] { "bag", "jar" },
+            CompatibilityHash = new string('a', 64)
+        };
+    }
+}

--- a/S1API.Tests/Products/CustomProductManifestDataTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestDataTests.cs
@@ -66,6 +66,33 @@ public sealed class CustomProductManifestDataTests
     }
 
     [Fact]
+    public void SerializeDoesNotMutateTheManifestWhenItSucceedsOrFails()
+    {
+        var manifest = new CustomProductManifestData
+        {
+            SessionId = "original-session",
+            Entries = Array.Empty<CustomProductManifestEntryData>()
+        };
+        manifest.CompatibilityHash =
+            CustomProductManifestData.ComputeManifestHash(manifest.Entries);
+
+        string payload = manifest.Serialize(new string('a', 32));
+
+        Assert.Equal("original-session", manifest.SessionId);
+        Assert.True(CustomProductManifestData.TryDeserialize(
+            payload,
+            out CustomProductManifestData serialized,
+            out string failure),
+            failure);
+        Assert.Equal(new string('a', 32), serialized.SessionId);
+
+        manifest.Entries = new[] { CreateEntry(new string('x', 65536)) };
+        Assert.Throws<InvalidOperationException>(
+            () => manifest.Serialize(new string('b', 32)));
+        Assert.Equal("original-session", manifest.SessionId);
+    }
+
+    [Fact]
     public void ManifestRejectsEntryCountAndUnsafeIdentifierBounds()
     {
         var tooManyEntries = new CustomProductManifestData

--- a/S1API.Tests/Products/CustomProductSaveApiCompileFixture.cs
+++ b/S1API.Tests/Products/CustomProductSaveApiCompileFixture.cs
@@ -23,4 +23,14 @@ internal static class CustomProductSaveApiCompileFixture
     {
         _ = CustomProductSaveProviderRegistry.Register(new Provider());
     }
+
+    internal static void CompileMultiplayerDiagnosticsCaller()
+    {
+        CustomProductMultiplayerPolicy policy =
+            CustomProductMultiplayer.MissingContentPolicy;
+        string compatibilityHash =
+            CustomProductMultiplayer.GetCompatibilityManifestHash();
+        _ = policy == CustomProductMultiplayerPolicy.Reject &&
+            compatibilityHash.Length == 64;
+    }
 }

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -160,6 +160,23 @@ public sealed class ProductApiCompatibilityTests
     }
 
     [Fact]
+    public void CustomProductMultiplayerApiIsAdditiveAndFailClosed()
+    {
+        Assert.True(typeof(CustomProductMultiplayer).IsAbstract);
+        Assert.True(typeof(CustomProductMultiplayer).IsSealed);
+        Assert.Equal(
+            CustomProductMultiplayerPolicy.Reject,
+            CustomProductMultiplayer.MissingContentPolicy);
+        Assert.NotNull(typeof(CustomProductMultiplayer).GetMethod(
+            nameof(CustomProductMultiplayer.GetCompatibilityManifestHash),
+            Type.EmptyTypes));
+        Assert.Equal(
+            new[] { 0 },
+            Enum.GetValues<CustomProductMultiplayerPolicy>()
+                .Select(value => (int)value));
+    }
+
+    [Fact]
     public void ProductPresentationProfileApiIsAdditiveAndRuntimeAgnostic()
     {
         Assert.True(typeof(ProductPresentationProfile).IsSealed);

--- a/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
@@ -181,6 +181,38 @@ public sealed class ProductPresentationProfileRegistryTests : IDisposable
     }
 
     [Fact]
+    public void OverlongManifestIdentityUsesABoundedCaseInsensitiveDigest()
+    {
+        string ownerId = "owner-" + new string('o', 150);
+        string productId = "example:" + new string('p', 110);
+        ProductPresentationProfile profile = CreateProfile();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            ownerId,
+            productId,
+            profile);
+        Assert.True(ProductPresentationProfileRegistry.TryGetManifestIdentity(
+            productId,
+            string.Empty,
+            out string lowerIdentity));
+
+        ProductPresentationProfileRegistry.ResetForTesting();
+        ProductPresentationProfileRegistry.RegisterForProduct(
+            ownerId.ToUpperInvariant(),
+            productId.ToUpperInvariant(),
+            profile);
+        Assert.True(ProductPresentationProfileRegistry.TryGetManifestIdentity(
+            productId,
+            string.Empty,
+            out string upperIdentity));
+
+        Assert.StartsWith("sha256:", lowerIdentity, StringComparison.Ordinal);
+        Assert.Equal(lowerIdentity, upperIdentity);
+        Assert.True(
+            lowerIdentity.Length <=
+            CustomProductManifestData.MaximumIdentifierLength);
+    }
+
+    [Fact]
     public void ConflictingOwnerFailsWithActionableIdentity()
     {
         string productId = CreateId();

--- a/S1API/Internal/Patches/CustomProductManifestPatches.cs
+++ b/S1API/Internal/Patches/CustomProductManifestPatches.cs
@@ -1,0 +1,75 @@
+#if IL2CPPMELON
+using S1Connection = Il2CppFishNet.Connection.NetworkConnection;
+using S1Persistence = Il2CppScheduleOne.Persistence;
+using S1Player = Il2CppScheduleOne.PlayerScripts.Player;
+#elif MONOMELON
+using S1Connection = FishNet.Connection.NetworkConnection;
+using S1Persistence = ScheduleOne.Persistence;
+using S1Player = ScheduleOne.PlayerScripts.Player;
+#endif
+
+using HarmonyLib;
+using S1API.Internal.Products;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>INTERNAL: Starts and stops custom-product manifest handshakes with native loading.</summary>
+    [HarmonyPatch]
+    internal static class CustomProductManifestLoadPatches
+    {
+        [HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.StartGame))]
+        [HarmonyPrefix]
+        private static void StartGamePrefix()
+        {
+            CustomProductManifestRuntime.BeginHostSession();
+        }
+
+        [HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.LoadAsClient))]
+        [HarmonyPrefix]
+        private static void LoadAsClientPrefix()
+        {
+            CustomProductManifestRuntime.BeginClientSession();
+        }
+
+        [HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.ExitToMenu))]
+        [HarmonyPrefix]
+        private static void ExitToMenuPrefix()
+        {
+            CustomProductManifestRuntime.EndHostSession();
+            CustomProductManifestRuntime.EndClientSession();
+        }
+
+        [HarmonyPatch(typeof(S1Persistence.LoadManager), nameof(S1Persistence.LoadManager.Update))]
+        [HarmonyPostfix]
+        private static void UpdatePostfix()
+        {
+            CustomProductManifestRuntime.Tick();
+        }
+    }
+
+    /// <summary>INTERNAL: Prevents client inventory deserialization before manifest validation.</summary>
+    [HarmonyPatch]
+    internal static class CustomProductManifestPlayerPatches
+    {
+        [HarmonyPatch(typeof(S1Player), nameof(S1Player.RequestPlayerData))]
+        [HarmonyPrefix]
+        private static bool RequestPlayerDataPrefix(S1Player __instance, string playerCode)
+        {
+            return CustomProductManifestRuntime.AuthorizeClientPlayerDataRequest(
+                () => __instance.RequestPlayerData(playerCode));
+        }
+
+        [HarmonyPatch(typeof(S1Player), nameof(S1Player.ReceivePlayerData))]
+        [HarmonyPrefix]
+        private static bool ReceivePlayerDataPrefix(object __instance, object[] __args)
+        {
+            if (__args.Length == 0 || !(__args[0] is S1Connection connection))
+                return true;
+
+            return CustomProductManifestRuntime.AuthorizeHostPlayerData(
+                __instance,
+                connection,
+                __args);
+        }
+    }
+}

--- a/S1API/Internal/Patches/CustomProductManifestPatches.cs
+++ b/S1API/Internal/Patches/CustomProductManifestPatches.cs
@@ -8,6 +8,7 @@ using S1Persistence = ScheduleOne.Persistence;
 using S1Player = ScheduleOne.PlayerScripts.Player;
 #endif
 
+using System.Reflection;
 using HarmonyLib;
 using S1API.Internal.Products;
 
@@ -61,7 +62,10 @@ namespace S1API.Internal.Patches
 
         [HarmonyPatch(typeof(S1Player), nameof(S1Player.ReceivePlayerData))]
         [HarmonyPrefix]
-        private static bool ReceivePlayerDataPrefix(object __instance, object[] __args)
+        private static bool ReceivePlayerDataPrefix(
+            object __instance,
+            object[] __args,
+            MethodBase __originalMethod)
         {
             if (__args.Length == 0 || !(__args[0] is S1Connection connection))
                 return true;
@@ -69,7 +73,8 @@ namespace S1API.Internal.Patches
             return CustomProductManifestRuntime.AuthorizeHostPlayerData(
                 __instance,
                 connection,
-                __args);
+                __args,
+                __originalMethod);
         }
     }
 }

--- a/S1API/Internal/Patches/CustomProductSavePatches.cs
+++ b/S1API/Internal/Patches/CustomProductSavePatches.cs
@@ -27,6 +27,7 @@ namespace S1API.Internal.Patches
         private static void RestorePrefix()
         {
             CustomProductSavePersistence.RestoreBeforeBaseLoaders(S1Persistence.LoadManager.Instance);
+            CustomProductManifestRuntime.FinalizeHostManifestAfterDescriptorRestore();
         }
     }
 }

--- a/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
@@ -373,6 +373,11 @@ namespace S1API.Internal.Products
             }
         }
 
+        internal static CustomProductManifestData CreateManifest()
+        {
+            return CustomProductManifestData.Create(Snapshot());
+        }
+
         private static bool AreSameDefinition(
             S1Product.ProductDefinition left,
             S1Product.ProductDefinition right)

--- a/S1API/Internal/Products/CustomProductManifestClientGate.cs
+++ b/S1API/Internal/Products/CustomProductManifestClientGate.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Models the client-side ordering gate independently of FishNet.
+    /// </summary>
+    internal sealed class CustomProductManifestClientGate
+    {
+        private Action? _deferredPlayerDataRequest;
+
+        internal bool IsWaiting { get; private set; }
+
+        internal void Begin(bool requiresValidation)
+        {
+            IsWaiting = requiresValidation;
+            _deferredPlayerDataRequest = null;
+        }
+
+        internal bool AuthorizePlayerDataRequest(Action request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            if (!IsWaiting)
+                return true;
+
+            if (_deferredPlayerDataRequest == null)
+                _deferredPlayerDataRequest = request;
+            return false;
+        }
+
+        internal CustomProductManifestAcceptance Accept(
+            string hostCompatibilityHash,
+            string localCompatibilityHash,
+            out Action? deferredPlayerDataRequest)
+        {
+            deferredPlayerDataRequest = null;
+            if (!string.Equals(
+                    hostCompatibilityHash,
+                    localCompatibilityHash,
+                    StringComparison.Ordinal))
+            {
+                return CustomProductManifestAcceptance.Incompatible;
+            }
+
+            if (!IsWaiting)
+                return CustomProductManifestAcceptance.AlreadyAccepted;
+
+            IsWaiting = false;
+            deferredPlayerDataRequest = _deferredPlayerDataRequest;
+            _deferredPlayerDataRequest = null;
+            return CustomProductManifestAcceptance.Accepted;
+        }
+
+        internal void End()
+        {
+            IsWaiting = false;
+            _deferredPlayerDataRequest = null;
+        }
+    }
+
+    internal enum CustomProductManifestAcceptance
+    {
+        Accepted,
+        AlreadyAccepted,
+        Incompatible
+    }
+}

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -70,8 +70,14 @@ namespace S1API.Internal.Products
             if (!IsSessionId(sessionId))
                 throw new InvalidOperationException("The custom-product session ID is invalid.");
 
-            SessionId = sessionId;
-            string payload = JsonConvert.SerializeObject(this, Formatting.None);
+            var snapshot = new CustomProductManifestData
+            {
+                ProtocolVersion = ProtocolVersion,
+                SessionId = sessionId,
+                CompatibilityHash = CompatibilityHash,
+                Entries = Entries
+            };
+            string payload = JsonConvert.SerializeObject(snapshot, Formatting.None);
             if (payload.Length > MaximumPayloadLength ||
                 Encoding.UTF8.GetByteCount(payload) > MaximumPayloadLength)
             {

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -1,0 +1,490 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Defines the scalar-only custom-product compatibility manifest.
+    /// </summary>
+    internal sealed class CustomProductManifestData
+    {
+        internal const int CurrentProtocolVersion = 1;
+        internal const int MaximumEntryCount = 256;
+        internal const int MaximumPayloadLength = 65536;
+        internal const int MaximumIdentifierLength = 256;
+        internal const int MaximumPackagingCount = 32;
+
+        public int ProtocolVersion = CurrentProtocolVersion;
+        public string SessionId = string.Empty;
+        public string CompatibilityHash = string.Empty;
+        public CustomProductManifestEntryData[] Entries =
+            Array.Empty<CustomProductManifestEntryData>();
+
+        internal static CustomProductManifestData Create(
+            IEnumerable<CustomProductDefinitionRegistration> registrations)
+        {
+            if (registrations == null)
+                throw new ArgumentNullException(nameof(registrations));
+
+            var entries = new List<CustomProductManifestEntryData>();
+            foreach (CustomProductDefinitionRegistration registration in registrations)
+            {
+                if (registration.Metadata == null || registration.SaveDescriptor == null)
+                    continue;
+
+                CustomProductManifestEntryData entry =
+                    CustomProductManifestEntryData.Create(registration);
+                if (!entry.IsValid())
+                {
+                    throw new InvalidOperationException(
+                        "Custom product '" + registration.ProductId +
+                        "' cannot be represented by the bounded multiplayer manifest.");
+                }
+                entries.Add(entry);
+            }
+
+            entries.Sort(CustomProductManifestEntryData.Compare);
+            if (entries.Count > MaximumEntryCount)
+            {
+                throw new InvalidOperationException(
+                    "The custom-product manifest exceeds the supported product count.");
+            }
+
+            var result = new CustomProductManifestData
+            {
+                Entries = entries.ToArray()
+            };
+            result.CompatibilityHash = ComputeManifestHash(result.Entries);
+            return result;
+        }
+
+        internal string Serialize(string sessionId)
+        {
+            if (!IsSessionId(sessionId))
+                throw new InvalidOperationException("The custom-product session ID is invalid.");
+
+            SessionId = sessionId;
+            string payload = JsonConvert.SerializeObject(this, Formatting.None);
+            if (payload.Length > MaximumPayloadLength ||
+                Encoding.UTF8.GetByteCount(payload) > MaximumPayloadLength)
+            {
+                throw new InvalidOperationException(
+                    "The custom-product manifest exceeds the supported payload size.");
+            }
+
+            return payload;
+        }
+
+        internal static bool TryDeserialize(
+            string? payload,
+            out CustomProductManifestData manifest,
+            out string failure)
+        {
+            manifest = null!;
+            failure = string.Empty;
+            if (payload == null || payload.Length == 0 ||
+                payload.Length > MaximumPayloadLength ||
+                Encoding.UTF8.GetByteCount(payload) > MaximumPayloadLength)
+            {
+                failure = "manifest payload size is invalid";
+                return false;
+            }
+
+            try
+            {
+                using var textReader = new StringReader(payload);
+                using var jsonReader = new JsonTextReader(textReader)
+                {
+                    DateParseHandling = DateParseHandling.None,
+                    MaxDepth = 16
+                };
+                JObject root = JObject.Load(jsonReader, new JsonLoadSettings
+                {
+                    DuplicatePropertyNameHandling = DuplicatePropertyNameHandling.Error
+                });
+                if (jsonReader.Read())
+                {
+                    failure = "manifest payload contains trailing data";
+                    return false;
+                }
+
+                CustomProductManifestData? candidate = root.ToObject<CustomProductManifestData>(
+                    JsonSerializer.Create(new JsonSerializerSettings
+                    {
+                        MissingMemberHandling = MissingMemberHandling.Error,
+                        MaxDepth = 16
+                    }));
+                if (!TryValidate(candidate, out failure))
+                    return false;
+
+                manifest = candidate!;
+                return true;
+            }
+            catch (Exception)
+            {
+                failure = "manifest payload is malformed";
+                return false;
+            }
+        }
+
+        internal static bool TryValidate(
+            CustomProductManifestData? manifest,
+            out string failure)
+        {
+            failure = string.Empty;
+            if (manifest == null ||
+                manifest.ProtocolVersion != CurrentProtocolVersion ||
+                !IsSessionId(manifest.SessionId) ||
+                !IsHash(manifest.CompatibilityHash) ||
+                manifest.Entries == null ||
+                manifest.Entries.Length > MaximumEntryCount)
+            {
+                failure = "manifest protocol, session, hash, or entry count is invalid";
+                return false;
+            }
+
+            var productIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            CustomProductManifestEntryData[] entries = manifest.Entries;
+            for (int i = 0; i < entries.Length; i++)
+            {
+                if (!entries[i].IsValid() || !productIds.Add(entries[i].ProductId))
+                {
+                    failure = "manifest contains an invalid or duplicate product entry";
+                    return false;
+                }
+
+                if (i > 0 && CustomProductManifestEntryData.Compare(
+                        entries[i - 1], entries[i]) >= 0)
+                {
+                    failure = "manifest entries are not in canonical order";
+                    return false;
+                }
+            }
+
+            if (!string.Equals(
+                    manifest.CompatibilityHash,
+                    ComputeManifestHash(entries),
+                    StringComparison.Ordinal))
+            {
+                failure = "manifest compatibility hash is invalid";
+                return false;
+            }
+
+            return true;
+        }
+
+        internal static string ComputeManifestHash(
+            IReadOnlyList<CustomProductManifestEntryData> entries)
+        {
+            var builder = new StringBuilder();
+            builder.Append(CurrentProtocolVersion).Append('|');
+            for (int i = 0; i < entries.Count; i++)
+                entries[i].AppendCanonical(builder, includeHash: true);
+
+            return ComputeHash(builder.ToString());
+        }
+
+        internal static string DescribeCompatibilityMismatch(
+            CustomProductManifestData host,
+            CustomProductManifestData local)
+        {
+            int hostIndex = 0;
+            int localIndex = 0;
+            while (hostIndex < host.Entries.Length &&
+                   localIndex < local.Entries.Length)
+            {
+                CustomProductManifestEntryData hostEntry = host.Entries[hostIndex];
+                CustomProductManifestEntryData localEntry = local.Entries[localIndex];
+                int comparison = CustomProductManifestEntryData.Compare(hostEntry, localEntry);
+                if (comparison < 0)
+                    return "local content is missing host product '" + hostEntry.ProductId + "'";
+                if (comparison > 0)
+                    return "local product '" + localEntry.ProductId + "' is not registered by the host";
+
+                string? entryFailure = hostEntry.DescribeMismatch(localEntry);
+                if (entryFailure != null)
+                    return "product '" + hostEntry.ProductId + "' " + entryFailure;
+
+                hostIndex++;
+                localIndex++;
+            }
+
+            if (hostIndex < host.Entries.Length)
+                return "local content is missing host product '" + host.Entries[hostIndex].ProductId + "'";
+            if (localIndex < local.Entries.Length)
+                return "local product '" + local.Entries[localIndex].ProductId + "' is not registered by the host";
+            return "manifest hash differs despite matching scalar identities";
+        }
+
+        internal static string ComputeHash(string value)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            using SHA256 hash = SHA256.Create();
+            byte[] digest = hash.ComputeHash(bytes);
+            var result = new StringBuilder(digest.Length * 2);
+            for (int i = 0; i < digest.Length; i++)
+                result.Append(digest[i].ToString("x2", CultureInfo.InvariantCulture));
+            return result.ToString();
+        }
+
+        internal static bool IsBoundedIdentifier(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) ||
+                value.Length > MaximumIdentifierLength ||
+                !string.Equals(value, value.Trim(), StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (char.IsControl(value[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        internal static bool IsSessionId(string? value) =>
+            value != null && value.Length == 32 && IsLowerHex(value);
+
+        internal static bool IsHash(string? value) =>
+            value != null && value.Length == 64 && IsLowerHex(value);
+
+        private static bool IsLowerHex(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+            {
+                char character = value[i];
+                if ((character < '0' || character > '9') &&
+                    (character < 'a' || character > 'f'))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>INTERNAL: One deterministic scalar custom-product manifest entry.</summary>
+    internal sealed class CustomProductManifestEntryData
+    {
+        public string ProductId = string.Empty;
+        public string OwnerId = string.Empty;
+        public string ProductKindId = string.Empty;
+        public int CompatibilityDrugType;
+        public int DescriptorFormatVersion;
+        public string? ProviderId;
+        public int ProviderVersion;
+        public bool ProviderAvailable;
+        public string RepresentationTemplateId = string.Empty;
+        public string PresentationProfileId = string.Empty;
+        public string[] PackagingIds = Array.Empty<string>();
+        public string CompatibilityHash = string.Empty;
+
+        internal static CustomProductManifestEntryData Create(
+            CustomProductDefinitionRegistration registration)
+        {
+            CustomProductSaveDescriptorData descriptor = registration.SaveDescriptor
+                ?? throw new InvalidOperationException("Custom product has no descriptor.");
+            CustomProductDefinitionMetadata metadata = registration.Metadata
+                ?? throw new InvalidOperationException("Custom product has no metadata.");
+
+            var packagingIds = new List<string>(metadata.ValidPackaging.Count);
+            for (int i = 0; i < metadata.ValidPackaging.Count; i++)
+                packagingIds.Add(metadata.ValidPackaging[i].ID);
+            packagingIds.Sort(StringComparer.OrdinalIgnoreCase);
+
+            ProductPresentationProfileRegistry.TryGetManifestIdentity(
+                registration.ProductId,
+                metadata.ProductKind.Id,
+                out string presentationProfileId);
+
+            var entry = new CustomProductManifestEntryData
+            {
+                ProductId = registration.ProductId,
+                OwnerId = registration.OwnerId,
+                ProductKindId = metadata.ProductKind.Id,
+                CompatibilityDrugType = (int)metadata.ProductKind.CompatibilityDrugType!.Value,
+                DescriptorFormatVersion = descriptor.FormatVersion,
+                ProviderId = descriptor.ProviderId,
+                ProviderVersion = descriptor.ProviderVersion,
+                ProviderAvailable = CustomProductSavePersistence.IsProviderAvailable(
+                    descriptor.ProviderId,
+                    descriptor.ProviderVersion),
+                RepresentationTemplateId = descriptor.RepresentationTemplateId,
+                PresentationProfileId = presentationProfileId,
+                PackagingIds = packagingIds.ToArray()
+            };
+            entry.CompatibilityHash = ComputeCompatibilityHash(entry, descriptor);
+            return entry;
+        }
+
+        internal bool IsValid()
+        {
+            if (!CustomProductManifestData.IsBoundedIdentifier(ProductId) ||
+                !CustomProductManifestData.IsBoundedIdentifier(OwnerId) ||
+                !CustomProductManifestData.IsBoundedIdentifier(ProductKindId) ||
+                 !CustomProductManifestData.IsBoundedIdentifier(RepresentationTemplateId) ||
+                 PresentationProfileId == null ||
+                 PresentationProfileId.Length > CustomProductManifestData.MaximumIdentifierLength ||
+                 (ProviderId != null && !CustomProductManifestData.IsBoundedIdentifier(ProviderId)) ||
+                 !Enum.IsDefined(typeof(DrugType), CompatibilityDrugType) ||
+                 (ProviderId == null && ProviderVersion != 0) ||
+                 ProviderVersion < 0 ||
+                 DescriptorFormatVersion != CustomProductSavePersistence.CurrentFormatVersion ||
+                PackagingIds == null ||
+                PackagingIds.Length > CustomProductManifestData.MaximumPackagingCount ||
+                !CustomProductManifestData.IsHash(CompatibilityHash))
+            {
+                return false;
+            }
+
+            var packaging = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < PackagingIds.Length; i++)
+            {
+                if (!CustomProductManifestData.IsBoundedIdentifier(PackagingIds[i]) ||
+                    !packaging.Add(PackagingIds[i]) ||
+                    (i > 0 && StringComparer.OrdinalIgnoreCase.Compare(
+                        PackagingIds[i - 1], PackagingIds[i]) >= 0))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static int Compare(
+            CustomProductManifestEntryData left,
+            CustomProductManifestEntryData right) =>
+            StringComparer.OrdinalIgnoreCase.Compare(left.ProductId, right.ProductId);
+
+        internal void AppendCanonical(StringBuilder builder, bool includeHash)
+        {
+            AppendIdentifier(builder, ProductId);
+            AppendIdentifier(builder, OwnerId);
+            AppendIdentifier(builder, ProductKindId);
+            Append(builder, CompatibilityDrugType.ToString(CultureInfo.InvariantCulture));
+            Append(builder, DescriptorFormatVersion.ToString(CultureInfo.InvariantCulture));
+            AppendIdentifier(builder, ProviderId ?? string.Empty);
+            Append(builder, ProviderVersion.ToString(CultureInfo.InvariantCulture));
+            Append(builder, ProviderAvailable ? "1" : "0");
+            AppendIdentifier(builder, RepresentationTemplateId);
+            AppendIdentifier(builder, PresentationProfileId);
+            for (int i = 0; i < PackagingIds.Length; i++)
+                AppendIdentifier(builder, PackagingIds[i]);
+            if (includeHash)
+                Append(builder, CompatibilityHash);
+        }
+
+        internal string? DescribeMismatch(CustomProductManifestEntryData local)
+        {
+            if (!string.Equals(OwnerId, local.OwnerId, StringComparison.OrdinalIgnoreCase))
+                return "owner ID differs";
+            if (!string.Equals(ProductKindId, local.ProductKindId, StringComparison.OrdinalIgnoreCase) ||
+                CompatibilityDrugType != local.CompatibilityDrugType)
+            {
+                return "logical kind or native compatibility mapping differs";
+            }
+            if (DescriptorFormatVersion != local.DescriptorFormatVersion)
+            {
+                return "descriptor format version differs (host " +
+                       DescriptorFormatVersion.ToString(CultureInfo.InvariantCulture) +
+                       ", local " +
+                       local.DescriptorFormatVersion.ToString(CultureInfo.InvariantCulture) +
+                       ")";
+            }
+            if (!string.Equals(ProviderId, local.ProviderId, StringComparison.OrdinalIgnoreCase) ||
+                ProviderVersion != local.ProviderVersion ||
+                ProviderAvailable != local.ProviderAvailable)
+            {
+                return "provider compatibility differs (host '" +
+                       (ProviderId ?? "<none>") +
+                       "' version " +
+                       ProviderVersion.ToString(CultureInfo.InvariantCulture) +
+                       " available " +
+                       ProviderAvailable.ToString(CultureInfo.InvariantCulture) +
+                       ", local '" +
+                       (local.ProviderId ?? "<none>") +
+                       "' version " +
+                       local.ProviderVersion.ToString(CultureInfo.InvariantCulture) +
+                       " available " +
+                       local.ProviderAvailable.ToString(CultureInfo.InvariantCulture) +
+                       ")";
+            }
+            if (!string.Equals(
+                    RepresentationTemplateId,
+                    local.RepresentationTemplateId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return "native representation template differs";
+            }
+            if (!string.Equals(
+                    PresentationProfileId,
+                    local.PresentationProfileId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return "presentation profile registration differs";
+            }
+            if (PackagingIds.Length != local.PackagingIds.Length)
+                return "packaging registration set differs";
+            for (int i = 0; i < PackagingIds.Length; i++)
+            {
+                if (!string.Equals(
+                        PackagingIds[i],
+                        local.PackagingIds[i],
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return "packaging registration set differs";
+                }
+            }
+            if (!string.Equals(
+                    CompatibilityHash,
+                    local.CompatibilityHash,
+                    StringComparison.Ordinal))
+            {
+                return "descriptor scalar or provider-data hash differs";
+            }
+
+            return null;
+        }
+
+        private static string ComputeCompatibilityHash(
+            CustomProductManifestEntryData entry,
+            CustomProductSaveDescriptorData descriptor)
+        {
+            var builder = new StringBuilder();
+            entry.AppendCanonical(builder, includeHash: false);
+            Append(builder, descriptor.ProductName);
+            Append(builder, descriptor.Description);
+            Append(builder, descriptor.InitialPrice.ToString("R", CultureInfo.InvariantCulture));
+            Append(builder, descriptor.LegalStatus.ToString(CultureInfo.InvariantCulture));
+            Append(builder, descriptor.BaseAddictiveness.ToString("R", CultureInfo.InvariantCulture));
+            Append(builder, descriptor.DefaultQuality.ToString(CultureInfo.InvariantCulture));
+            Append(builder, descriptor.PlayerEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
+            Append(builder, descriptor.NpcEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
+            // Provider data remains local; only its deterministic digest participates in compatibility.
+            Append(builder, CustomProductManifestData.ComputeHash(descriptor.ProviderData));
+            return CustomProductManifestData.ComputeHash(builder.ToString());
+        }
+
+        private static void Append(StringBuilder builder, string value)
+        {
+            builder.Append(value.Length).Append(':').Append(value).Append('|');
+        }
+
+        private static void AppendIdentifier(StringBuilder builder, string value)
+        {
+            Append(builder, value.ToUpperInvariant());
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductManifestRuntime.cs
+++ b/S1API/Internal/Products/CustomProductManifestRuntime.cs
@@ -1,0 +1,1151 @@
+#if IL2CPPMELON
+using FishNetBroadcast = Il2CppFishNet.Broadcast;
+using FishNetConnection = Il2CppFishNet.Connection;
+using FishNetInstanceFinder = Il2CppFishNet.InstanceFinder;
+using FishNetSerializing = Il2CppFishNet.Serializing;
+using FishNetTransporting = Il2CppFishNet.Transporting;
+using Il2CppInterop.Runtime.Attributes;
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Injection;
+#elif MONOMELON
+using FishNetBroadcast = FishNet.Broadcast;
+using FishNetConnection = FishNet.Connection;
+using FishNetInstanceFinder = FishNet.InstanceFinder;
+using FishNetSerializing = FishNet.Serializing;
+using FishNetTransporting = FishNet.Transporting;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using MelonLoader;
+using S1API.Lifecycle;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Owns the host-authoritative manifest handshake.</summary>
+    internal static class CustomProductManifestRuntime
+    {
+        private const int HandshakeTimeoutSeconds = 15;
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<int, PendingHostData>
+            PendingHostDataByConnection =
+                new Dictionary<int, PendingHostData>();
+        private static readonly Dictionary<int, PendingConnection>
+            PendingConnections =
+                new Dictionary<int, PendingConnection>();
+        private static readonly HashSet<int>
+            AcceptedConnections =
+                new HashSet<int>();
+        private static readonly CustomProductManifestClientGate ClientGate =
+            new CustomProductManifestClientGate();
+
+        private static bool _serializersConfigured;
+        private static bool _hostSubscribed;
+        private static bool _clientSubscribed;
+        private static bool _clientLifecycleSubscribed;
+        private static bool _clientSessionActive;
+        private static bool _clientDefinitionsReady;
+        private static bool _hostActive;
+        private static bool _hostManifestReady;
+        private static bool _hostRequiresValidation;
+        private static DateTime _clientDeadline;
+        private static int _hostEntryCount;
+        private static string _sessionId = string.Empty;
+        private static string _hostPayload = string.Empty;
+        private static string _hostHash = string.Empty;
+        private static CustomProductManifestData? _pendingClientManifest;
+        private static CustomProductManifestData? _localClientManifest;
+#if IL2CPPMELON
+        private static Il2CppSystem.Action<FishNetConnection.NetworkConnection,
+            CustomProductManifestAckBroadcast>? _acknowledgementReceiver;
+        private static Il2CppSystem.Action<FishNetConnection.NetworkConnection,
+            FishNetTransporting.RemoteConnectionStateArgs>? _remoteConnectionStateReceiver;
+        private static Il2CppSystem.Action<FishNetConnection.NetworkConnection,
+            bool>? _authenticationResultReceiver;
+        private static Il2CppSystem.Action<CustomProductManifestBroadcast>? _manifestReceiver;
+        private static Il2CppSystem.Action<FishNetTransporting.ClientConnectionStateArgs>? _clientConnectionStateReceiver;
+        private static Il2CppSystem.Action<FishNetSerializing.Writer,
+            CustomProductManifestBroadcast>? _manifestWriter;
+        private static Il2CppSystem.Func<FishNetSerializing.Reader,
+            CustomProductManifestBroadcast>? _manifestReader;
+        private static Il2CppSystem.Action<FishNetSerializing.Writer,
+            CustomProductManifestAckBroadcast>? _acknowledgementWriter;
+        private static Il2CppSystem.Func<FishNetSerializing.Reader,
+            CustomProductManifestAckBroadcast>? _acknowledgementReader;
+#endif
+
+        internal static void BeginHostSession()
+        {
+            ConfigureSerializers();
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.Reset();
+#endif
+            lock (Gate)
+            {
+                _hostActive = true;
+                _hostManifestReady = false;
+                _sessionId = Guid.NewGuid().ToString("N");
+                _hostPayload = string.Empty;
+                _hostHash = string.Empty;
+                _hostRequiresValidation = false;
+                PendingConnections.Clear();
+                PendingHostDataByConnection.Clear();
+                AcceptedConnections.Clear();
+                if (!_hostSubscribed)
+                {
+
+#if IL2CPPMELON
+                    _acknowledgementReceiver ??= DelegateSupport.ConvertDelegate<
+                        Il2CppSystem.Action<FishNetConnection.NetworkConnection,
+                            CustomProductManifestAckBroadcast>>(
+                        new Action<FishNetConnection.NetworkConnection,
+                            CustomProductManifestAckBroadcast>(ReceiveAcknowledgement));
+                    _remoteConnectionStateReceiver ??= DelegateSupport.ConvertDelegate<
+                        Il2CppSystem.Action<FishNetConnection.NetworkConnection,
+                            FishNetTransporting.RemoteConnectionStateArgs>>(
+                        new Action<FishNetConnection.NetworkConnection,
+                            FishNetTransporting.RemoteConnectionStateArgs>(OnRemoteConnectionState));
+                    _authenticationResultReceiver ??= DelegateSupport.ConvertDelegate<
+                        Il2CppSystem.Action<FishNetConnection.NetworkConnection, bool>>(
+                        new Action<FishNetConnection.NetworkConnection, bool>(OnAuthenticationResult));
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .RegisterBroadcast<CustomProductManifestAckBroadcast>(
+                            _acknowledgementReceiver,
+                            requireAuthentication: true);
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .OnRemoteConnectionState += _remoteConnectionStateReceiver;
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .OnAuthenticationResult += _authenticationResultReceiver;
+#else
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .RegisterBroadcast<CustomProductManifestAckBroadcast>(
+                            ReceiveAcknowledgement,
+                            requireAuthentication: true);
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .OnRemoteConnectionState += OnRemoteConnectionState;
+                    FishNetInstanceFinder.NetworkManager.ServerManager
+                        .OnAuthenticationResult += OnAuthenticationResult;
+#endif
+                    _hostSubscribed = true;
+                }
+            }
+        }
+
+        internal static void FinalizeHostManifestAfterDescriptorRestore()
+        {
+            var releasedData = new List<PendingHostData>();
+            bool requiresValidation;
+            lock (Gate)
+            {
+                if (!_hostActive || _hostManifestReady)
+                    return;
+
+                try
+                {
+                    CustomProductManifestData manifest =
+                        CustomProductDefinitionRegistry.CreateManifest();
+                    _hostPayload = manifest.Serialize(_sessionId);
+                    _hostHash = manifest.CompatibilityHash;
+                    _hostEntryCount = manifest.Entries.Length;
+                    _hostRequiresValidation = manifest.Entries.Length != 0;
+                }
+                catch (Exception exception)
+                {
+                    _hostPayload = string.Empty;
+                    _hostHash = string.Empty;
+                    _hostEntryCount =
+                        CustomProductDefinitionRegistry.GetSaveDescriptors().Length;
+                    _hostRequiresValidation =
+                        _hostEntryCount != 0;
+                    Warn("custom-product manifest is unavailable; multiplayer joins will be " +
+                         "rejected while single-player loading continues: " +
+                         exception.GetType().Name);
+                }
+
+                _hostManifestReady = true;
+                Info("host manifest finalized after descriptor restore; entries=" +
+                     _hostEntryCount);
+                if (!_hostRequiresValidation)
+                {
+                    releasedData.AddRange(PendingHostDataByConnection.Values);
+                    PendingHostDataByConnection.Clear();
+                }
+                requiresValidation = _hostRequiresValidation;
+            }
+
+            if (requiresValidation)
+                SendManifestToAuthenticatedClients();
+            else
+            {
+                for (int i = 0; i < releasedData.Count; i++)
+                    releasedData[i].Invoke();
+            }
+        }
+
+        internal static void BeginClientSession()
+        {
+            ConfigureSerializers();
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.Reset();
+#endif
+            lock (Gate)
+            {
+                _clientSessionActive = true;
+                _clientDefinitionsReady = false;
+                _pendingClientManifest = null;
+                _localClientManifest = null;
+                ClientGate.Begin(requiresValidation: true);
+                _clientDeadline = DateTime.MaxValue;
+                if (!_clientLifecycleSubscribed)
+                {
+                    GameLifecycle.OnPreLoad += OnClientDefinitionsReady;
+                    _clientLifecycleSubscribed = true;
+                }
+                if (_clientSubscribed)
+                    return;
+
+#if IL2CPPMELON
+                _manifestReceiver ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Action<CustomProductManifestBroadcast>>(
+                    new Action<CustomProductManifestBroadcast>(ReceiveManifest));
+                _clientConnectionStateReceiver ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Action<FishNetTransporting.ClientConnectionStateArgs>>(
+                    new Action<FishNetTransporting.ClientConnectionStateArgs>(OnClientConnectionState));
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .RegisterBroadcast<CustomProductManifestBroadcast>(
+                        _manifestReceiver);
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .OnClientConnectionState += _clientConnectionStateReceiver;
+#else
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .RegisterBroadcast<CustomProductManifestBroadcast>(ReceiveManifest);
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .OnClientConnectionState += OnClientConnectionState;
+#endif
+                _clientSubscribed = true;
+            }
+        }
+
+        internal static void EndHostSession()
+        {
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.Reset();
+#endif
+            lock (Gate)
+            {
+                _hostActive = false;
+                _hostManifestReady = false;
+                _hostRequiresValidation = false;
+                _sessionId = string.Empty;
+                _hostPayload = string.Empty;
+                _hostHash = string.Empty;
+                _hostEntryCount = 0;
+                PendingConnections.Clear();
+                PendingHostDataByConnection.Clear();
+                AcceptedConnections.Clear();
+                if (!_hostSubscribed)
+                    return;
+                if (FishNetInstanceFinder.NetworkManager == null)
+                {
+                    _hostSubscribed = false;
+                    return;
+                }
+
+#if IL2CPPMELON
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .UnregisterBroadcast<CustomProductManifestAckBroadcast>(
+                        _acknowledgementReceiver);
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .OnRemoteConnectionState -= _remoteConnectionStateReceiver;
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .OnAuthenticationResult -= _authenticationResultReceiver;
+#else
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .UnregisterBroadcast<CustomProductManifestAckBroadcast>(
+                        ReceiveAcknowledgement);
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .OnRemoteConnectionState -= OnRemoteConnectionState;
+                FishNetInstanceFinder.NetworkManager.ServerManager
+                    .OnAuthenticationResult -= OnAuthenticationResult;
+#endif
+                _hostSubscribed = false;
+            }
+        }
+
+        internal static void EndClientSession()
+        {
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.Reset();
+#endif
+            lock (Gate)
+            {
+                _clientSessionActive = false;
+                _clientDefinitionsReady = false;
+                _pendingClientManifest = null;
+                _localClientManifest = null;
+                ClientGate.End();
+                if (_clientLifecycleSubscribed)
+                {
+                    GameLifecycle.OnPreLoad -= OnClientDefinitionsReady;
+                    _clientLifecycleSubscribed = false;
+                }
+                if (!_clientSubscribed)
+                    return;
+                if (FishNetInstanceFinder.NetworkManager == null)
+                {
+                    _clientSubscribed = false;
+                    return;
+                }
+
+#if IL2CPPMELON
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .UnregisterBroadcast<CustomProductManifestBroadcast>(
+                        _manifestReceiver);
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .OnClientConnectionState -= _clientConnectionStateReceiver;
+#else
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .UnregisterBroadcast<CustomProductManifestBroadcast>(ReceiveManifest);
+                FishNetInstanceFinder.NetworkManager.ClientManager
+                    .OnClientConnectionState -= OnClientConnectionState;
+#endif
+                _clientSubscribed = false;
+            }
+        }
+
+        internal static void Tick()
+        {
+            DateTime now = DateTime.UtcNow;
+            bool rejectClient;
+            var rejectedConnections = new List<PendingConnection>();
+            lock (Gate)
+            {
+                rejectClient = ClientGate.IsWaiting && now >= _clientDeadline;
+                if (rejectClient)
+                    ClientGate.End();
+
+                foreach (KeyValuePair<int, PendingConnection> pair
+                    in PendingConnections)
+                {
+                    if (now >= pair.Value.Deadline)
+                        rejectedConnections.Add(pair.Value);
+                }
+
+                for (int i = 0; i < rejectedConnections.Count; i++)
+                {
+                    int connectionId = rejectedConnections[i].ConnectionId;
+                    PendingConnections.Remove(connectionId);
+                    PendingHostDataByConnection.Remove(connectionId);
+                }
+            }
+
+            if (rejectClient)
+            {
+                Warn("custom-product manifest was not received before player data; disconnecting safely");
+                FishNetInstanceFinder.NetworkManager?.ClientManager.StopConnection();
+            }
+
+            for (int i = 0; i < rejectedConnections.Count; i++)
+            {
+                Warn("custom-product manifest acknowledgement timed out; rejecting the joining client");
+                rejectedConnections[i].Connection.Disconnect(true);
+            }
+        }
+
+        internal static bool AuthorizeClientPlayerDataRequest(Action request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            lock (Gate)
+            {
+                if (!FishNetInstanceFinder.IsClient || FishNetInstanceFinder.IsServer)
+                {
+                    return true;
+                }
+
+                bool authorized = ClientGate.AuthorizePlayerDataRequest(request);
+                if (!authorized)
+                {
+                    _clientDeadline = DateTime.UtcNow.AddSeconds(HandshakeTimeoutSeconds);
+                    Info("client player-data request deferred until manifest validation");
+                }
+                return authorized;
+            }
+        }
+
+        internal static bool AuthorizeHostPlayerData(
+            object player,
+            FishNetConnection.NetworkConnection connection,
+            object[] arguments)
+        {
+            if (player == null || connection == null || arguments == null)
+                return true;
+
+            int connectionId = connection.ClientId;
+            lock (Gate)
+            {
+                if (!_hostActive)
+                    return true;
+                if (!_hostManifestReady)
+                {
+                    if (!PendingHostDataByConnection.ContainsKey(connectionId))
+                    {
+                        PendingHostDataByConnection.Add(
+                            connectionId,
+                            new PendingHostData(player, (object[])arguments.Clone()));
+                    }
+                    return false;
+                }
+                if (!_hostRequiresValidation)
+                    return true;
+
+                if (AcceptedConnections.Contains(connectionId))
+                    return true;
+            }
+
+            bool manifestAvailable = SendManifest(connection);
+            lock (Gate)
+            {
+                if (AcceptedConnections.Contains(connectionId))
+                    return true;
+                if (!manifestAvailable)
+                    return false;
+
+                if (!PendingHostDataByConnection.ContainsKey(connectionId))
+                {
+                    PendingHostDataByConnection.Add(
+                        connectionId,
+                        new PendingHostData(player, (object[])arguments.Clone()));
+                }
+                return false;
+            }
+        }
+
+        internal static string GetLocalCompatibilityHash() =>
+            CustomProductDefinitionRegistry.CreateManifest().CompatibilityHash;
+
+        private static void ConfigureSerializers()
+        {
+            lock (Gate)
+            {
+                if (_serializersConfigured)
+                    return;
+
+#if IL2CPPMELON
+                _manifestWriter ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Action<FishNetSerializing.Writer,
+                        CustomProductManifestBroadcast>>(
+                    new Action<FishNetSerializing.Writer,
+                        CustomProductManifestBroadcast>(WriteManifest));
+                _manifestReader ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Func<FishNetSerializing.Reader,
+                        CustomProductManifestBroadcast>>(
+                    new Func<FishNetSerializing.Reader,
+                        CustomProductManifestBroadcast>(ReadManifest));
+                _acknowledgementWriter ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Action<FishNetSerializing.Writer,
+                        CustomProductManifestAckBroadcast>>(
+                    new Action<FishNetSerializing.Writer,
+                        CustomProductManifestAckBroadcast>(WriteAcknowledgement));
+                _acknowledgementReader ??= DelegateSupport.ConvertDelegate<
+                    Il2CppSystem.Func<FishNetSerializing.Reader,
+                        CustomProductManifestAckBroadcast>>(
+                    new Func<FishNetSerializing.Reader,
+                        CustomProductManifestAckBroadcast>(ReadAcknowledgement));
+                FishNetSerializing.GenericWriter<CustomProductManifestBroadcast>.Write =
+                    _manifestWriter;
+                FishNetSerializing.GenericReader<CustomProductManifestBroadcast>.Read =
+                    _manifestReader;
+                FishNetSerializing.GenericWriter<CustomProductManifestAckBroadcast>.Write =
+                    _acknowledgementWriter;
+                FishNetSerializing.GenericReader<CustomProductManifestAckBroadcast>.Read =
+                    _acknowledgementReader;
+#else
+                FishNetSerializing.GenericWriter<CustomProductManifestBroadcast>.Write =
+                    WriteManifest;
+                FishNetSerializing.GenericReader<CustomProductManifestBroadcast>.Read =
+                    ReadManifest;
+                FishNetSerializing.GenericWriter<CustomProductManifestAckBroadcast>.Write =
+                    WriteAcknowledgement;
+                FishNetSerializing.GenericReader<CustomProductManifestAckBroadcast>.Read =
+                    ReadAcknowledgement;
+#endif
+                _serializersConfigured = true;
+            }
+        }
+
+        private static void OnRemoteConnectionState(
+            FishNetConnection.NetworkConnection connection,
+            FishNetTransporting.RemoteConnectionStateArgs arguments)
+        {
+            if (arguments.ConnectionState == FishNetTransporting.RemoteConnectionState.Stopped)
+            {
+                int connectionId = connection.ClientId;
+                lock (Gate)
+                {
+                    PendingConnections.Remove(connectionId);
+                    PendingHostDataByConnection.Remove(connectionId);
+                    AcceptedConnections.Remove(connectionId);
+                }
+            }
+        }
+
+        private static void OnAuthenticationResult(
+            FishNetConnection.NetworkConnection connection,
+            bool authenticated)
+        {
+            if (authenticated)
+                SendManifestOrReject(connection);
+        }
+
+        private static void SendManifestToAuthenticatedClients()
+        {
+            if (FishNetInstanceFinder.NetworkManager == null)
+                return;
+
+            foreach (var pair in FishNetInstanceFinder.NetworkManager.ServerManager.Clients)
+            {
+                FishNetConnection.NetworkConnection connection = pair.Value;
+                if (connection != null && connection.Authenticated && !connection.IsLocalClient)
+                    SendManifestOrReject(connection);
+            }
+        }
+
+        private static void SendManifestOrReject(
+            FishNetConnection.NetworkConnection connection)
+        {
+            if (SendManifest(connection))
+                return;
+
+            bool reject;
+            lock (Gate)
+                reject = _hostActive && _hostManifestReady && _hostRequiresValidation;
+            if (!reject)
+                return;
+
+            Warn("custom-product manifest is unavailable; rejecting the joining client");
+            connection.Disconnect(true);
+        }
+
+        private static bool SendManifest(FishNetConnection.NetworkConnection connection)
+        {
+            if (connection == null || connection.IsLocalClient || !connection.Authenticated)
+                return false;
+
+            int connectionId = connection.ClientId;
+            string payload;
+            lock (Gate)
+            {
+                if (!_hostActive || !_hostManifestReady || !_hostRequiresValidation ||
+                    string.IsNullOrEmpty(_hostPayload))
+                {
+                    return false;
+                }
+
+                if (PendingConnections.ContainsKey(connectionId) ||
+                    AcceptedConnections.Contains(connectionId))
+                {
+                    return true;
+                }
+
+                payload = _hostPayload;
+                PendingConnections[connectionId] = new PendingConnection(
+                    connectionId,
+                    connection,
+                    DateTime.UtcNow.AddSeconds(HandshakeTimeoutSeconds));
+            }
+
+            try
+            {
+#if IL2CPPMELON
+                CustomProductManifestIl2CppWire.PrepareOutgoingManifest(payload);
+                BroadcastToConnection(
+                    FishNetInstanceFinder.NetworkManager.ServerManager,
+                    connection,
+                    new CustomProductManifestBroadcast());
+#else
+                FishNetInstanceFinder.NetworkManager.ServerManager.Broadcast(
+                    connection,
+                    new CustomProductManifestBroadcast { Payload = payload },
+                    requireAuthenticated: true,
+                    channel: FishNetTransporting.Channel.Reliable);
+#endif
+                Info("host manifest sent to authenticated client; entries=" +
+                     _hostEntryCount);
+                return true;
+            }
+            catch (Exception exception)
+            {
+#if IL2CPPMELON
+                CustomProductManifestIl2CppWire.ClearOutgoingManifest();
+#endif
+                lock (Gate)
+                    PendingConnections.Remove(connectionId);
+                Warn("custom-product manifest could not be sent; rejecting the joining client: " +
+                     exception.GetType().Name);
+                connection.Disconnect(true);
+                return false;
+            }
+        }
+
+#if IL2CPPMELON
+        private static void BroadcastToConnection<T>(object serverManager, object connection, T message)
+        {
+            foreach (MethodInfo method in serverManager.GetType().GetMethods(
+                         BindingFlags.Instance | BindingFlags.Public))
+            {
+                if (method.Name != "Broadcast" || !method.IsGenericMethodDefinition ||
+                    method.GetParameters().Length != 4 ||
+                    method.GetParameters()[0].ParameterType.Name != "NetworkConnection")
+                {
+                    continue;
+                }
+
+                method.MakeGenericMethod(typeof(T)).Invoke(serverManager, new object[]
+                {
+                    connection,
+                    message!,
+                    true,
+                    FishNetTransporting.Channel.Reliable
+                });
+                return;
+            }
+
+            throw new MissingMethodException("FishNet ServerManager.Broadcast<T>(NetworkConnection, T, bool, Channel)");
+        }
+#endif
+
+        private static void ReceiveManifest(CustomProductManifestBroadcast message)
+        {
+#if IL2CPPMELON
+            string payload = CustomProductManifestIl2CppWire.TakeIncomingManifest();
+#else
+            string payload = message.Payload;
+#endif
+            if (!CustomProductManifestData.TryDeserialize(
+                    payload,
+                    out CustomProductManifestData manifest,
+                    out string failure))
+            {
+                RejectClient("received " + failure);
+                return;
+            }
+
+            bool conflictingPendingManifest = false;
+            bool queuedUntilDefinitionsReady = false;
+            lock (Gate)
+            {
+                if (!_clientSessionActive)
+                    return;
+                if (!_clientDefinitionsReady)
+                {
+                    if (_pendingClientManifest != null &&
+                        (!string.Equals(
+                            _pendingClientManifest.SessionId,
+                            manifest.SessionId,
+                            StringComparison.Ordinal) ||
+                         !string.Equals(
+                            _pendingClientManifest.CompatibilityHash,
+                            manifest.CompatibilityHash,
+                            StringComparison.Ordinal)))
+                    {
+                        conflictingPendingManifest = true;
+                    }
+                    else
+                    {
+                        _pendingClientManifest = manifest;
+                        queuedUntilDefinitionsReady = true;
+                    }
+                }
+            }
+
+            if (conflictingPendingManifest)
+            {
+                RejectClient("received conflicting manifests before local definitions were ready");
+                return;
+            }
+            if (queuedUntilDefinitionsReady)
+            {
+                Info("client manifest queued until pre-load custom definitions are registered");
+                return;
+            }
+
+            ProcessManifest(manifest);
+        }
+
+        private static void OnClientDefinitionsReady()
+        {
+            CustomProductManifestData localManifest;
+            try
+            {
+                localManifest = CustomProductDefinitionRegistry.CreateManifest();
+            }
+            catch (Exception exception)
+            {
+                RejectClient(
+                    "local custom-product registrations cannot be represented safely: " +
+                    exception.GetType().Name);
+                return;
+            }
+
+            CustomProductManifestData? pending;
+            lock (Gate)
+            {
+                if (!_clientSessionActive)
+                    return;
+                _localClientManifest = localManifest;
+                _clientDefinitionsReady = true;
+                ClientGate.Begin(localManifest.Entries.Length != 0);
+                pending = _pendingClientManifest;
+                _pendingClientManifest = null;
+            }
+
+            Info("client pre-load custom definitions ready; entries=" +
+                 localManifest.Entries.Length);
+            if (pending != null)
+                ProcessManifest(pending);
+        }
+
+        private static void ProcessManifest(CustomProductManifestData manifest)
+        {
+            CustomProductManifestData localManifest;
+            lock (Gate)
+            {
+                if (!_clientSessionActive || !_clientDefinitionsReady ||
+                    _localClientManifest == null)
+                {
+                    return;
+                }
+                localManifest = _localClientManifest;
+            }
+
+            string localHash = localManifest.CompatibilityHash;
+            Action? deferredRequest;
+            CustomProductManifestAcceptance acceptance;
+            lock (Gate)
+            {
+                acceptance = ClientGate.Accept(
+                    manifest.CompatibilityHash,
+                    localHash,
+                    out deferredRequest);
+            }
+
+            if (acceptance == CustomProductManifestAcceptance.AlreadyAccepted)
+                return;
+            if (acceptance == CustomProductManifestAcceptance.Incompatible)
+            {
+                RejectClient(
+                    CustomProductManifestData.DescribeCompatibilityMismatch(
+                        manifest,
+                        localManifest));
+                return;
+            }
+
+#if IL2CPPMELON
+            try
+            {
+                CustomProductManifestIl2CppWire.PrepareOutgoingAcknowledgement(
+                    manifest.SessionId,
+                    manifest.CompatibilityHash);
+                FishNetInstanceFinder.NetworkManager.ClientManager.Broadcast(
+                    new CustomProductManifestAckBroadcast(),
+                    FishNetTransporting.Channel.Reliable);
+            }
+            catch (Exception exception)
+            {
+                CustomProductManifestIl2CppWire.ClearOutgoingAcknowledgement();
+                RejectClient(
+                    "manifest acknowledgement could not be sent safely: " +
+                    exception.GetType().Name);
+                return;
+            }
+#else
+            FishNetInstanceFinder.NetworkManager.ClientManager.Broadcast(
+                new CustomProductManifestAckBroadcast
+                {
+                    SessionId = manifest.SessionId,
+                    CompatibilityHash = manifest.CompatibilityHash
+                },
+                FishNetTransporting.Channel.Reliable);
+#endif
+            Info("client manifest accepted before player-data request; entries=" +
+                 manifest.Entries.Length);
+            deferredRequest?.Invoke();
+        }
+
+        private static void ReceiveAcknowledgement(
+            FishNetConnection.NetworkConnection connection,
+            CustomProductManifestAckBroadcast acknowledgement)
+        {
+#if IL2CPPMELON
+            (string acknowledgementSessionId, string acknowledgementCompatibilityHash) =
+                CustomProductManifestIl2CppWire.TakeIncomingAcknowledgement();
+#else
+            string acknowledgementSessionId = acknowledgement.SessionId;
+            string acknowledgementCompatibilityHash = acknowledgement.CompatibilityHash;
+#endif
+            PendingHostData? pending = null;
+            string? rejection = null;
+            int connectionId = connection.ClientId;
+            lock (Gate)
+            {
+                if (!CustomProductManifestData.IsSessionId(acknowledgementSessionId) ||
+                    !CustomProductManifestData.IsHash(acknowledgementCompatibilityHash))
+                {
+                    rejection = "manifest acknowledgement bounds are invalid";
+                }
+                else if (!_hostActive ||
+                    !string.Equals(acknowledgementSessionId, _sessionId, StringComparison.Ordinal) ||
+                    !string.Equals(
+                        acknowledgementCompatibilityHash,
+                        _hostHash,
+                        StringComparison.Ordinal))
+                {
+                    rejection = "manifest acknowledgement does not match this host session";
+                }
+                else if (AcceptedConnections.Contains(connectionId))
+                {
+                    return;
+                }
+                else if (!PendingConnections.Remove(connectionId))
+                {
+                    rejection = "manifest acknowledgement was unsolicited or replayed";
+                }
+                else
+                {
+                    AcceptedConnections.Add(connectionId);
+                    if (PendingHostDataByConnection.TryGetValue(connectionId, out pending))
+                        PendingHostDataByConnection.Remove(connectionId);
+                }
+            }
+
+            if (rejection != null)
+            {
+                RejectConnection(connection, rejection);
+                return;
+            }
+
+            Info("host manifest acknowledgement accepted; deferredPlayerData=" +
+                 (pending != null));
+            pending?.Invoke();
+        }
+
+        private static void OnClientConnectionState(
+            FishNetTransporting.ClientConnectionStateArgs arguments)
+        {
+            if (arguments.ConnectionState == FishNetTransporting.LocalConnectionState.Stopping ||
+                arguments.ConnectionState == FishNetTransporting.LocalConnectionState.Stopped)
+            {
+                EndClientSession();
+            }
+        }
+
+        private static void RejectClient(string reason)
+        {
+            Warn("custom-product manifest rejected: " + reason);
+            lock (Gate)
+            {
+                ClientGate.End();
+                _clientSessionActive = false;
+                _clientDefinitionsReady = false;
+                _pendingClientManifest = null;
+                _localClientManifest = null;
+            }
+            FishNetInstanceFinder.NetworkManager?.ClientManager.StopConnection();
+        }
+
+        private static void RejectConnection(
+            FishNetConnection.NetworkConnection connection,
+            string reason)
+        {
+            int connectionId = connection.ClientId;
+            lock (Gate)
+            {
+                PendingConnections.Remove(connectionId);
+                PendingHostDataByConnection.Remove(connectionId);
+                AcceptedConnections.Remove(connectionId);
+            }
+            Warn("custom-product manifest acknowledgement rejected: " + reason);
+            connection.Disconnect(true);
+        }
+
+        private static void WriteManifest(
+            FishNetSerializing.Writer writer,
+            CustomProductManifestBroadcast value)
+        {
+#if IL2CPPMELON
+            writer.WriteString(CustomProductManifestIl2CppWire.TakeOutgoingManifest());
+#else
+            string payload = value.Payload;
+            writer.WriteString(payload);
+#endif
+        }
+
+        private static CustomProductManifestBroadcast ReadManifest(
+            FishNetSerializing.Reader reader)
+        {
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.SetIncomingManifest(reader.ReadString());
+            return new CustomProductManifestBroadcast();
+#else
+            return new CustomProductManifestBroadcast
+            {
+                Payload = reader.ReadString()
+            };
+#endif
+        }
+
+        private static void WriteAcknowledgement(
+            FishNetSerializing.Writer writer,
+            CustomProductManifestAckBroadcast value)
+        {
+#if IL2CPPMELON
+            (string sessionId, string compatibilityHash) =
+                CustomProductManifestIl2CppWire.TakeOutgoingAcknowledgement();
+#else
+            string sessionId = value.SessionId;
+            string compatibilityHash = value.CompatibilityHash;
+#endif
+            writer.WriteString(sessionId);
+            writer.WriteString(compatibilityHash);
+        }
+
+        private static CustomProductManifestAckBroadcast ReadAcknowledgement(
+            FishNetSerializing.Reader reader)
+        {
+#if IL2CPPMELON
+            CustomProductManifestIl2CppWire.SetIncomingAcknowledgement(
+                reader.ReadString(),
+                reader.ReadString());
+            return new CustomProductManifestAckBroadcast();
+#else
+            return new CustomProductManifestAckBroadcast
+            {
+                SessionId = reader.ReadString(),
+                CompatibilityHash = reader.ReadString()
+            };
+#endif
+        }
+
+        private static void Warn(string message)
+        {
+            try { MelonLoader.MelonLogger.Warning("[CustomProductManifest] " + message); }
+            catch (Exception) { }
+        }
+
+        private static void Info(string message)
+        {
+            try { MelonLoader.MelonLogger.Msg("[CustomProductManifest] " + message); }
+            catch (Exception) { }
+        }
+
+        private sealed class PendingHostData
+        {
+            private readonly object _player;
+            private readonly object[] _arguments;
+
+            internal PendingHostData(object player, object[] arguments)
+            {
+                _player = player;
+                _arguments = arguments;
+            }
+
+            internal void Invoke()
+            {
+                MethodInfo? method = AccessTools.Method(
+                    _player.GetType(),
+                    "ReceivePlayerData");
+                method?.Invoke(_player, _arguments);
+            }
+        }
+
+        private sealed class PendingConnection
+        {
+            internal PendingConnection(
+                int connectionId,
+                FishNetConnection.NetworkConnection connection,
+                DateTime deadline)
+            {
+                ConnectionId = connectionId;
+                Connection = connection;
+                Deadline = deadline;
+            }
+
+            internal int ConnectionId { get; }
+            internal FishNetConnection.NetworkConnection Connection { get; }
+            internal DateTime Deadline { get; }
+        }
+    }
+
+#if IL2CPPMELON
+    [RegisterTypeInIl2Cpp]
+    [Il2CppImplements(typeof(FishNetBroadcast.IBroadcast))]
+    internal sealed class CustomProductManifestBroadcast : Il2CppSystem.Object
+    {
+        public CustomProductManifestBroadcast(IntPtr pointer)
+            : base(pointer)
+        {
+        }
+
+        public CustomProductManifestBroadcast()
+            : base(ClassInjector.DerivedConstructorPointer<CustomProductManifestBroadcast>())
+        {
+            ClassInjector.DerivedConstructorBody(this);
+        }
+    }
+
+    [RegisterTypeInIl2Cpp]
+    [Il2CppImplements(typeof(FishNetBroadcast.IBroadcast))]
+    internal sealed class CustomProductManifestAckBroadcast : Il2CppSystem.Object
+    {
+        public CustomProductManifestAckBroadcast(IntPtr pointer)
+            : base(pointer)
+        {
+        }
+
+        public CustomProductManifestAckBroadcast()
+            : base(ClassInjector.DerivedConstructorPointer<CustomProductManifestAckBroadcast>())
+        {
+            ClassInjector.DerivedConstructorBody(this);
+        }
+    }
+
+    internal static class CustomProductManifestIl2CppWire
+    {
+        private static readonly object Sync = new object();
+        private static string? _outgoingManifest;
+        private static string? _incomingManifest;
+        private static (string SessionId, string CompatibilityHash)? _outgoingAcknowledgement;
+        private static (string SessionId, string CompatibilityHash)? _incomingAcknowledgement;
+
+        internal static void PrepareOutgoingManifest(string payload) =>
+            Set(ref _outgoingManifest, payload, "outgoing manifest");
+
+        internal static string TakeOutgoingManifest() =>
+            Take(ref _outgoingManifest, "outgoing manifest");
+
+        internal static void ClearOutgoingManifest() =>
+            Clear(ref _outgoingManifest);
+
+        internal static void SetIncomingManifest(string payload) =>
+            Set(ref _incomingManifest, payload, "incoming manifest");
+
+        internal static string TakeIncomingManifest() =>
+            Take(ref _incomingManifest, "incoming manifest");
+
+        internal static void PrepareOutgoingAcknowledgement(
+            string sessionId,
+            string compatibilityHash) =>
+            Set(
+                ref _outgoingAcknowledgement,
+                (sessionId, compatibilityHash),
+                "outgoing acknowledgement");
+
+        internal static (string SessionId, string CompatibilityHash)
+            TakeOutgoingAcknowledgement() =>
+                Take(ref _outgoingAcknowledgement, "outgoing acknowledgement");
+
+        internal static void ClearOutgoingAcknowledgement() =>
+            Clear(ref _outgoingAcknowledgement);
+
+        internal static void SetIncomingAcknowledgement(
+            string sessionId,
+            string compatibilityHash) =>
+            Set(
+                ref _incomingAcknowledgement,
+                (sessionId, compatibilityHash),
+                "incoming acknowledgement");
+
+        internal static (string SessionId, string CompatibilityHash)
+            TakeIncomingAcknowledgement() =>
+                Take(ref _incomingAcknowledgement, "incoming acknowledgement");
+
+        internal static void Reset()
+        {
+            lock (Sync)
+            {
+                _outgoingManifest = null;
+                _incomingManifest = null;
+                _outgoingAcknowledgement = null;
+                _incomingAcknowledgement = null;
+            }
+        }
+
+        private static void Set<T>(ref T? slot, T value, string name)
+            where T : struct
+        {
+            lock (Sync)
+            {
+                if (slot.HasValue)
+                    throw new InvalidOperationException(
+                        "IL2CPP custom-product " + name + " overlapped another message.");
+                slot = value;
+            }
+        }
+
+        private static void Set(ref string? slot, string value, string name)
+        {
+            lock (Sync)
+            {
+                if (slot != null)
+                    throw new InvalidOperationException(
+                        "IL2CPP custom-product " + name + " overlapped another message.");
+                slot = value;
+            }
+        }
+
+        private static T Take<T>(ref T? slot, string name)
+            where T : struct
+        {
+            lock (Sync)
+            {
+                if (!slot.HasValue)
+                    throw new InvalidOperationException(
+                        "IL2CPP custom-product " + name + " was not prepared.");
+                T value = slot.Value;
+                slot = null;
+                return value;
+            }
+        }
+
+        private static string Take(ref string? slot, string name)
+        {
+            lock (Sync)
+            {
+                string value = slot
+                    ?? throw new InvalidOperationException(
+                        "IL2CPP custom-product " + name + " was not prepared.");
+                slot = null;
+                return value;
+            }
+        }
+
+        private static void Clear<T>(ref T? slot)
+            where T : struct
+        {
+            lock (Sync)
+                slot = null;
+        }
+
+        private static void Clear(ref string? slot)
+        {
+            lock (Sync)
+                slot = null;
+        }
+    }
+#else
+    internal struct CustomProductManifestBroadcast : FishNetBroadcast.IBroadcast
+    {
+        internal string Payload { get; set; }
+    }
+
+    internal struct CustomProductManifestAckBroadcast : FishNetBroadcast.IBroadcast
+    {
+        internal string SessionId { get; set; }
+        internal string CompatibilityHash { get; set; }
+    }
+#endif
+}

--- a/S1API/Internal/Products/CustomProductManifestRuntime.cs
+++ b/S1API/Internal/Products/CustomProductManifestRuntime.cs
@@ -18,7 +18,6 @@ using FishNetTransporting = FishNet.Transporting;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using HarmonyLib;
 using MelonLoader;
 using S1API.Lifecycle;
 
@@ -58,6 +57,8 @@ namespace S1API.Internal.Products
         private static CustomProductManifestData? _pendingClientManifest;
         private static CustomProductManifestData? _localClientManifest;
 #if IL2CPPMELON
+        private static MethodInfo? _broadcastToConnectionMethod;
+        private static Type? _broadcastServerManagerType;
         private static Il2CppSystem.Action<FishNetConnection.NetworkConnection,
             CustomProductManifestAckBroadcast>? _acknowledgementReceiver;
         private static Il2CppSystem.Action<FishNetConnection.NetworkConnection,
@@ -379,10 +380,14 @@ namespace S1API.Internal.Products
         internal static bool AuthorizeHostPlayerData(
             object player,
             FishNetConnection.NetworkConnection connection,
-            object[] arguments)
+            object[] arguments,
+            MethodBase originalMethod)
         {
-            if (player == null || connection == null || arguments == null)
+            if (player == null || connection == null || arguments == null ||
+                originalMethod == null)
+            {
                 return true;
+            }
 
             int connectionId = connection.ClientId;
             lock (Gate)
@@ -395,7 +400,10 @@ namespace S1API.Internal.Products
                     {
                         PendingHostDataByConnection.Add(
                             connectionId,
-                            new PendingHostData(player, (object[])arguments.Clone()));
+                            new PendingHostData(
+                                player,
+                                (object[])arguments.Clone(),
+                                originalMethod));
                     }
                     return false;
                 }
@@ -418,7 +426,10 @@ namespace S1API.Internal.Products
                 {
                     PendingHostDataByConnection.Add(
                         connectionId,
-                        new PendingHostData(player, (object[])arguments.Clone()));
+                        new PendingHostData(
+                            player,
+                            (object[])arguments.Clone(),
+                            originalMethod));
                 }
                 return false;
             }
@@ -594,27 +605,52 @@ namespace S1API.Internal.Products
 #if IL2CPPMELON
         private static void BroadcastToConnection<T>(object serverManager, object connection, T message)
         {
-            foreach (MethodInfo method in serverManager.GetType().GetMethods(
-                         BindingFlags.Instance | BindingFlags.Public))
+            MethodInfo method = ResolveBroadcastToConnectionMethod(serverManager.GetType());
+            method.MakeGenericMethod(typeof(T)).Invoke(serverManager, new object[]
             {
-                if (method.Name != "Broadcast" || !method.IsGenericMethodDefinition ||
-                    method.GetParameters().Length != 4 ||
-                    method.GetParameters()[0].ParameterType.Name != "NetworkConnection")
+                connection,
+                message!,
+                true,
+                FishNetTransporting.Channel.Reliable
+            });
+        }
+
+        private static MethodInfo ResolveBroadcastToConnectionMethod(Type serverManagerType)
+        {
+            lock (Gate)
+            {
+                if (_broadcastToConnectionMethod != null &&
+                    _broadcastServerManagerType == serverManagerType)
                 {
-                    continue;
+                    return _broadcastToConnectionMethod;
                 }
 
-                method.MakeGenericMethod(typeof(T)).Invoke(serverManager, new object[]
+                foreach (MethodInfo method in serverManagerType.GetMethods(
+                             BindingFlags.Instance | BindingFlags.Public))
                 {
-                    connection,
-                    message!,
-                    true,
-                    FishNetTransporting.Channel.Reliable
-                });
-                return;
+                    ParameterInfo[] parameters = method.GetParameters();
+                    if (method.Name != "Broadcast" ||
+                        !method.IsGenericMethodDefinition ||
+                        method.GetGenericArguments().Length != 1 ||
+                        parameters.Length != 4 ||
+                        parameters[0].ParameterType !=
+                        typeof(FishNetConnection.NetworkConnection) ||
+                        !parameters[1].ParameterType.IsGenericParameter ||
+                        parameters[2].ParameterType != typeof(bool) ||
+                        parameters[3].ParameterType !=
+                        typeof(FishNetTransporting.Channel))
+                    {
+                        continue;
+                    }
+
+                    _broadcastServerManagerType = serverManagerType;
+                    _broadcastToConnectionMethod = method;
+                    return method;
+                }
             }
 
-            throw new MissingMethodException("FishNet ServerManager.Broadcast<T>(NetworkConnection, T, bool, Channel)");
+            throw new MissingMethodException(
+                "FishNet ServerManager.Broadcast<T>(NetworkConnection, T, bool, Channel)");
         }
 #endif
 
@@ -946,19 +982,21 @@ namespace S1API.Internal.Products
         {
             private readonly object _player;
             private readonly object[] _arguments;
+            private readonly MethodBase _method;
 
-            internal PendingHostData(object player, object[] arguments)
+            internal PendingHostData(
+                object player,
+                object[] arguments,
+                MethodBase method)
             {
                 _player = player;
                 _arguments = arguments;
+                _method = method;
             }
 
             internal void Invoke()
             {
-                MethodInfo? method = AccessTools.Method(
-                    _player.GetType(),
-                    "ReceivePlayerData");
-                method?.Invoke(_player, _arguments);
+                _method.Invoke(_player, _arguments);
             }
         }
 

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -51,6 +51,22 @@ namespace S1API.Internal.Products
             }
         }
 
+        internal static bool IsProviderAvailable(
+            string? providerId,
+            int descriptorVersion)
+        {
+            if (string.IsNullOrEmpty(providerId))
+                return true;
+
+            lock (Gate)
+            {
+                return Providers.TryGetValue(
+                           providerId,
+                           out ICustomProductSaveProvider? provider) &&
+                       descriptorVersion <= provider.MaximumDescriptorVersion;
+            }
+        }
+
         internal static void Save(string saveFolderPath)
         {
             CustomProductSaveDescriptorData[] descriptors = CustomProductDefinitionRegistry.GetSaveDescriptors();

--- a/S1API/Products/CustomProductMultiplayer.cs
+++ b/S1API/Products/CustomProductMultiplayer.cs
@@ -1,0 +1,42 @@
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>Describes how incompatible custom-product content is handled in multiplayer.</summary>
+    public enum CustomProductMultiplayerPolicy
+    {
+        /// <summary>
+        /// Reject the joining client before its inventory or product state is deserialized.
+        /// </summary>
+        Reject = 0
+    }
+
+    /// <summary>
+    /// Provides additive diagnostics for custom-product multiplayer compatibility.
+    /// </summary>
+    /// <remarks>
+    /// S1API transmits only a bounded scalar manifest and never transfers assets, delegates,
+    /// arbitrary types, paths, or save files. A client whose locally registered definitions do not
+    /// match the host is rejected before its player inventory is deserialized.
+    /// </remarks>
+    public static class CustomProductMultiplayer
+    {
+        /// <summary>Gets the explicit policy used for missing or incompatible custom content.</summary>
+        public static CustomProductMultiplayerPolicy MissingContentPolicy =>
+            CustomProductMultiplayerPolicy.Reject;
+
+        /// <summary>
+        /// Gets the deterministic compatibility hash for custom products registered in this process.
+        /// </summary>
+        /// <remarks>
+        /// The value is intended for diagnostics only. It contains no assets, paths, raw provider
+        /// data, or save content. The method throws when the current registrations cannot be
+        /// represented by the bounded protocol.
+        /// </remarks>
+        /// <exception cref="System.InvalidOperationException">
+        /// A registered custom product cannot be represented by the bounded compatibility protocol.
+        /// </exception>
+        public static string GetCompatibilityManifestHash() =>
+            CustomProductManifestRuntime.GetLocalCompatibilityHash();
+    }
+}

--- a/S1API/Products/ProductPresentationProfileRegistry.cs
+++ b/S1API/Products/ProductPresentationProfileRegistry.cs
@@ -184,6 +184,24 @@ namespace S1API.Products
             }
         }
 
+        internal static bool TryGetManifestIdentity(
+            string productId,
+            string productKindId,
+            out string identity)
+        {
+            if (TryResolve(productId, productKindId, out ProductPresentationProfileRegistration? registration) &&
+                registration != null)
+            {
+                identity =
+                    registration.OwnerId.Length + ":" + registration.OwnerId +
+                    registration.Key.Length + ":" + registration.Key;
+                return true;
+            }
+
+            identity = string.Empty;
+            return false;
+        }
+
         internal static void ResetForTesting()
         {
             lock (Gate)

--- a/S1API/Products/ProductPresentationProfileRegistry.cs
+++ b/S1API/Products/ProductPresentationProfileRegistry.cs
@@ -192,9 +192,14 @@ namespace S1API.Products
             if (TryResolve(productId, productKindId, out ProductPresentationProfileRegistration? registration) &&
                 registration != null)
             {
-                identity =
+                string readableIdentity =
                     registration.OwnerId.Length + ":" + registration.OwnerId +
                     registration.Key.Length + ":" + registration.Key;
+                identity = readableIdentity.Length <=
+                           CustomProductManifestData.MaximumIdentifierLength
+                    ? readableIdentity
+                    : "sha256:" + CustomProductManifestData.ComputeHash(
+                        readableIdentity.ToLowerInvariant());
                 return true;
             }
 

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -31,14 +31,14 @@ GameLifecycle.OnPreLoad += () =>
         return;
 
     var representationTemplate =
-        ItemManager.GetDefinition("weed") as ProductDefinition;
+        ItemManager.GetDefinition("ogkush") as ProductDefinition;
     var baggie = ProductPopulator.GetPackaging("baggie");
 
     if (representationTemplate == null)
     {
         throw new InvalidOperationException(
             "Cannot register example.mod:products/focus-tablet: " +
-            "the representation template 'weed' is unavailable during OnPreLoad.");
+            "the representation template 'ogkush' is unavailable during OnPreLoad.");
     }
 
     if (baggie == null)
@@ -408,6 +408,48 @@ also skipped with an actionable warning; loading continues and S1API never attem
 an arbitrary ID migration. Reinstall the content mod/provider with the original
 stable ID to restore the product. These warnings intentionally contain IDs only,
 never local paths or personal data.
+
+## Multiplayer compatibility manifest
+
+When a host starts a multiplayer load, S1API establishes a manifest session,
+then finalizes its snapshot immediately after the versioned save descriptors are
+restored and before base product/inventory loaders run. It sends each joining
+S1API client that host-authoritative manifest before the native player-data
+request is allowed to deserialize inventory product instances. The client
+responds only after comparing its locally registered definitions with the host
+manifest. This also covers clients already joined before load, late joins, and
+reconnects: registrations remain process-lifetime and the handshake is repeated
+per connection without adding duplicate definitions, providers, presentation
+profiles, or Product Manager entries.
+
+The manifest is deterministic and bounded (at most 256 entries and 64 KiB). It
+contains stable product/owner/kind IDs, the native compatibility drug type,
+descriptor and provider versions, local provider availability,
+representation-template and packaging IDs,
+the resolved presentation-profile registration identity, and a compatibility
+hash. The hash additionally covers the local descriptor's display/scalar fields
+and provider-data digest, but raw provider data is never transmitted. It never
+contains or downloads Unity objects, assets, bundles, sprites, meshes, prefabs,
+delegates, arbitrary types, local paths, or save files.
+
+The missing or incompatible-content policy is **reject**. S1API disconnects a
+joining client whose local manifest is missing, malformed, too new, duplicated,
+timed out, replayed with conflicting content, or incompatible with the host.
+It does not create a placeholder or silently deserialize product data against a
+different definition. The host also holds target player data until it receives
+the matching acknowledgement, so an unmodded or incompatible peer cannot obtain
+custom inventory state before validation.
+
+When the host has no descriptor-backed custom products, no manifest packet or
+player-data gate is added. Vanilla/no-custom-product sessions retain the native
+network path. A client with local custom products still waits for a compatible
+custom-product host manifest and fails closed rather than sending its custom
+inventory request into an unvalidated session.
+
+`CustomProductMultiplayer.MissingContentPolicy` exposes this fixed policy and
+`CustomProductMultiplayer.GetCompatibilityManifestHash()` provides a safe local
+diagnostic value. Neither exposes asset references, provider payloads, paths, or
+personal information.
 
 ## Supported and unsupported behavior
 


### PR DESCRIPTION
## Summary

- add a versioned, host-authoritative custom-product manifest finalized after #104 descriptor restoration and before native product/inventory loaders
- gate the client player-data request and the host target player-data response until local definitions, providers, presentation profiles, packaging IDs, descriptor versions, and compatibility hashes match
- fail closed with actionable stable-ID diagnostics; support clients connected before load, late joins, and reconnects without mutating process-lifetime registries
- expose the additive `CustomProductMultiplayer` diagnostics API and document the reject policy

## Native lifecycle evidence

`LoadManager.LoadAsClient` raises `OnPreLoad`, waits for `Player.Local`, then waits for `playerDataRetrieveReturned` before replication. `Player.OnStartClient` requests player data, and the generated `ReceivePlayerData` RPC applies player state and conditionally deserializes inventory before replication completes. The handshake therefore patches the request/target-response seam, not lobby creation or the later replication queue. On the host, the manifest snapshot is finalized in the existing #104 restore prefix immediately after descriptor recovery and before base loaders.

The wire snapshot validates local process-lifetime registrations only. It never recreates peer registries, so the existing first-registration-wins, provider, presentation-profile, collection, and UI idempotence rules remain authoritative.

## Compatibility

- **Source:** additive only. Existing public/protected syntax, signatures, parameter names, defaults, enums, builders, and validation behavior are unchanged. New public surface is `CustomProductMultiplayerPolicy` and `CustomProductMultiplayer`.
- **Binary:** additive only; no existing metadata signatures or virtual shapes changed. Compile-only and reflection contracts cover the new surface.
- **Behavior:** descriptor-backed custom-product multiplayer now rejects missing or incompatible content before player-data application. Existing registration order, duplicate policy, durable IDs, and transactional rollback remain unchanged. Sessions with no descriptor-backed custom products retain the native player-data path with no manifest traffic or host gate.
- **Save:** unchanged. No descriptor or save-file schema changed; the manifest is derived from the committed #104 descriptors after early restore and never writes save data.
- **Network/wire:** new protocol version 1 is additive and applies only when custom products require validation. It uses authenticated FishNet broadcasts and a per-host-session acknowledgement. There is no previous custom-product wire format to replace. Vanilla authentication/version checks are not bypassed or weakened.

## Security and bounds

The protocol accepts at most 256 canonically ordered entries and 64 KiB of UTF-8 JSON, with 256-character stable IDs, 32 packaging IDs per entry, depth 16, exact supported versions, duplicate JSON/property/product/packaging rejection, control-character rejection, and deterministic SHA-256 hashes. Session IDs and hashes require exact lowercase hexadecimal lengths. Timeouts, disconnects, conflicting replays, unsolicited acknowledgements, and failed sends clear pending state and fail closed.

Only stable IDs, enum-compatible scalar values, versions, provider availability, and hashes cross the wire. Provider data contributes only a digest. Meshes, textures, sprites, prefabs, asset bundles, Unity objects, delegates, arbitrary types, local paths, raw provider data, and save files are never transmitted or downloaded.

## Testing

Canonical validation:

- MonoMelon restore/build: pass, 0 warnings; `S1API.Tests`: 229 passed
- Il2CppMelon restore/build: pass, 0 warnings; `S1API.Tests`: 222 passed
- DocFX 2.78.3: pass, 0 errors (4 pre-existing unresolved dependency warnings)
- public API documentation coverage: 81.33% (2,902 / 3,568; minimum 80%)
- `git diff --check`: pass

Canonical tests cover deterministic/case-insensitive canonicalization, UTF-8 and entry/identifier/packaging bounds, malformed/unknown/duplicate JSON, protocol/hash/scalar mismatch, transactional rollback, descriptor-before-manifest ordering, deferred player-data ordering, reconnect/idempotence, vanilla bypass, compile-only callers, and reflection contracts.

Isolated Goldberg P2P validation used GSE Client API 08.33.09.23, LocalLobby 1.0.0, unique identities/run tokens, separate host/client installs and disposable saves, exact mod allowlists, and runner-owned process cleanup. Lobby membership was positively observed by both processes before host load in preload scenarios; a lobby ID alone was not treated as success. The client probe patched the generated native player-data application RPC and confirmed the definition was already available.

| Runtime | Scenario evidence |
| --- | --- |
| Mono | matching `20260724-025455-aae219d5`; late `20260724-021404-c05cd00d`; reconnect `20260724-021439-9ee49306`; missing definition `20260724-021535-24406111`; missing provider `20260724-021617-2bb0466f`; hash mismatch `20260724-021700-fb95642b`; version mismatch `20260724-021742-d1427f8c`; malformed `20260724-021824-7cbdc6d7`; oversized `20260724-021909-f754cd41`; vanilla `20260724-021952-fc5cc07c` |
| IL2CPP | matching `20260724-025601-ec903e49`; late `20260724-023840-aeee860a`; reconnect `20260724-023924-fbce0304`; missing definition `20260724-024029-9018b6e1`; missing provider `20260724-024119-c8798c0d`; hash mismatch `20260724-024210-b92966d5`; version mismatch `20260724-024300-ee238f29`; malformed `20260724-024601-2bc614b9`; oversized `20260724-024651-a1c8cb34`; vanilla `20260724-024742-d2a1233d` |

Final matching runs produced the same host/client manifest hash in each lane and reported `DefinitionAvailableAtPlayerData=True` on the client. Reconnect runs passed two client attempts without duplicate definitions or UI/registry state.

## Known limitations

- missing or incompatible content is rejected; mods/assets are never downloaded and no placeholder/disabled-product mode is provided
- incompatible native game builds remain governed by the game's version gate
- cross-runtime host/client pairing was not claimed or exercised; Mono and IL2CPP were validated as separate supported lanes
- dedicated-server support and custom mixing/output factories remain out of scope

Closes #105