### PR TITLE
feat(products): add opt-in custom mixing profiles

### DIFF
--- a/S1API.Tests/Products/CustomProductMixingIdentityTests.cs
+++ b/S1API.Tests/Products/CustomProductMixingIdentityTests.cs
@@ -1,0 +1,29 @@
+using S1API.Internal.Products;
+using S1API.Products;
+using Xunit;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductMixingIdentityTests
+{
+    [Fact]
+    public void PostSanitizationNativeIdGetsStableNamespacedGeneratedIdentity()
+    {
+        // ProductManager.FinishAndNameMix lowercases, calls MakeIDFileSafe, then strips ':'
+        // before the private FinishAndNameMix/RPC seam. This is the actual post-sanitization
+        // value, not an assumed MakeIDFileSafe result.
+        const string nativePostSanitizationId = "moremdmablue";
+
+        string generated = CustomProductMixingIdentity.CreateGeneratedProductId(
+            "moredrugs:mdma",
+            nativePostSanitizationId);
+
+        Assert.StartsWith("moredrugs:mix/mdma/", generated);
+        Assert.Equal("moredrugs",
+            CustomProductDefinitionBuilderContract.GetOwnerId(generated));
+        Assert.Equal(generated, CustomProductMixingIdentity.CreateGeneratedProductId(
+            "moredrugs:mdma", nativePostSanitizationId));
+        Assert.True(CustomProductMixingIdentity.IsGeneratedIdForSource(
+            "moredrugs:mdma", generated));
+    }
+}

--- a/S1API.Tests/Products/ProductMixingProfileTests.cs
+++ b/S1API.Tests/Products/ProductMixingProfileTests.cs
@@ -1,0 +1,72 @@
+using System;
+using S1API.Products;
+using Xunit;
+
+namespace S1API.Tests.Products
+{
+    public sealed class ProductMixingProfileTests
+    {
+        [Fact]
+        public void ProfileRegistrationRetainsKindAndInvokesDeterministicFactory()
+        {
+            ProductKind kind = CreateKind();
+            Func<ProductMixingOutput, ProductMixingOutputDefinition> factory = input =>
+                new ProductMixingOutputDefinition(input.MixName + " Output", input.SourceKind, input.SourcePrice + 10f);
+
+            ProductMixingProfile profile = new ProductMixingProfileBuilder(kind)
+                .WithMixerMap(ProductMixingMap.Marijuana)
+                .WithOutputFactory(factory)
+                .Build();
+
+            Assert.Same(profile, ProductMixingProfiles.Get(kind));
+            Assert.Equal(ProductMixingMap.Marijuana, profile.MixerMap);
+            ProductMixingOutputDefinition output = profile.OutputFactory(
+                new ProductMixingOutput("example:output", "Named Mix", "example:source", kind, 20f));
+            Assert.Equal("Named Mix Output", output.Name);
+            Assert.Same(kind, output.ProductKind);
+            Assert.Equal(30f, output.Price);
+        }
+
+        [Fact]
+        public void MissingOutputFactoryFailsBeforeRegistration()
+        {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => new ProductMixingProfileBuilder(CreateKind()).Build());
+
+            Assert.Contains("WithOutputFactory", exception.Message);
+        }
+
+        [Fact]
+        public void OutputDefinitionRejectsInvalidPriceAndMissingKind()
+        {
+            ProductKind kind = CreateKind();
+
+            Assert.Throws<ArgumentNullException>(
+                () => new ProductMixingOutputDefinition("Output", null!, 5f));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new ProductMixingOutputDefinition("Output", kind, float.NaN));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new ProductMixingOutputDefinition("Output", kind, 1000f));
+        }
+
+        [Fact]
+        public void MismatchedMapCannotEnterAnUnsupportedNativeFamily()
+        {
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => new ProductMixingProfileBuilder(CreateKind())
+                    .WithMixerMap(ProductMixingMap.Cocaine)
+                    .WithOutputFactory(input =>
+                        new ProductMixingOutputDefinition(input.MixName, input.SourceKind, input.SourcePrice))
+                    .Build());
+
+            Assert.Contains("must match", exception.Message);
+        }
+
+        private static ProductKind CreateKind()
+        {
+            return new ProductKindBuilder("mixingtests:" + Guid.NewGuid().ToString("N"))
+                .WithCompatibilityDrugType(DrugType.Marijuana)
+                .Build();
+        }
+    }
+}

--- a/S1API.Tests/Products/ProductMixingProfileTests.cs
+++ b/S1API.Tests/Products/ProductMixingProfileTests.cs
@@ -50,16 +50,23 @@ namespace S1API.Tests.Products
         }
 
         [Fact]
-        public void MismatchedMapCannotEnterAnUnsupportedNativeFamily()
+        public void CustomLogicalKindWithoutNativeEnumCanSelectAnExplicitMixerStrategy()
         {
-            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
-                () => new ProductMixingProfileBuilder(CreateKind())
-                    .WithMixerMap(ProductMixingMap.Cocaine)
-                    .WithOutputFactory(input =>
-                        new ProductMixingOutputDefinition(input.MixName, input.SourceKind, input.SourcePrice))
-                    .Build());
+            ProductKind futureKind = new ProductKindBuilder(
+                    "consumer-shape:" + Guid.NewGuid().ToString("N"))
+                .Build();
 
-            Assert.Contains("must match", exception.Message);
+            ProductMixingProfile profile = new ProductMixingProfileBuilder(futureKind)
+                .WithMixerMap(ProductMixingMap.Cocaine)
+                .WithOutputFactoryCompatibility("consumer-shape:mix-output", 3)
+                .WithOutputFactory(input => new ProductMixingOutputDefinition(
+                    input.MixName, input.SourceKind, input.SourcePrice))
+                .Build();
+
+            Assert.Same(futureKind, profile.ProductKind);
+            Assert.Equal(ProductMixingMap.Cocaine, profile.MixerMap);
+            Assert.Equal("consumer-shape:mix-output", profile.OutputFactoryIdentity);
+            Assert.Equal(3, profile.OutputFactoryVersion);
         }
 
         private static ProductKind CreateKind()

--- a/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
@@ -1,0 +1,28 @@
+using System;
+using S1API.Internal.Products;
+using S1API.Products;
+using Xunit;
+
+namespace S1API.Tests.Products;
+
+[Collection(CustomProductRegistryCollection.Name)]
+public sealed class ProductPackagingContentFallbackTests : IDisposable
+{
+    public void Dispose() => ProductPackagingContentProfileRegistry.ResetForTesting();
+
+    [Fact]
+    public void LogicalKindFallbackResolvesForDynamicallyAllocatedGeneratedMixes()
+    {
+        string kindId = "moredrugs:mdma-" + Guid.NewGuid().ToString("N");
+        var profile = new ProductPackagingContentProfileBuilder()
+            .WithContent(() => null)
+            .Build();
+
+        ProductPackagingContentProfileRegistry.RegisterForProductKind(
+            "moredrugs", kindId, "baggie", profile);
+
+        Assert.True(ProductPackagingContentProfileRegistry.TryResolveForProductKind(
+            kindId, "baggie", out ProductPackagingContentProfileRegistration? resolved));
+        Assert.Same(profile, resolved!.Profile);
+    }
+}

--- a/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
@@ -3,6 +3,7 @@ using S1API.Products;
 
 namespace S1API.Tests.Products;
 
+[Collection(CustomProductRegistryCollection.Name)]
 public sealed class ProductPackagingContentProfileRegistryTests : IDisposable
 {
     public ProductPackagingContentProfileRegistryTests()

--- a/S1API/Internal/Patches/MixReactionPatches.cs
+++ b/S1API/Internal/Patches/MixReactionPatches.cs
@@ -150,7 +150,7 @@ namespace S1API.Internal.Patches
             string productID,
             string ingredientID,
             string mixName,
-            string mixID)
+            ref string mixID)
         {
             try
             {
@@ -164,6 +164,14 @@ namespace S1API.Internal.Patches
                     Logger.Error("Custom product '" + productID + "' has logical kind '" + metadata.ProductKind.Id + "' but no ProductMixingProfile is registered. The mix was rejected before the unsupported native output switch.");
                     return false;
                 }
+
+                if (!CustomProductMixingIdentity.IsGeneratedIdForSource(productID, mixID))
+                    mixID = CustomProductMixingIdentity.CreateGeneratedProductId(productID, mixID);
+
+                // FishNet can execute the same observer RPC after a local host path. Preserve
+                // the native first-wins behavior and do not allocate a second definition.
+                if (CustomProductDefinitionRegistry.IsRegistered(mixID))
+                    return false;
 
                 S1Product.PropertyItemDefinition? ingredient =
                     S1Registry.GetItem(ingredientID) as S1Product.PropertyItemDefinition;
@@ -189,8 +197,14 @@ namespace S1API.Internal.Patches
                     source.BasePrice);
                 ProductMixingOutputDefinition output = profile!.OutputFactory(outputInput)
                     ?? throw new InvalidOperationException("The mixing output factory returned null.");
-                if (!output.ProductKind.CompatibilityDrugType.HasValue)
-                    throw new InvalidOperationException("The mixing output kind must define a compatibility drug type.");
+                DrugType nativeDrugType = ProductMixingMapContract.GetNativeDrugType(profile.MixerMap);
+                if ((int)source.DrugType != (int)nativeDrugType)
+                {
+                    throw new InvalidOperationException(
+                        "Custom product '" + productID + "' uses native drug type '" +
+                        source.DrugType + "' but its ProductMixingProfile selects mixer map '" +
+                        profile.MixerMap + "'. Configure the product's explicit native mixer map to match the profile.");
+                }
 
                 var packaging = new System.Collections.Generic.List<S1Packaging.PackagingDefinition>();
                 for (int i = 0; i < metadata.ValidPackaging.Count; i++)
