### PR TITLE
fix(stations): allow clicking chemistry recipes

### DIFF
--- a/S1API/Internal/Patches/ChemistryStationPatches.cs
+++ b/S1API/Internal/Patches/ChemistryStationPatches.cs
@@ -21,6 +21,7 @@ using S1API.Items;
 using S1API.Logging;
 using S1API.Stations;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace S1API.Internal.Patches
 {
@@ -33,6 +34,10 @@ namespace S1API.Internal.Patches
         private static readonly Log Logger = new Log("ChemistryStationPatches");
         private static readonly ConditionalWeakTable<object, CanvasInjectionState> CanvasStateTable =
             new ConditionalWeakTable<object, CanvasInjectionState>();
+        private static readonly MethodInfo? SetSelectedRecipeMethod =
+            AccessTools.Method(
+                typeof(S1UIStations.ChemistryStationInterface),
+                "SetSelectedRecipe");
 
         private static bool _loggedRecipeEntriesMissing;
         private static bool _loggedChemistryStationUiMissing;
@@ -41,6 +46,7 @@ namespace S1API.Internal.Patches
         {
             public readonly HashSet<string> LoggedRecipeConflicts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             public readonly HashSet<string> LoggedEntryConflicts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            public readonly HashSet<int> ClickBoundEntryIds = new HashSet<int>();
         }
 
         private static CanvasInjectionState GetCanvasState(object canvas)
@@ -266,6 +272,50 @@ namespace S1API.Internal.Patches
                 {
                     Logger.Warning($"[S1API] Failed to create StationRecipeEntry for '{id}': {ex.Message}");
                 }
+            }
+
+            EnsureRecipeEntryClickHandlers(canvas, entries, state);
+        }
+
+        private static void EnsureRecipeEntryClickHandlers(
+            object canvas,
+#if IL2CPPMELON
+            Il2CppSystem.Collections.Generic.List<S1UIStations.StationRecipeEntry> entries,
+#else
+            List<S1UIStations.StationRecipeEntry> entries,
+#endif
+            CanvasInjectionState state)
+        {
+            if (SetSelectedRecipeMethod == null)
+                return;
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                S1UIStations.StationRecipeEntry entry = entries[i];
+                if (entry == null || entry.Button == null)
+                    continue;
+
+                int instanceId = entry.GetInstanceID();
+                if (!state.ClickBoundEntryIds.Add(instanceId))
+                    continue;
+
+                entry.Button.onClick.AddListener(
+                    (UnityAction)(() => SelectRecipeFromClick(canvas, entry)));
+            }
+        }
+
+        private static void SelectRecipeFromClick(
+            object canvas,
+            S1UIStations.StationRecipeEntry entry)
+        {
+            try
+            {
+                SetSelectedRecipeMethod?.Invoke(canvas, new object[] { entry });
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"[S1API] Chemistry Station recipe click selection failed: {ex.Message}");
             }
         }
 

--- a/S1API/Internal/Patches/ChemistryStationPatches.cs
+++ b/S1API/Internal/Patches/ChemistryStationPatches.cs
@@ -41,6 +41,7 @@ namespace S1API.Internal.Patches
 
         private static bool _loggedRecipeEntriesMissing;
         private static bool _loggedChemistryStationUiMissing;
+        private static bool _loggedSetSelectedRecipeMissing;
 
         private sealed class CanvasInjectionState
         {
@@ -228,9 +229,6 @@ namespace S1API.Internal.Patches
             }
 
             var registered = ChemistryStationRecipes.GetAllNative();
-            if (registered.Count == 0)
-                return;
-
             var state = GetCanvasState(canvas);
             for (int i = 0; i < registered.Count; i++)
             {
@@ -287,7 +285,16 @@ namespace S1API.Internal.Patches
             CanvasInjectionState state)
         {
             if (SetSelectedRecipeMethod == null)
+            {
+                if (!_loggedSetSelectedRecipeMissing)
+                {
+                    _loggedSetSelectedRecipeMissing = true;
+                    Logger.Warning(
+                        "[S1API] Chemistry station selection method could not be resolved. Recipe click binding will be skipped.");
+                }
+
                 return;
+            }
 
             for (int i = 0; i < entries.Count; i++)
             {


### PR DESCRIPTION
## Summary
- bind each Chemistry Station recipe row's existing button to the native selection method
- cover both native and late-injected S1API recipe rows
- keep binding idempotent across repeated station opens
- preserve mouse-wheel and keyboard selection behavior

## Root cause
The current game creates visible Button components for recipe rows, but neither ChemistryStationInterface.Awake, StationRecipeEntry.AssignRecipe, nor the serialized recipe-entry prefab wires an onClick callback. S1API already synchronizes late recipe rows during Open, making that the narrow lifecycle seam for additive click support.

## Testing
- dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` 
- dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build (238 passed)
- dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` 
- dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build (231 passed)
- manual Mono/IL2CPP click verification pending

## Compatibility
- **Public API:** unchanged; no public or protected symbols were added, removed, or modified
- **Binary/source compatibility:** unchanged
- **Behavior:** additive; existing mouse-wheel, keyboard, sorting, validity, and selection paths are retained
- **Persistence/networking:** unchanged; no recipe IDs, saves, or network payloads changed
- **Runtime parity:** the same internal path builds under Mono and IL2CPP