@@ -206,7 +220,7 @@ namespace S1API.Internal.Patches
                     source.BaseAddictiveness,
                     source.PlayerEffectDuration,
                     source.NPCEffectDuration,
-                    output.ProductKind.CompatibilityDrugType.Value,
+                    nativeDrugType,
                     resolvedProperties,
                     packaging,
                     template);
@@ -226,12 +240,13 @@ namespace S1API.Internal.Patches
                     BaseAddictiveness = source.BaseAddictiveness,
                     DefaultQuality = (int)metadata.DefaultQuality,
                     ProductKindId = output.ProductKind.Id,
-                    CompatibilityDrugType = (int)output.ProductKind.CompatibilityDrugType.Value,
+                    CompatibilityDrugType = (int)nativeDrugType,
                     RepresentationTemplateId = template.ID,
                     PlayerEffectDurationSeconds = source.PlayerEffectDuration,
                     NpcEffectDurationSeconds = source.NPCEffectDuration,
                     PropertyIds = resolvedProperties.ConvertAll(property => property.ID).ToArray(),
-                    PackagingIds = metadata.ValidPackaging.Select(packagingDefinition => packagingDefinition.ID).ToArray()
+                    PackagingIds = metadata.ValidPackaging.Select(packagingDefinition => packagingDefinition.ID).ToArray(),
+                    IsGeneratedMix = true
                 };
                 try
                 {
@@ -261,42 +276,40 @@ namespace S1API.Internal.Patches
     }
 
     /// <summary>
-    /// INTERNAL: Names generated custom mixes with their source namespace before native creation.
+    /// INTERNAL: Replaces the fully sanitized native ID at the RPC seams.
     /// </summary>
-    [HarmonyPatch(typeof(S1Product.ProductManager), "FinishAndNameMix", new[] { typeof(string), typeof(string), typeof(string) })]
+    [HarmonyPatch(typeof(S1Product.ProductManager), "FinishAndNameMix", new[] { typeof(string), typeof(string), typeof(string), typeof(string) })]
     internal static class CustomProductMixingIdPatches
     {
-        [ThreadStatic]
-        internal static string? PendingOwnerId;
-
         [HarmonyPrefix]
-        private static void FinishAndNameMix_Prefix(string productID)
+        private static void FinishAndNameMix_Prefix(string productID, ref string mixID)
         {
             S1Product.ProductDefinition? source = S1Registry.GetItem(productID) as S1Product.ProductDefinition;
             if (source == null || !CustomProductDefinitionRegistry.TryGetMetadata(source, out CustomProductDefinitionMetadata? metadata))
                 return;
-            if (ProductMixingProfiles.TryGet(metadata!.ProductKind.Id, out _))
-                PendingOwnerId = CustomProductDefinitionBuilderContract.GetOwnerId(metadata.ProductKind.Id);
-        }
-
-        [HarmonyPostfix]
-        private static void FinishAndNameMix_Postfix()
-        {
-            PendingOwnerId = null;
+            if (ProductMixingProfiles.TryGet(metadata!.ProductKind.Id, out _) &&
+                !CustomProductMixingIdentity.IsGeneratedIdForSource(productID, mixID))
+            {
+                mixID = CustomProductMixingIdentity.CreateGeneratedProductId(productID, mixID);
+            }
         }
     }
 
-    /// <summary>
-    /// INTERNAL: Applies the generated custom-product namespace to the native mix ID.
-    /// </summary>
-    [HarmonyPatch(typeof(S1Product.ProductManager), "MakeIDFileSafe")]
-    internal static class CustomProductMixingIdGenerationPatches
+    /// <summary>INTERNAL: Uses the same generated ID on client-to-server mix requests.</summary>
+    [HarmonyPatch(typeof(S1Product.ProductManager), "SendFinishAndNameMix", new[] { typeof(string), typeof(string), typeof(string), typeof(string) })]
+    internal static class CustomProductMixingClientRpcPatches
     {
-        [HarmonyPostfix]
-        private static void MakeIDFileSafe_Postfix(ref string __result)
+        [HarmonyPrefix]
+        private static void SendFinishAndNameMix_Prefix(string productID, ref string mixID)
         {
-            if (!string.IsNullOrEmpty(CustomProductMixingIdPatches.PendingOwnerId) && !string.IsNullOrEmpty(__result))
-                __result = CustomProductMixingIdPatches.PendingOwnerId + ":" + __result;
+            S1Product.ProductDefinition? source = S1Registry.GetItem(productID) as S1Product.ProductDefinition;
+            if (source == null || !CustomProductDefinitionRegistry.TryGetMetadata(source, out CustomProductDefinitionMetadata? metadata))
+                return;
+            if (ProductMixingProfiles.TryGet(metadata!.ProductKind.Id, out _) &&
+                !CustomProductMixingIdentity.IsGeneratedIdForSource(productID, mixID))
+            {
+                mixID = CustomProductMixingIdentity.CreateGeneratedProductId(productID, mixID);
+            }
         }
     }
 }

--- a/S1API/Internal/Patches/MixReactionPatches.cs
+++ b/S1API/Internal/Patches/MixReactionPatches.cs
@@ -1,16 +1,22 @@
 #if (IL2CPPMELON)
 using S1Effects = Il2CppScheduleOne.Effects;
 using S1Product = Il2CppScheduleOne.Product;
+using S1Registry = Il2CppScheduleOne.Registry;
+using S1Packaging = Il2CppScheduleOne.Product.Packaging;
 using EffectList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Effects.Effect>;
 #elif MONOMELON
 using S1Effects = ScheduleOne.Effects;
 using S1Product = ScheduleOne.Product;
+using S1Registry = ScheduleOne.Registry;
+using S1Packaging = ScheduleOne.Product.Packaging;
 using EffectList = System.Collections.Generic.List<ScheduleOne.Effects.Effect>;
 #endif
 using System;
+using System.Linq;
 using HarmonyLib;
 using S1API.Logging;
 using S1API.Products;
+using S1API.Internal.Products;
 
 namespace S1API.Internal.Patches
 {
@@ -128,6 +134,169 @@ namespace S1API.Internal.Patches
                 if (effect != null && string.Equals(effect.ID, id, StringComparison.OrdinalIgnoreCase))
                     list.RemoveAt(i);
             }
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL: Replaces only registered generic-product mix outputs before the native family switch.
+    /// </summary>
+    [HarmonyPatch(typeof(S1Product.ProductManager), "RpcLogic___FinishAndNameMix_4237212381")]
+    internal static class CustomProductMixingPatches
+    {
+        private static readonly Log Logger = new Log("CustomProductMixingPatches");
+
+        [HarmonyPrefix]
+        private static bool FinishAndNameMix_Prefix(
+            string productID,
+            string ingredientID,
+            string mixName,
+            string mixID)
+        {
+            try
+            {
+                S1Product.ProductDefinition? source =
+                    S1Registry.GetItem(productID) as S1Product.ProductDefinition;
+                if (source == null || !CustomProductDefinitionRegistry.TryGetMetadata(source, out CustomProductDefinitionMetadata? metadata))
+                    return true;
+
+                if (!ProductMixingProfiles.TryGet(metadata!.ProductKind.Id, out ProductMixingProfile? profile))
+                {
+                    Logger.Error("Custom product '" + productID + "' has logical kind '" + metadata.ProductKind.Id + "' but no ProductMixingProfile is registered. The mix was rejected before the unsupported native output switch.");
+                    return false;
+                }
+
+                S1Product.PropertyItemDefinition? ingredient =
+                    S1Registry.GetItem(ingredientID) as S1Product.PropertyItemDefinition;
+                if (ingredient == null || ingredient.Properties == null || ingredient.Properties.Count != 1)
+                {
+                    Logger.Error("Custom product mix '" + productID + "' has no valid single-property ingredient '" + ingredientID + "'.");
+                    return false;
+                }
+
+                EffectList properties = S1Effects.EffectMixCalculator.MixProperties(
+                    source.Properties,
+                    ingredient.Properties[0],
+                    source.DrugType);
+                var resolvedProperties =
+                    new System.Collections.Generic.List<S1Effects.Effect>(properties.Count);
+                for (int i = 0; i < properties.Count; i++)
+                    resolvedProperties.Add(properties[i]);
+                var outputInput = new ProductMixingOutput(
+                    mixID,
+                    mixName,
+                    productID,
+                    metadata.ProductKind,
+                    source.BasePrice);
+                ProductMixingOutputDefinition output = profile!.OutputFactory(outputInput)
+                    ?? throw new InvalidOperationException("The mixing output factory returned null.");
+                if (!output.ProductKind.CompatibilityDrugType.HasValue)
+                    throw new InvalidOperationException("The mixing output kind must define a compatibility drug type.");
+
+                var packaging = new System.Collections.Generic.List<S1Packaging.PackagingDefinition>();
+                for (int i = 0; i < metadata.ValidPackaging.Count; i++)
+                    packaging.Add(metadata.ValidPackaging[i].S1PackagingDefinition);
+
+                S1Product.ProductDefinition template = metadata.RepresentationTemplate ?? source;
+                S1Product.ProductDefinition generated = CustomProductDefinitionFactory.Create(
+                    mixID,
+                    output.Name,
+                    source.Description,
+                    output.Price,
+                    (global::S1API.Items.LegalStatus)(int)source.legalStatus,
+                    source.BaseAddictiveness,
+                    source.PlayerEffectDuration,
+                    source.NPCEffectDuration,
+                    output.ProductKind.CompatibilityDrugType.Value,
+                    resolvedProperties,
+                    packaging,
+                    template);
+                var generatedMetadata = new CustomProductDefinitionMetadata(
+                    output.ProductKind,
+                    metadata.DefaultQuality,
+                    metadata.ValidPackaging,
+                    template);
+                var saveDescriptor = new CustomProductSaveDescriptorData
+                {
+                    ProductId = mixID,
+                    OwnerId = CustomProductDefinitionBuilderContract.GetOwnerId(mixID),
+                    ProductName = output.Name,
+                    Description = source.Description,
+                    InitialPrice = output.Price,
+                    LegalStatus = (int)source.legalStatus,
+                    BaseAddictiveness = source.BaseAddictiveness,
+                    DefaultQuality = (int)metadata.DefaultQuality,
+                    ProductKindId = output.ProductKind.Id,
+                    CompatibilityDrugType = (int)output.ProductKind.CompatibilityDrugType.Value,
+                    RepresentationTemplateId = template.ID,
+                    PlayerEffectDurationSeconds = source.PlayerEffectDuration,
+                    NpcEffectDurationSeconds = source.NPCEffectDuration,
+                    PropertyIds = resolvedProperties.ConvertAll(property => property.ID).ToArray(),
+                    PackagingIds = metadata.ValidPackaging.Select(packagingDefinition => packagingDefinition.ID).ToArray()
+                };
+                try
+                {
+                    CustomProductDefinitionRegistry.Register(
+                        CustomProductDefinitionBuilderContract.GetOwnerId(mixID),
+                        mixID,
+                        output.Name,
+                        output.Price,
+                        generated,
+                        generatedMetadata,
+                        saveDescriptor);
+                }
+                catch
+                {
+                    CustomProductDefinitionFactory.Destroy(generated);
+                    throw;
+                }
+
+                return false;
+            }
+            catch (Exception exception)
+            {
+                Logger.Error("Custom product mixing output failed for '" + productID + "': " + exception);
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL: Names generated custom mixes with their source namespace before native creation.
+    /// </summary>
+    [HarmonyPatch(typeof(S1Product.ProductManager), "FinishAndNameMix", new[] { typeof(string), typeof(string), typeof(string) })]
+    internal static class CustomProductMixingIdPatches
+    {
+        [ThreadStatic]
+        internal static string? PendingOwnerId;
+
+        [HarmonyPrefix]
+        private static void FinishAndNameMix_Prefix(string productID)
+        {
+            S1Product.ProductDefinition? source = S1Registry.GetItem(productID) as S1Product.ProductDefinition;
+            if (source == null || !CustomProductDefinitionRegistry.TryGetMetadata(source, out CustomProductDefinitionMetadata? metadata))
+                return;
+            if (ProductMixingProfiles.TryGet(metadata!.ProductKind.Id, out _))
+                PendingOwnerId = CustomProductDefinitionBuilderContract.GetOwnerId(metadata.ProductKind.Id);
+        }
+
+        [HarmonyPostfix]
+        private static void FinishAndNameMix_Postfix()
+        {
+            PendingOwnerId = null;
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL: Applies the generated custom-product namespace to the native mix ID.
+    /// </summary>
+    [HarmonyPatch(typeof(S1Product.ProductManager), "MakeIDFileSafe")]
+    internal static class CustomProductMixingIdGenerationPatches
+    {
+        [HarmonyPostfix]
+        private static void MakeIDFileSafe_Postfix(ref string __result)
+        {
+            if (!string.IsNullOrEmpty(CustomProductMixingIdPatches.PendingOwnerId) && !string.IsNullOrEmpty(__result))
+                __result = CustomProductMixingIdPatches.PendingOwnerId + ":" + __result;
         }
     }
 }

--- a/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionRegistry.cs
@@ -138,6 +138,9 @@ namespace S1API.Internal.Products
 
                     _runtimeAdapter.Apply(registration);
 
+                    if (added)
+                        CustomProductManifestRuntime.RefreshHostManifestIfReady();
+
                     if (profile == null)
                         _presentationRuntime.Apply(registration, null);
                 }
@@ -219,6 +222,28 @@ namespace S1API.Internal.Products
                         out CustomProductDefinitionRegistration? registration) ||
                     registration.Metadata == null ||
                     !AreSameDefinition(registration.Definition, definition))
+                {
+                    return false;
+                }
+
+                metadata = registration.Metadata;
+                return true;
+            }
+        }
+
+        internal static bool TryGetMetadata(
+            string productId,
+            out CustomProductDefinitionMetadata? metadata)
+        {
+            metadata = null;
+            if (string.IsNullOrWhiteSpace(productId))
+                return false;
+
+            lock (Gate)
+            {
+                if (!Registrations.TryGetValue(productId,
+                        out CustomProductDefinitionRegistration? registration) ||
+                    registration.Metadata == null)
                 {
                     return false;
                 }

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -15,7 +15,7 @@ namespace S1API.Internal.Products
     /// </summary>
     internal sealed class CustomProductManifestData
     {
-        internal const int CurrentProtocolVersion = 1;
+        internal const int CurrentProtocolVersion = 2;
         internal const int MaximumEntryCount = 256;
         internal const int MaximumPayloadLength = 65536;
         internal const int MaximumIdentifierLength = 256;
@@ -26,6 +26,10 @@ namespace S1API.Internal.Products
         public string CompatibilityHash = string.Empty;
         public CustomProductManifestEntryData[] Entries =
             Array.Empty<CustomProductManifestEntryData>();
+        public CustomProductMixingProfileManifestEntryData[] MixingProfiles =
+            Array.Empty<CustomProductMixingProfileManifestEntryData>();
+        public CustomProductSaveDescriptorData[] GeneratedDescriptors =
+            Array.Empty<CustomProductSaveDescriptorData>();
 
         internal static CustomProductManifestData Create(
             IEnumerable<CustomProductDefinitionRegistration> registrations)
@@ -57,11 +61,27 @@ namespace S1API.Internal.Products
                     "The custom-product manifest exceeds the supported product count.");
             }
 
+            ProductMixingProfile[] profiles = ProductMixingProfileRegistry.Snapshot();
+            var profileEntries = new List<CustomProductMixingProfileManifestEntryData>(profiles.Length);
+            for (int i = 0; i < profiles.Length; i++)
+                profileEntries.Add(CustomProductMixingProfileManifestEntryData.Create(profiles[i]));
+            profileEntries.Sort(CustomProductMixingProfileManifestEntryData.Compare);
+
+            var generatedDescriptors = new List<CustomProductSaveDescriptorData>();
+            foreach (CustomProductDefinitionRegistration registration in registrations)
+            {
+                if (registration.SaveDescriptor != null && registration.SaveDescriptor.IsGeneratedMix)
+                    generatedDescriptors.Add(registration.SaveDescriptor);
+            }
+            generatedDescriptors.Sort((left, right) => StringComparer.OrdinalIgnoreCase.Compare(left.ProductId, right.ProductId));
+
             var result = new CustomProductManifestData
             {
-                Entries = entries.ToArray()
+                Entries = entries.ToArray(),
+                MixingProfiles = profileEntries.ToArray(),
+                GeneratedDescriptors = generatedDescriptors.ToArray()
             };
-            result.CompatibilityHash = ComputeManifestHash(result.Entries);
+            result.CompatibilityHash = ComputeManifestHash(result.Entries, result.MixingProfiles);
             return result;
         }
 
@@ -75,7 +95,9 @@ namespace S1API.Internal.Products
                 ProtocolVersion = ProtocolVersion,
                 SessionId = sessionId,
                 CompatibilityHash = CompatibilityHash,
-                Entries = Entries
+                Entries = Entries,
+                MixingProfiles = MixingProfiles,
+                GeneratedDescriptors = GeneratedDescriptors
             };
             string payload = JsonConvert.SerializeObject(snapshot, Formatting.None);
             if (payload.Length > MaximumPayloadLength ||
@@ -149,11 +171,39 @@ namespace S1API.Internal.Products
                 manifest.ProtocolVersion != CurrentProtocolVersion ||
                 !IsSessionId(manifest.SessionId) ||
                 !IsHash(manifest.CompatibilityHash) ||
-                manifest.Entries == null ||
-                manifest.Entries.Length > MaximumEntryCount)
+                manifest.Entries == null || manifest.MixingProfiles == null ||
+                manifest.GeneratedDescriptors == null ||
+                manifest.Entries.Length > MaximumEntryCount ||
+                manifest.MixingProfiles.Length > MaximumEntryCount ||
+                manifest.GeneratedDescriptors.Length > MaximumEntryCount)
             {
                 failure = "manifest protocol, session, hash, or entry count is invalid";
                 return false;
+            }
+
+            var profileKinds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < manifest.MixingProfiles.Length; i++)
+            {
+                if (!manifest.MixingProfiles[i].IsValid() ||
+                    !profileKinds.Add(manifest.MixingProfiles[i].ProductKindId) ||
+                    (i > 0 && CustomProductMixingProfileManifestEntryData.Compare(
+                        manifest.MixingProfiles[i - 1], manifest.MixingProfiles[i]) >= 0))
+                {
+                    failure = "manifest contains an invalid or duplicate mixing profile";
+                    return false;
+                }
+            }
+
+            var generatedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (int i = 0; i < manifest.GeneratedDescriptors.Length; i++)
+            {
+                CustomProductSaveDescriptorData descriptor = manifest.GeneratedDescriptors[i];
+                if (!descriptor.IsGeneratedMix || !generatedIds.Add(descriptor.ProductId) ||
+                    !CustomProductSavePersistence.IsNetworkGeneratedDescriptorValid(descriptor))
+                {
+                    failure = "manifest contains an invalid generated descriptor";
+                    return false;
+                }
             }
 
             var productIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -176,7 +226,7 @@ namespace S1API.Internal.Products
 
             if (!string.Equals(
                     manifest.CompatibilityHash,
-                    ComputeManifestHash(entries),
+                    ComputeManifestHash(entries, manifest.MixingProfiles),
                     StringComparison.Ordinal))
             {
                 failure = "manifest compatibility hash is invalid";
@@ -189,10 +239,21 @@ namespace S1API.Internal.Products
         internal static string ComputeManifestHash(
             IReadOnlyList<CustomProductManifestEntryData> entries)
         {
+            return ComputeManifestHash(entries,
+                Array.Empty<CustomProductMixingProfileManifestEntryData>());
+        }
+
+        internal static string ComputeManifestHash(
+            IReadOnlyList<CustomProductManifestEntryData> entries,
+            IReadOnlyList<CustomProductMixingProfileManifestEntryData> mixingProfiles)
+        {
             var builder = new StringBuilder();
             builder.Append(CurrentProtocolVersion).Append('|');
             for (int i = 0; i < entries.Count; i++)
                 entries[i].AppendCanonical(builder, includeHash: true);
+            builder.Append("profiles|");
+            for (int i = 0; i < mixingProfiles.Count; i++)
+                mixingProfiles[i].AppendCanonical(builder);
 
             return ComputeHash(builder.ToString());
         }
@@ -226,6 +287,22 @@ namespace S1API.Internal.Products
                 return "local content is missing host product '" + host.Entries[hostIndex].ProductId + "'";
             if (localIndex < local.Entries.Length)
                 return "local product '" + local.Entries[localIndex].ProductId + "' is not registered by the host";
+
+            int profileIndex = 0;
+            while (profileIndex < host.MixingProfiles.Length && profileIndex < local.MixingProfiles.Length)
+            {
+                CustomProductMixingProfileManifestEntryData hostProfile = host.MixingProfiles[profileIndex];
+                CustomProductMixingProfileManifestEntryData localProfile = local.MixingProfiles[profileIndex];
+                if (CustomProductMixingProfileManifestEntryData.Compare(hostProfile, localProfile) != 0)
+                    return "mixing profile registrations differ";
+                string? profileFailure = hostProfile.DescribeMismatch(localProfile);
+                if (profileFailure != null)
+                    return "mixing profile '" + hostProfile.ProductKindId + "' " + profileFailure;
+                profileIndex++;
+            }
+
+            if (profileIndex < host.MixingProfiles.Length || profileIndex < local.MixingProfiles.Length)
+                return "mixing profile registrations differ";
             return "manifest hash differs despite matching scalar identities";
         }
 
@@ -319,7 +396,7 @@ namespace S1API.Internal.Products
                 ProductId = registration.ProductId,
                 OwnerId = registration.OwnerId,
                 ProductKindId = metadata.ProductKind.Id,
-                CompatibilityDrugType = (int)metadata.ProductKind.CompatibilityDrugType!.Value,
+                CompatibilityDrugType = descriptor.CompatibilityDrugType,
                 DescriptorFormatVersion = descriptor.FormatVersion,
                 ProviderId = descriptor.ProviderId,
                 ProviderVersion = descriptor.ProviderVersion,
@@ -478,6 +555,8 @@ namespace S1API.Internal.Products
             Append(builder, descriptor.DefaultQuality.ToString(CultureInfo.InvariantCulture));
             Append(builder, descriptor.PlayerEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
             Append(builder, descriptor.NpcEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
+            for (int i = 0; i < descriptor.PropertyIds.Length; i++)
+                AppendIdentifier(builder, descriptor.PropertyIds[i]);
             // Provider data remains local; only its deterministic digest participates in compatibility.
             Append(builder, CustomProductManifestData.ComputeHash(descriptor.ProviderData));
             return CustomProductManifestData.ComputeHash(builder.ToString());

--- a/S1API/Internal/Products/CustomProductManifestRuntime.cs
+++ b/S1API/Internal/Products/CustomProductManifestRuntime.cs
@@ -150,7 +150,8 @@ namespace S1API.Internal.Products
                     _hostPayload = manifest.Serialize(_sessionId);
                     _hostHash = manifest.CompatibilityHash;
                     _hostEntryCount = manifest.Entries.Length;
-                    _hostRequiresValidation = manifest.Entries.Length != 0;
+                    _hostRequiresValidation = manifest.Entries.Length != 0 ||
+                        manifest.MixingProfiles.Length != 0;
                 }
                 catch (Exception exception)
                 {
@@ -182,6 +183,25 @@ namespace S1API.Internal.Products
             {
                 for (int i = 0; i < releasedData.Count; i++)
                     releasedData[i].Invoke();
+            }
+        }
+
+        internal static void RefreshHostManifestIfReady()
+        {
+            lock (Gate)
+            {
+                if (!_hostActive || !_hostManifestReady)
+                    return;
+
+                CustomProductManifestData manifest =
+                    CustomProductDefinitionRegistry.CreateManifest();
+                _hostPayload = manifest.Serialize(_sessionId);
+                _hostHash = manifest.CompatibilityHash;
+                _hostEntryCount = manifest.Entries.Length;
+                _hostRequiresValidation = manifest.Entries.Length != 0 ||
+                    manifest.MixingProfiles.Length != 0;
+                Info("host manifest refreshed after dynamic custom-product registration; entries=" +
+                    _hostEntryCount);
             }
         }
 
@@ -756,6 +776,29 @@ namespace S1API.Internal.Products
                     return;
                 }
                 localManifest = _localClientManifest;
+            }
+
+            for (int i = 0; i < manifest.GeneratedDescriptors.Length; i++)
+            {
+                if (!CustomProductSavePersistence.TryRestoreGeneratedDescriptorFromNetwork(
+                        manifest.GeneratedDescriptors[i]))
+                {
+                    RejectClient("generated custom-product descriptor could not be restored safely");
+                    return;
+                }
+            }
+
+            try
+            {
+                localManifest = CustomProductDefinitionRegistry.CreateManifest();
+                lock (Gate)
+                    _localClientManifest = localManifest;
+            }
+            catch (Exception exception)
+            {
+                RejectClient("generated custom-product manifest could not be recreated: " +
+                    exception.GetType().Name);
+                return;
             }
 
             string localHash = localManifest.CompatibilityHash;

--- a/S1API/Internal/Products/CustomProductMixingIdentity.cs
+++ b/S1API/Internal/Products/CustomProductMixingIdentity.cs
@@ -1,0 +1,35 @@
+using System;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Allocates stable IDs after the native mix-name sanitizer has run.</summary>
+    internal static class CustomProductMixingIdentity
+    {
+        internal static string CreateGeneratedProductId(
+            string sourceProductId,
+            string nativeMixId)
+        {
+            string sourceId = ProductKindId.Normalize(sourceProductId, nameof(sourceProductId));
+            if (string.IsNullOrWhiteSpace(nativeMixId))
+                throw new InvalidOperationException("The native mix-name sanitizer produced an empty ID.");
+
+            int separator = sourceId.IndexOf(':');
+            string ownerId = sourceId.Substring(0, separator);
+            string sourceName = sourceId.Substring(separator + 1);
+            string nativeHash = CustomProductManifestData.ComputeHash(nativeMixId);
+            return ProductKindId.Normalize(
+                ownerId + ":mix/" + sourceName + "/" + nativeHash,
+                nameof(nativeMixId));
+        }
+
+        internal static bool IsGeneratedIdForSource(string sourceProductId, string productId)
+        {
+            string sourceId = ProductKindId.Normalize(sourceProductId, nameof(sourceProductId));
+            int separator = sourceId.IndexOf(':');
+            string prefix = sourceId.Substring(0, separator) + ":mix/" +
+                sourceId.Substring(separator + 1) + "/";
+            return productId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductMixingProfileManifestEntryData.cs
+++ b/S1API/Internal/Products/CustomProductMixingProfileManifestEntryData.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Globalization;
+using System.Text;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Scalar compatibility identity for a registered mixing profile.</summary>
+    internal sealed class CustomProductMixingProfileManifestEntryData
+    {
+        public string ProductKindId = string.Empty;
+        public int MixerMap;
+        public string OutputFactoryIdentity = string.Empty;
+        public int OutputFactoryVersion;
+
+        internal static CustomProductMixingProfileManifestEntryData Create(ProductMixingProfile profile) =>
+            new CustomProductMixingProfileManifestEntryData
+            {
+                ProductKindId = profile.ProductKind.Id,
+                MixerMap = (int)profile.MixerMap,
+                OutputFactoryIdentity = profile.OutputFactoryIdentity,
+                OutputFactoryVersion = profile.OutputFactoryVersion
+            };
+
+        internal bool IsValid() =>
+            CustomProductManifestData.IsBoundedIdentifier(ProductKindId) &&
+            Enum.IsDefined(typeof(ProductMixingMap), MixerMap) &&
+            CustomProductManifestData.IsBoundedIdentifier(OutputFactoryIdentity) &&
+            OutputFactoryVersion >= 0;
+
+        internal static int Compare(
+            CustomProductMixingProfileManifestEntryData left,
+            CustomProductMixingProfileManifestEntryData right) =>
+            StringComparer.OrdinalIgnoreCase.Compare(left.ProductKindId, right.ProductKindId);
+
+        internal void AppendCanonical(StringBuilder builder)
+        {
+            builder.Append(ProductKindId.ToUpperInvariant()).Append('|');
+            builder.Append(MixerMap.ToString(CultureInfo.InvariantCulture)).Append('|');
+            builder.Append(OutputFactoryIdentity.ToUpperInvariant()).Append('|');
+            builder.Append(OutputFactoryVersion.ToString(CultureInfo.InvariantCulture)).Append('|');
+        }
+
+        internal string? DescribeMismatch(CustomProductMixingProfileManifestEntryData local)
+        {
+            if (MixerMap != local.MixerMap)
+                return "native mixer-map strategy differs";
+            if (!string.Equals(OutputFactoryIdentity, local.OutputFactoryIdentity, StringComparison.OrdinalIgnoreCase) ||
+                OutputFactoryVersion != local.OutputFactoryVersion)
+            {
+                return "output-factory compatibility identity or version differs";
+            }
+            return null;
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
+++ b/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
@@ -24,6 +24,7 @@ namespace S1API.Internal.Products
         public string? ProviderId;
         public int ProviderVersion;
         public string ProviderData = string.Empty;
+        public bool IsGeneratedMix;
     }
 
     [Serializable]

--- a/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
+++ b/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
@@ -19,6 +19,8 @@ namespace S1API.Internal.Products
         public string RepresentationTemplateId = string.Empty;
         public int PlayerEffectDurationSeconds;
         public int NpcEffectDurationSeconds;
+        public string[] PropertyIds = Array.Empty<string>();
+        public string[] PackagingIds = Array.Empty<string>();
         public string? ProviderId;
         public int ProviderVersion;
         public string ProviderData = string.Empty;

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -180,7 +180,8 @@ namespace S1API.Internal.Products
                 S1Product.ProductDefinition? template = S1Registry.GetItem(data.RepresentationTemplateId) as S1Product.ProductDefinition;
                 if (template == null)
                     throw new InvalidOperationException("the saved vanilla representation template is unavailable");
-                ProductKind kind = ProductKindRegistry.Register(new ProductKind(data.ProductKindId, (DrugType)data.CompatibilityDrugType));
+                ProductKind kind = ProductKindRegistry.Get(data.ProductKindId) ??
+                    ProductKindRegistry.Register(new ProductKind(data.ProductKindId, null));
                 List<NativeEffect> properties = PropertyResolver.ResolveToGamePropertiesById(data.PropertyIds ?? Array.Empty<string>());
                 var packaging = new List<NativePackagingDefinition>();
                 foreach (string packagingId in data.PackagingIds ?? Array.Empty<string>())
@@ -251,6 +252,31 @@ namespace S1API.Internal.Products
                     return false;
             }
             return true;
+        }
+
+        internal static bool TryRestoreGeneratedDescriptorFromNetwork(
+            CustomProductSaveDescriptorData data)
+        {
+            if (!data.IsGeneratedMix || !string.IsNullOrEmpty(data.ProviderId) ||
+                data.ProviderVersion != 0 || !string.IsNullOrEmpty(data.ProviderData) ||
+                !TryValidate(data, out CustomProductSaveDescriptor descriptor))
+            {
+                return false;
+            }
+
+            if (!CustomProductDefinitionRegistry.IsRegistered(descriptor.ProductId))
+                RestoreFallback(descriptor);
+            return CustomProductDefinitionRegistry.IsRegistered(descriptor.ProductId);
+        }
+
+        internal static bool IsNetworkGeneratedDescriptorValid(
+            CustomProductSaveDescriptorData data)
+        {
+            return data != null && data.IsGeneratedMix &&
+                   string.IsNullOrEmpty(data.ProviderId) &&
+                   data.ProviderVersion == 0 &&
+                   string.IsNullOrEmpty(data.ProviderData) &&
+                   TryValidate(data, out _);
         }
         private static void Warn(string message) { try { MelonLoader.MelonLogger.Warning("[CustomProductSave] " + message); } catch { } }
     }

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using S1API.Products;
+using S1API.Internal.Properties;
 
 namespace S1API.Internal.Products
 {
@@ -180,13 +181,25 @@ namespace S1API.Internal.Products
                 if (template == null)
                     throw new InvalidOperationException("the saved vanilla representation template is unavailable");
                 ProductKind kind = ProductKindRegistry.Register(new ProductKind(data.ProductKindId, (DrugType)data.CompatibilityDrugType));
+                List<NativeEffect> properties = PropertyResolver.ResolveToGamePropertiesById(data.PropertyIds ?? Array.Empty<string>());
+                var packaging = new List<NativePackagingDefinition>();
+                foreach (string packagingId in data.PackagingIds ?? Array.Empty<string>())
+                {
+                    NativePackagingDefinition? item = S1Registry.GetItem(packagingId) as NativePackagingDefinition;
+                    if (item == null)
+                        throw new InvalidOperationException("saved packaging '" + packagingId + "' is unavailable");
+                    packaging.Add(item);
+                }
                 var native = CustomProductDefinitionFactory.Create(
                     data.ProductId, data.ProductName, data.Description, data.InitialPrice,
                     (global::S1API.Items.LegalStatus)data.LegalStatus, data.BaseAddictiveness,
                     data.PlayerEffectDurationSeconds, data.NpcEffectDurationSeconds,
-                    (DrugType)data.CompatibilityDrugType, new List<NativeEffect>(),
-                    new List<NativePackagingDefinition>(), template);
-                var metadata = new CustomProductDefinitionMetadata(kind, (Quality)data.DefaultQuality);
+                    (DrugType)data.CompatibilityDrugType, properties,
+                    packaging, template);
+                var packagingMetadata = new List<PackagingDefinition>();
+                foreach (NativePackagingDefinition item in packaging)
+                    packagingMetadata.Add(new PackagingDefinition(item));
+                var metadata = new CustomProductDefinitionMetadata(kind, (Quality)data.DefaultQuality, packagingMetadata, template);
                 try
                 {
                     CustomProductDefinitionRegistry.Register(data.OwnerId, data.ProductId, data.ProductName, data.InitialPrice, native, metadata, data);
@@ -218,7 +231,8 @@ namespace S1API.Internal.Products
                 if (!IsBounded(data.ProductName) || !IsBounded(data.Description) || !IsBounded(data.ProductKindId) || !IsBounded(data.RepresentationTemplateId) ||
                     !float.IsFinite(data.InitialPrice) || !float.IsFinite(data.BaseAddictiveness) || data.InitialPrice < 1 ||
                     data.BaseAddictiveness < 0 || data.BaseAddictiveness > 1 || data.PlayerEffectDurationSeconds < 0 || data.NpcEffectDurationSeconds < 0 ||
-                    !Enum.IsDefined(typeof(global::S1API.Items.LegalStatus), data.LegalStatus) || !Enum.IsDefined(typeof(Quality), data.DefaultQuality) || !Enum.IsDefined(typeof(DrugType), data.CompatibilityDrugType)) return false;
+                    !Enum.IsDefined(typeof(global::S1API.Items.LegalStatus), data.LegalStatus) || !Enum.IsDefined(typeof(Quality), data.DefaultQuality) || !Enum.IsDefined(typeof(DrugType), data.CompatibilityDrugType) ||
+                    !IsBoundedCollection(data.PropertyIds) || !IsBoundedCollection(data.PackagingIds)) return false;
                 string kindId = ProductKindId.Normalize(data.ProductKindId, nameof(data.ProductKindId));
                 ProductKindId.Normalize(data.RepresentationTemplateId, nameof(data.RepresentationTemplateId));
                 descriptor = new CustomProductSaveDescriptor(data.FormatVersion, productId, ownerId, data.ProductName, data.Description, data.InitialPrice, kindId, providerId, data.ProviderVersion, data.ProviderData) { Data = data };
@@ -227,6 +241,17 @@ namespace S1API.Internal.Products
             catch { return false; }
         }
         private static bool IsBounded(string? value) => value != null && value.Length <= MaximumStringLength;
+        private static bool IsBoundedCollection(string[]? values)
+        {
+            if (values == null || values.Length > 32)
+                return false;
+            foreach (string value in values)
+            {
+                if (!IsBounded(value))
+                    return false;
+            }
+            return true;
+        }
         private static void Warn(string message) { try { MelonLoader.MelonLogger.Warning("[CustomProductSave] " + message); } catch { } }
     }
 }

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -188,7 +188,10 @@ namespace S1API.Internal.Products
                 {
                     NativePackagingDefinition? item = S1Registry.GetItem(packagingId) as NativePackagingDefinition;
                     if (item == null)
-                        throw new InvalidOperationException("saved packaging '" + packagingId + "' is unavailable");
+                    {
+                        Warn("saved packaging '" + packagingId + "' is unavailable; restoring the product without that packaging");
+                        continue;
+                    }
                     packaging.Add(item);
                 }
                 var native = CustomProductDefinitionFactory.Create(

--- a/S1API/Internal/Products/ProductMixingMapContract.cs
+++ b/S1API/Internal/Products/ProductMixingMapContract.cs
@@ -1,0 +1,26 @@
+using System;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Resolves a selected native mixer-map strategy.</summary>
+    internal static class ProductMixingMapContract
+    {
+        internal static DrugType GetNativeDrugType(ProductMixingMap mixerMap)
+        {
+            switch (mixerMap)
+            {
+                case ProductMixingMap.Marijuana:
+                    return DrugType.Marijuana;
+                case ProductMixingMap.Methamphetamine:
+                    return DrugType.Methamphetamine;
+                case ProductMixingMap.Cocaine:
+                    return DrugType.Cocaine;
+                case ProductMixingMap.Shrooms:
+                    return DrugType.Shrooms;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mixerMap));
+            }
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductMixingProfileRegistry.cs
+++ b/S1API/Internal/Products/ProductMixingProfileRegistry.cs
@@ -18,7 +18,10 @@ namespace S1API.Internal.Products
                     Profiles.Add(profile.ProductKind.Id, profile);
                     return profile;
                 }
-                if (existing.MixerMap == profile.MixerMap && ReferenceEquals(existing.OutputFactory, profile.OutputFactory))
+                if (existing.MixerMap == profile.MixerMap &&
+                    ReferenceEquals(existing.OutputFactory, profile.OutputFactory) &&
+                    string.Equals(existing.OutputFactoryIdentity, profile.OutputFactoryIdentity, StringComparison.OrdinalIgnoreCase) &&
+                    existing.OutputFactoryVersion == profile.OutputFactoryVersion)
                     return existing;
                 throw new InvalidOperationException("A conflicting mixing profile is already registered for product kind '" + profile.ProductKind.Id + "'.");
             }
@@ -35,6 +38,16 @@ namespace S1API.Internal.Products
         {
             lock (Gate)
                 Profiles.Clear();
+        }
+
+        internal static ProductMixingProfile[] Snapshot()
+        {
+            lock (Gate)
+            {
+                var snapshot = new ProductMixingProfile[Profiles.Count];
+                Profiles.Values.CopyTo(snapshot, 0);
+                return snapshot;
+            }
         }
     }
 }

--- a/S1API/Internal/Products/ProductMixingProfileRegistry.cs
+++ b/S1API/Internal/Products/ProductMixingProfileRegistry.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal static class ProductMixingProfileRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, ProductMixingProfile> Profiles = new Dictionary<string, ProductMixingProfile>(StringComparer.OrdinalIgnoreCase);
+
+        internal static ProductMixingProfile Register(ProductMixingProfile profile)
+        {
+            lock (Gate)
+            {
+                if (!Profiles.TryGetValue(profile.ProductKind.Id, out ProductMixingProfile? existing))
+                {
+                    Profiles.Add(profile.ProductKind.Id, profile);
+                    return profile;
+                }
+                if (existing.MixerMap == profile.MixerMap && ReferenceEquals(existing.OutputFactory, profile.OutputFactory))
+                    return existing;
+                throw new InvalidOperationException("A conflicting mixing profile is already registered for product kind '" + profile.ProductKind.Id + "'.");
+            }
+        }
+
+        internal static bool TryGet(string productKindId, out ProductMixingProfile? profile)
+        {
+            string normalized = ProductKindId.Normalize(productKindId, nameof(productKindId));
+            lock (Gate)
+                return Profiles.TryGetValue(normalized, out profile);
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+                Profiles.Clear();
+        }
+    }
+}

--- a/S1API/Internal/Properties/PropertyResolver.cs
+++ b/S1API/Internal/Properties/PropertyResolver.cs
@@ -55,6 +55,27 @@ namespace S1API.Internal.Properties
             return results;
         }
 
+        internal static List<S1Properties.Effect> ResolveToGamePropertiesById(IEnumerable<string> ids)
+        {
+            var results = new List<S1Properties.Effect>();
+            if (ids == null)
+                return results;
+
+            foreach (string id in ids)
+            {
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
+                S1Properties.Effect? effect = null;
+                if (!CustomEffectRegistry.TryGetExisting(id, out effect))
+                    effect = FindByIdOrName(id, string.Empty);
+                if (effect != null && !results.Contains(effect))
+                    results.Add(effect);
+            }
+
+            return results;
+        }
+
         private static S1Properties.Effect? FindByIdOrName(string id, string unityName)
         {
             var idNorm = (id ?? string.Empty).Trim();

--- a/S1API/Products/CustomProductDefinitionBuilder.cs
+++ b/S1API/Products/CustomProductDefinitionBuilder.cs
@@ -57,6 +57,7 @@ namespace S1API.Products
         private ProductDefinition? _representationTemplate;
         private int? _playerEffectDurationSeconds;
         private int? _npcEffectDurationSeconds;
+        private ProductMixingMap? _nativeMixerMap;
         private string? _saveProviderId;
         private int _saveProviderVersion;
         private string _saveProviderData = string.Empty;
@@ -310,6 +311,24 @@ namespace S1API.Products
         }
 
         /// <summary>
+        /// Selects the native product family used to execute a generic custom product.
+        /// </summary>
+        /// <remarks>
+        /// This is an explicit runtime strategy, not logical-kind metadata. It lets a product
+        /// kind with no vanilla <see cref="DrugType"/> use a supported native product and mixer
+        /// implementation without changing that kind's identity.
+        /// </remarks>
+        public CustomProductDefinitionBuilder WithNativeMixerMap(ProductMixingMap mixerMap)
+        {
+            EnsureMutable();
+            if (!Enum.IsDefined(typeof(ProductMixingMap), mixerMap))
+                throw new ArgumentOutOfRangeException(nameof(mixerMap));
+
+            _nativeMixerMap = mixerMap;
+            return this;
+        }
+
+        /// <summary>
         /// Associates this definition with a process-registered provider that can recreate it on a
         /// fresh-process save load.
         /// </summary>
@@ -371,13 +390,16 @@ namespace S1API.Products
                     "WithRepresentationsFrom must be called before Build().");
             }
 
-            if (!_productKind.CompatibilityDrugType.HasValue)
+            if (!_productKind.CompatibilityDrugType.HasValue && !_nativeMixerMap.HasValue)
             {
                 throw new InvalidOperationException(
                     $"Product kind '{_productKind.Id}' does not define a compatibility drug type. " +
-                    "Generic products require ProductKindBuilder.WithCompatibilityDrugType(...) " +
-                    "for native save and product-item data.");
+                    "Configure WithNativeMixerMap(...) to select an explicit native execution strategy.");
             }
+
+            DrugType nativeDrugType = _nativeMixerMap.HasValue
+                ? ProductMixingMapContract.GetNativeDrugType(_nativeMixerMap.Value)
+                : _productKind.CompatibilityDrugType!.Value;
 
             List<NativeEffect> resolvedProperties =
                 PropertyResolver.ResolveToGameProperties(_properties);
@@ -416,7 +438,7 @@ namespace S1API.Products
                     _representationTemplate.S1ProductDefinition.PlayerEffectDuration,
                 _npcEffectDurationSeconds ??
                     _representationTemplate.S1ProductDefinition.NPCEffectDuration,
-                _productKind.CompatibilityDrugType.Value,
+                nativeDrugType,
                 resolvedProperties,
                 nativePackaging,
                 _representationTemplate.S1ProductDefinition);
@@ -445,7 +467,7 @@ namespace S1API.Products
                 BaseAddictiveness = _baseAddictiveness,
                 DefaultQuality = (int)_defaultQuality,
                 ProductKindId = _productKind.Id,
-                CompatibilityDrugType = (int)_productKind.CompatibilityDrugType.Value,
+                CompatibilityDrugType = (int)nativeDrugType,
                 RepresentationTemplateId = _representationTemplate.ID,
                 PlayerEffectDurationSeconds = _playerEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.PlayerEffectDuration,
                 NpcEffectDurationSeconds = _npcEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.NPCEffectDuration,

--- a/S1API/Products/CustomProductDefinitionBuilder.cs
+++ b/S1API/Products/CustomProductDefinitionBuilder.cs
@@ -449,6 +449,8 @@ namespace S1API.Products
                 RepresentationTemplateId = _representationTemplate.ID,
                 PlayerEffectDurationSeconds = _playerEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.PlayerEffectDuration,
                 NpcEffectDurationSeconds = _npcEffectDurationSeconds ?? _representationTemplate.S1ProductDefinition.NPCEffectDuration,
+                PropertyIds = resolvedProperties.ConvertAll(property => property.ID).ToArray(),
+                PackagingIds = _validPackaging.ConvertAll(packaging => packaging.ID).ToArray(),
                 ProviderId = _saveProviderId,
                 ProviderVersion = _saveProviderVersion,
                 ProviderData = _saveProviderData

--- a/S1API/Products/ProductMixingMap.cs
+++ b/S1API/Products/ProductMixingMap.cs
@@ -1,0 +1,17 @@
+namespace S1API.Products
+{
+    /// <summary>
+    /// Identifies one of the game-supported mixer-map families.
+    /// </summary>
+    /// <remarks>
+    /// This is a map-selection value, not a logical product-kind identity and it never creates a
+    /// synthetic native drug-type value.
+    /// </remarks>
+    public enum ProductMixingMap
+    {
+        Marijuana,
+        Methamphetamine,
+        Cocaine,
+        Shrooms
+    }
+}

--- a/S1API/Products/ProductMixingOutput.cs
+++ b/S1API/Products/ProductMixingOutput.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Supplies deterministic, runtime-independent input to a custom mixing-output factory.
+    /// </summary>
+    public sealed class ProductMixingOutput
+    {
+        internal ProductMixingOutput(string outputId, string mixName, string sourceProductId, ProductKind sourceKind, float sourcePrice)
+        {
+            OutputId = outputId;
+            MixName = mixName;
+            SourceProductId = sourceProductId;
+            SourceKind = sourceKind;
+            SourcePrice = sourcePrice;
+        }
+
+        /// <summary>Gets the stable ID allocated by the native mixing flow.</summary>
+        public string OutputId { get; }
+        /// <summary>Gets the player-selected display name for the output.</summary>
+        public string MixName { get; }
+        /// <summary>Gets the source custom-product ID.</summary>
+        public string SourceProductId { get; }
+        /// <summary>Gets the source logical product kind.</summary>
+        public ProductKind SourceKind { get; }
+        /// <summary>Gets the source product's current base price.</summary>
+        public float SourcePrice { get; }
+    }
+}

--- a/S1API/Products/ProductMixingOutputDefinition.cs
+++ b/S1API/Products/ProductMixingOutputDefinition.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Describes the logical identity and price of a generated custom mixed product.
+    /// </summary>
+    public sealed class ProductMixingOutputDefinition
+    {
+        /// <summary>Creates an output definition.</summary>
+        /// <param name="name">The non-empty output name.</param>
+        /// <param name="productKind">The logical kind of the generated output.</param>
+        /// <param name="price">The finite generated-output price.</param>
+        public ProductMixingOutputDefinition(string name, ProductKind productKind, float price)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Output name cannot be empty or whitespace.", nameof(name));
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+            if (float.IsNaN(price) || float.IsInfinity(price) || price < 1f || price > 999f)
+                throw new ArgumentOutOfRangeException(nameof(price), "Output price must be finite and within the native 1 through 999 range.");
+
+            Name = name.Trim();
+            ProductKind = productKind;
+            Price = price;
+        }
+
+        /// <summary>Gets the generated display name.</summary>
+        public string Name { get; }
+        /// <summary>Gets the explicit output logical kind.</summary>
+        public ProductKind ProductKind { get; }
+        /// <summary>Gets the generated price.</summary>
+        public float Price { get; }
+    }
+}

--- a/S1API/Products/ProductMixingProfile.cs
+++ b/S1API/Products/ProductMixingProfile.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Opts a logical product kind into native mixing with a supported map and deterministic output factory.
+    /// </summary>
+    public sealed class ProductMixingProfile
+    {
+        internal ProductMixingProfile(ProductKind productKind, ProductMixingMap mixerMap, Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory)
+        {
+            ProductKind = productKind;
+            MixerMap = mixerMap;
+            OutputFactory = outputFactory;
+        }
+
+        /// <summary>Gets the opted-in logical product kind.</summary>
+        public ProductKind ProductKind { get; }
+        /// <summary>Gets the supported native mixer-map family selected for this kind.</summary>
+        public ProductMixingMap MixerMap { get; }
+        internal Func<ProductMixingOutput, ProductMixingOutputDefinition> OutputFactory { get; }
+    }
+}

--- a/S1API/Products/ProductMixingProfile.cs
+++ b/S1API/Products/ProductMixingProfile.cs
@@ -3,21 +3,27 @@ using System;
 namespace S1API.Products
 {
     /// <summary>
-    /// Opts a logical product kind into native mixing with a supported map and deterministic output factory.
+    /// Opts a logical product kind into native mixing through an explicit native map strategy.
     /// </summary>
     public sealed class ProductMixingProfile
     {
-        internal ProductMixingProfile(ProductKind productKind, ProductMixingMap mixerMap, Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory)
+        internal ProductMixingProfile(ProductKind productKind, ProductMixingMap mixerMap, Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory, string outputFactoryIdentity, int outputFactoryVersion)
         {
             ProductKind = productKind;
             MixerMap = mixerMap;
             OutputFactory = outputFactory;
+            OutputFactoryIdentity = outputFactoryIdentity;
+            OutputFactoryVersion = outputFactoryVersion;
         }
 
         /// <summary>Gets the opted-in logical product kind.</summary>
         public ProductKind ProductKind { get; }
-        /// <summary>Gets the supported native mixer-map family selected for this kind.</summary>
+        /// <summary>Gets the native mixer-map execution strategy selected for this logical kind.</summary>
         public ProductMixingMap MixerMap { get; }
+        /// <summary>Gets the stable identity used to compare output-factory behavior across peers.</summary>
+        public string OutputFactoryIdentity { get; }
+        /// <summary>Gets the output-factory compatibility version used across peers.</summary>
+        public int OutputFactoryVersion { get; }
         internal Func<ProductMixingOutput, ProductMixingOutputDefinition> OutputFactory { get; }
     }
 }

--- a/S1API/Products/ProductMixingProfileBuilder.cs
+++ b/S1API/Products/ProductMixingProfileBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Builds and registers an opt-in mixing profile for one logical product kind.
+    /// </summary>
+    public sealed class ProductMixingProfileBuilder
+    {
+        private readonly ProductKind _productKind;
+        private ProductMixingMap _mixerMap;
+        private Func<ProductMixingOutput, ProductMixingOutputDefinition>? _outputFactory;
+
+        /// <summary>Creates a profile builder for a registered logical product kind.</summary>
+        public ProductMixingProfileBuilder(ProductKind productKind)
+        {
+            _productKind = productKind ?? throw new ArgumentNullException(nameof(productKind));
+        }
+
+        /// <summary>Sets the supported native mixer-map family.</summary>
+        public ProductMixingProfileBuilder WithMixerMap(ProductMixingMap mixerMap)
+        {
+            if (!Enum.IsDefined(typeof(ProductMixingMap), mixerMap))
+                throw new ArgumentOutOfRangeException(nameof(mixerMap));
+            _mixerMap = mixerMap;
+            return this;
+        }
+
+        /// <summary>Sets the deterministic factory used to name, price, and optionally transform generated outputs.</summary>
+        public ProductMixingProfileBuilder WithOutputFactory(Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory)
+        {
+            _outputFactory = outputFactory ?? throw new ArgumentNullException(nameof(outputFactory));
+            return this;
+        }
+
+        /// <summary>Registers this immutable profile.</summary>
+        public ProductMixingProfile Build()
+        {
+            if (_outputFactory == null)
+                throw new InvalidOperationException("WithOutputFactory must be called before Build().");
+            if (!_productKind.CompatibilityDrugType.HasValue)
+                throw new InvalidOperationException("A mixing profile requires a product kind with a compatibility drug type.");
+            if (_productKind.CompatibilityDrugType.Value != GetCompatibilityDrugType(_mixerMap))
+            {
+                throw new InvalidOperationException(
+                    "The selected mixer map must match the product kind's compatibility drug type. " +
+                    "This keeps custom logical kinds out of unsupported native enum switches.");
+            }
+            return ProductMixingProfileRegistry.Register(new ProductMixingProfile(_productKind, _mixerMap, _outputFactory));
+        }
+
+        private static DrugType GetCompatibilityDrugType(ProductMixingMap mixerMap)
+        {
+            switch (mixerMap)
+            {
+                case ProductMixingMap.Marijuana:
+                    return DrugType.Marijuana;
+                case ProductMixingMap.Methamphetamine:
+                    return DrugType.Methamphetamine;
+                case ProductMixingMap.Cocaine:
+                    return DrugType.Cocaine;
+                case ProductMixingMap.Shrooms:
+                    return DrugType.Shrooms;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mixerMap));
+            }
+        }
+    }
+}

--- a/S1API/Products/ProductMixingProfileBuilder.cs
+++ b/S1API/Products/ProductMixingProfileBuilder.cs
@@ -11,6 +11,8 @@ namespace S1API.Products
         private readonly ProductKind _productKind;
         private ProductMixingMap _mixerMap;
         private Func<ProductMixingOutput, ProductMixingOutputDefinition>? _outputFactory;
+        private string? _outputFactoryIdentity;
+        private int _outputFactoryVersion;
 
         /// <summary>Creates a profile builder for a registered logical product kind.</summary>
         public ProductMixingProfileBuilder(ProductKind productKind)
@@ -18,7 +20,13 @@ namespace S1API.Products
             _productKind = productKind ?? throw new ArgumentNullException(nameof(productKind));
         }
 
-        /// <summary>Sets the supported native mixer-map family.</summary>
+        /// <summary>
+        /// Sets the native mixer-map execution strategy.
+        /// </summary>
+        /// <remarks>
+        /// This does not alter the logical product kind or require it to have a matching vanilla
+        /// drug type. The selected map is only the explicit native seam used while mixing.
+        /// </remarks>
         public ProductMixingProfileBuilder WithMixerMap(ProductMixingMap mixerMap)
         {
             if (!Enum.IsDefined(typeof(ProductMixingMap), mixerMap))
@@ -34,37 +42,42 @@ namespace S1API.Products
             return this;
         }
 
+        /// <summary>
+        /// Sets the stable compatibility identity for the configured output factory.
+        /// </summary>
+        /// <remarks>
+        /// Register the same identity and version on every peer. This identity is included in the
+        /// multiplayer manifest so different output behavior is rejected before a mix can diverge.
+        /// </remarks>
+        public ProductMixingProfileBuilder WithOutputFactoryCompatibility(
+            string identity,
+            int version)
+        {
+            if (string.IsNullOrWhiteSpace(identity))
+                throw new ArgumentException("Output-factory compatibility identity cannot be empty or whitespace.", nameof(identity));
+            if (version < 0)
+                throw new ArgumentOutOfRangeException(nameof(version));
+
+            _outputFactoryIdentity = ProductKindId.Normalize(identity, nameof(identity));
+            _outputFactoryVersion = version;
+            return this;
+        }
+
         /// <summary>Registers this immutable profile.</summary>
         public ProductMixingProfile Build()
         {
             if (_outputFactory == null)
                 throw new InvalidOperationException("WithOutputFactory must be called before Build().");
-            if (!_productKind.CompatibilityDrugType.HasValue)
-                throw new InvalidOperationException("A mixing profile requires a product kind with a compatibility drug type.");
-            if (_productKind.CompatibilityDrugType.Value != GetCompatibilityDrugType(_mixerMap))
-            {
-                throw new InvalidOperationException(
-                    "The selected mixer map must match the product kind's compatibility drug type. " +
-                    "This keeps custom logical kinds out of unsupported native enum switches.");
-            }
-            return ProductMixingProfileRegistry.Register(new ProductMixingProfile(_productKind, _mixerMap, _outputFactory));
-        }
-
-        private static DrugType GetCompatibilityDrugType(ProductMixingMap mixerMap)
-        {
-            switch (mixerMap)
-            {
-                case ProductMixingMap.Marijuana:
-                    return DrugType.Marijuana;
-                case ProductMixingMap.Methamphetamine:
-                    return DrugType.Methamphetamine;
-                case ProductMixingMap.Cocaine:
-                    return DrugType.Cocaine;
-                case ProductMixingMap.Shrooms:
-                    return DrugType.Shrooms;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mixerMap));
-            }
+            string compatibilityIdentity = _outputFactoryIdentity ??
+                "s1api:factory/" + CustomProductManifestData.ComputeHash(
+                    (_outputFactory.Method.DeclaringType?.AssemblyQualifiedName ?? string.Empty) +
+                    "|" + _outputFactory.Method.Name);
+            return ProductMixingProfileRegistry.Register(new ProductMixingProfile(
+                _productKind,
+                _mixerMap,
+                _outputFactory,
+                compatibilityIdentity,
+                _outputFactoryVersion));
         }
     }
 }

--- a/S1API/Products/ProductMixingProfiles.cs
+++ b/S1API/Products/ProductMixingProfiles.cs
@@ -1,0 +1,29 @@
+using System;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Provides lookup for opt-in custom product mixing profiles.
+    /// </summary>
+    public static class ProductMixingProfiles
+    {
+        /// <summary>Gets a profile for a logical product kind, or null when mixing was not opted in.</summary>
+        public static ProductMixingProfile? Get(ProductKind productKind)
+        {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+            return Get(productKind.Id);
+        }
+
+        /// <summary>Gets a profile by logical product-kind ID, or null when mixing was not opted in.</summary>
+        public static ProductMixingProfile? Get(string productKindId)
+        {
+            ProductMixingProfileRegistry.TryGet(productKindId, out ProductMixingProfile? profile);
+            return profile;
+        }
+
+        internal static bool TryGet(string productKindId, out ProductMixingProfile? profile) =>
+            ProductMixingProfileRegistry.TryGet(productKindId, out profile);
+    }
+}

--- a/S1API/Products/ProductPackagingContentProfileRegistry.cs
+++ b/S1API/Products/ProductPackagingContentProfileRegistry.cs
@@ -18,6 +18,10 @@ namespace S1API.Products
             ProductPackagingContentProfileRegistration> Registrations =
                 new Dictionary<ProductPackagingContentKey,
                     ProductPackagingContentProfileRegistration>();
+        private static readonly Dictionary<ProductPackagingContentKey,
+            ProductPackagingContentProfileRegistration> KindRegistrations =
+                new Dictionary<ProductPackagingContentKey,
+                    ProductPackagingContentProfileRegistration>();
 
         /// <summary>
         /// Registers content for one stable product and packaging pair.
@@ -93,6 +97,47 @@ namespace S1API.Products
             }
         }
 
+        /// <summary>
+        /// Registers packaging content as a fallback for every custom product of one logical kind.
+        /// </summary>
+        /// <remarks>
+        /// A product-specific registration still wins. This fallback is useful for generated mixes,
+        /// whose stable product IDs are allocated by the native mixing lifecycle.
+        /// </remarks>
+        public static ProductPackagingContentProfile RegisterForProductKind(
+            string ownerId,
+            string productKindId,
+            string packagingId,
+            ProductPackagingContentProfile profile)
+        {
+            string normalizedOwnerId = NormalizeRequired(ownerId, nameof(ownerId));
+            string normalizedKindId = ProductKindId.Normalize(productKindId, nameof(productKindId));
+            string normalizedPackagingId = NormalizeRequired(packagingId, nameof(packagingId));
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+
+            var key = new ProductPackagingContentKey(normalizedKindId, normalizedPackagingId);
+            lock (Gate)
+            {
+                if (KindRegistrations.TryGetValue(key, out ProductPackagingContentProfileRegistration? existing))
+                {
+                    if (!string.Equals(existing.OwnerId, normalizedOwnerId, StringComparison.OrdinalIgnoreCase) ||
+                        !ReferenceEquals(existing.Profile, profile))
+                    {
+                        throw new InvalidOperationException(
+                            $"Packaging content fallback for logical kind '{normalizedKindId}' and packaging " +
+                            $"'{normalizedPackagingId}' is already registered.");
+                    }
+
+                    return existing.Profile;
+                }
+
+                KindRegistrations.Add(key, new ProductPackagingContentProfileRegistration(
+                    normalizedOwnerId, key, profile));
+                return profile;
+            }
+        }
+
         internal static bool TryResolve(
             string productId,
             string packagingId,
@@ -100,13 +145,42 @@ namespace S1API.Products
         {
             var key = new ProductPackagingContentKey(productId, packagingId);
             lock (Gate)
-                return Registrations.TryGetValue(key, out registration);
+            {
+                if (Registrations.TryGetValue(key, out registration))
+                    return true;
+            }
+
+            if (CustomProductDefinitionRegistry.TryGetMetadata(productId,
+                    out CustomProductDefinitionMetadata? metadata) &&
+                metadata != null)
+            {
+                return TryResolveForProductKind(
+                    metadata.ProductKind.Id,
+                    packagingId,
+                    out registration);
+            }
+
+            registration = null;
+            return false;
+        }
+
+        internal static bool TryResolveForProductKind(
+            string productKindId,
+            string packagingId,
+            out ProductPackagingContentProfileRegistration? registration)
+        {
+            var key = new ProductPackagingContentKey(productKindId, packagingId);
+            lock (Gate)
+                return KindRegistrations.TryGetValue(key, out registration);
         }
 
         internal static void ResetForTesting()
         {
             lock (Gate)
+            {
                 Registrations.Clear();
+                KindRegistrations.Clear();
+            }
             ProductPackagingContentRuntime.ResetForSceneChange();
         }
 

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -68,10 +68,10 @@ GameLifecycle.OnPreLoad += () =>
 };
 ```
 
-The compatibility drug type is required because the native generic
-`ProductDefinition` save representation expects one. It does not turn the
-logical kind into a native enum member, native family definition, or mixable
-product.
+The compatibility drug type remains optional metadata. A generic product needs
+a native execution representation: use compatibility metadata when it is
+appropriate, or explicitly select `WithNativeMixerMap(...)` for a logical kind
+that has no base-game enum. Neither option changes the logical kind's identity.
 
 To give the logical kind a Product Manager section, separately register
 [`ProductKindMetadata`](product-kinds.md#register-presentation-and-product-manager-metadata).
@@ -474,9 +474,8 @@ Not supported:
 - automatic arbitrary renamed-ID migration or recovery of content assets from a
   removed mod.
 
-Do not place a generic custom product in native mixing flows. The compatibility
-drug type only satisfies native product-item and save assumptions; S1API does
-not register mix recipes or generated outputs for this definition.
+Generic products remain non-mixable until they explicitly register a
+`ProductMixingProfile`. See the mixing guide for the supported opt-in boundary.
 
 ## Compatibility
 

--- a/S1API/docs/mixing-ingredients.md
+++ b/S1API/docs/mixing-ingredients.md
@@ -3,6 +3,42 @@
 Create custom mixing ingredients (the additives you drop into the Mixing Station),
 custom effects (drug properties), and mixing reactions between them.
 
+## Opting a custom logical kind into mixing
+
+`ProductMixingProfile` opts one logical `ProductKind` into the native mixing
+lifecycle. `ProductMixingMap` is an explicit native execution strategy, not a
+logical-kind alias: the output preserves the logical kind selected by the
+factory. This supports mod-created kinds with no game enum as well as kinds
+whose optional compatibility metadata is MDMA or another dormant enum.
+
+The input generic product must use the same explicit native map through
+`CustomProductDefinitionBuilder.WithNativeMixerMap(...)`; otherwise S1API
+rejects the mix before the unsupported native switch. Do not cast or invent
+native enum values.
+
+```csharp
+var kind = new ProductKindBuilder("moredrugs:mdma").Build();
+
+var profile = new ProductMixingProfileBuilder(kind)
+    .WithMixerMap(ProductMixingMap.Cocaine)
+    .WithOutputFactoryCompatibility("moredrugs:mdma-mixing", 1)
+    .WithOutputFactory(input => new ProductMixingOutputDefinition(
+        input.MixName, input.SourceKind, input.SourcePrice + 10f))
+    .Build();
+```
+
+Use the same output-factory compatibility identity and version on every peer.
+S1API includes it and the selected map in the multiplayer manifest, rejects a
+mismatch before player data, and transports scalar descriptors for mixes created
+after the host session starts so late joins and reconnects recreate them.
+
+Generated product IDs are allocated only after the native mix-name sanitizer
+has finished, then namespaced deterministically by source product and sanitized
+native ID. Saves and FishNet RPCs therefore use the same ID. For packaging
+content registered by product ID, add `RegisterForProductKind(...)` as a safe
+fallback for generated output IDs; product-specific content still takes
+precedence.
+
 ## Important Notes
 
 - A mixing ingredient is a builder-only definition. Configure its imprinted effect at build time.


### PR DESCRIPTION
## Summary
- add opt-in `ProductMixingProfile` registration for logical custom product kinds, with explicit supported mixer-map selection and deterministic output factories
- intercept only registered custom products before the native output-family switch; vanilla mixing remains on the untouched native path and missing profiles are rejected clearly
- retain generated properties, packaging, price, logical kind, presentation template, and namespaced identity through custom-product descriptor persistence

Closes #106

## Compatibility
- Added only new public product-mixing types; no released members, enum values, native signatures, or vanilla behavior changed.
- Source/binary compatibility: unchanged for existing APIs.
- Behavioral compatibility: profiles are opt-in; unregistered custom products are rejected before the unsupported native switch, and all vanilla products retain their native flow.
- Save/network compatibility: generated IDs are namespaced from the source logical kind. Descriptor data now preserves property and packaging IDs; legacy descriptors with omitted arrays restore as their prior empty collections.

## Testing
- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 236 passed
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 229 passed

Runtime multiplayer smoke coverage has not been run in this worktree. Before merge, run the host/client generated-output, save/reload, late-join, reconnect/de-duplication, and missing/mismatched-profile rejection matrix for each runtime.