### PR TITLE
fix(products): prepare packaged product icons during loading

### DIFF
--- a/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileRegistryTests.cs
@@ -79,6 +79,40 @@ public sealed class ProductPackagingContentProfileRegistryTests : IDisposable
     }
 
     [Fact]
+    public void SnapshotIncludesProductAndKindRegistrations()
+    {
+        string productId = CreateProductId();
+        string productKindId = CreateProductId();
+        ProductPackagingContentProfile profile = CreateProfile();
+
+        ProductPackagingContentProfileRegistry.Register(
+            "examplemod",
+            productId,
+            "baggie",
+            profile);
+        ProductPackagingContentProfileRegistry.RegisterForProductKind(
+            "examplemod",
+            productKindId,
+            "baggie",
+            profile);
+
+        ProductPackagingContentProfileRegistration[] snapshot =
+            ProductPackagingContentProfileRegistry.Snapshot();
+
+        Assert.Equal(2, snapshot.Length);
+        Assert.Contains(
+            snapshot,
+            registration =>
+                registration.Key.ProductId == productId &&
+                registration.Key.PackagingId == "baggie");
+        Assert.Contains(
+            snapshot,
+            registration =>
+                registration.Key.ProductId == productKindId &&
+                registration.Key.PackagingId == "baggie");
+    }
+
+    [Fact]
     public void RegisteredProductWithUnregisteredPackagingPreservesNativeFallback()
     {
         string productId = CreateProductId();

--- a/S1API/Internal/Patches/LoadingScreenPatches.cs
+++ b/S1API/Internal/Patches/LoadingScreenPatches.cs
@@ -67,6 +67,8 @@ namespace S1API.Internal.Patches
             if (!IsGameLoading())
                 return true;
 
+            ProductPackagingContentRuntime.QueueRegisteredIconsForLoading();
+
             bool waitForMugshots =
                 ShouldWaitForMugshots() &&
                 !NPCAppearance.MugshotsProcessingComplete;

--- a/S1API/Internal/Patches/LoadingScreenPatches.cs
+++ b/S1API/Internal/Patches/LoadingScreenPatches.cs
@@ -67,6 +67,9 @@ namespace S1API.Internal.Patches
             if (!IsGameLoading())
                 return true;
 
+            if (_isWaitingForRenderedIcons)
+                return false;
+
             ProductPackagingContentRuntime.QueueRegisteredIconsForLoading();
 
             bool waitForMugshots =
@@ -78,9 +81,6 @@ namespace S1API.Internal.Patches
                     ProductPackagingContentRuntime.GeneratedIconWorkComplete);
             if (!waitForMugshots && !waitForProductIcons)
                 return true;
-
-            if (_isWaitingForRenderedIcons)
-                return false;
 
             _isWaitingForRenderedIcons = true;
             _waitForMugshots = waitForMugshots;

--- a/S1API/Internal/Products/ProductPackagingContentRuntime.cs
+++ b/S1API/Internal/Products/ProductPackagingContentRuntime.cs
@@ -236,7 +236,10 @@ namespace S1API.Internal.Products
             }
 
             QueueGeneratedIcon(registration);
-            return TryGetLooseProductIcon(productId, out icon);
+            return TryGetLooseProductIcon(
+                registration,
+                productId,
+                out icon);
         }
 
         internal static void QueueRegisteredIconsForLoading()
@@ -583,6 +586,7 @@ namespace S1API.Internal.Products
         }
 
         private static bool TryGetLooseProductIcon(
+            ProductPackagingContentProfileRegistration registration,
             string productId,
             out Sprite? icon)
         {
@@ -594,8 +598,12 @@ namespace S1API.Internal.Products
                         ?.Icon;
                 return icon != null;
             }
-            catch
+            catch (Exception exception)
             {
+                LogFailureOnce(
+                    registration,
+                    "loose-icon lookup",
+                    exception.Message);
                 return false;
             }
         }

--- a/S1API/Internal/Products/ProductPackagingContentRuntime.cs
+++ b/S1API/Internal/Products/ProductPackagingContentRuntime.cs
@@ -236,7 +236,15 @@ namespace S1API.Internal.Products
             }
 
             QueueGeneratedIcon(registration);
-            return false;
+            return TryGetLooseProductIcon(productId, out icon);
+        }
+
+        internal static void QueueRegisteredIconsForLoading()
+        {
+            ProductPackagingContentProfileRegistration[] registrations =
+                ProductPackagingContentProfileRegistry.Snapshot();
+            for (int i = 0; i < registrations.Length; i++)
+                QueueGeneratedIcon(registrations[i]);
         }
 
         internal static void ResetForSceneChange()
@@ -436,6 +444,18 @@ namespace S1API.Internal.Products
         private static void QueueGeneratedIcon(
             ProductPackagingContentProfileRegistration registration)
         {
+            lock (IconGate)
+            {
+                if (GeneratedIcons.TryGetValue(
+                        registration.Key,
+                        out GeneratedPackagingIcon? generated) &&
+                    generated.Icon != null &&
+                    generated.Texture != null)
+                {
+                    return;
+                }
+            }
+
             bool startProcessor = false;
             int generation;
             lock (IconQueueGate)
@@ -559,6 +579,24 @@ namespace S1API.Internal.Products
                 // RuntimePreviewGenerator uses a shared render rig. Give its
                 // temporary model a frame to leave the rig before the next pair.
                 yield return null;
+            }
+        }
+
+        private static bool TryGetLooseProductIcon(
+            string productId,
+            out Sprite? icon)
+        {
+            icon = null;
+            try
+            {
+                icon =
+                    global::S1API.Items.ItemManager.GetDefinition(productId)
+                        ?.Icon;
+                return icon != null;
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/S1API/Products/ProductPackagingContentProfileRegistry.cs
+++ b/S1API/Products/ProductPackagingContentProfileRegistry.cs
@@ -174,6 +174,21 @@ namespace S1API.Products
                 return KindRegistrations.TryGetValue(key, out registration);
         }
 
+        internal static ProductPackagingContentProfileRegistration[] Snapshot()
+        {
+            lock (Gate)
+            {
+                var snapshot =
+                    new ProductPackagingContentProfileRegistration[
+                        Registrations.Count + KindRegistrations.Count];
+                Registrations.Values.CopyTo(snapshot, 0);
+                KindRegistrations.Values.CopyTo(
+                    snapshot,
+                    Registrations.Count);
+                return snapshot;
+            }
+        }
+
         internal static void ResetForTesting()
         {
             lock (Gate)


### PR DESCRIPTION
## Root cause

Registered custom packaging profiles generate their composite icons asynchronously on first lookup. The first `ProductIconManager.GetIcon` call therefore fell through to the native missing-icon result, leaving a white placeholder in the existing inventory slot even though S1API generated and cached the correct icon later.

Manual reproduction with MoreDrugs confirmed the renderer itself succeeds: a newly bagged MDMA item initially displayed white and changed to the generated baggie icon after several minutes without restarting the game.

## Changes

- Snapshot registered product-specific and product-kind packaging profiles internally.
- Queue their composite icons before the loading screen closes, after mods have registered content.
- Reuse valid cached composites rather than requeueing them on repeated close attempts.
- Return the custom product's loose icon while a late composite render is pending instead of exposing the native white placeholder.
- Cover registry snapshot behavior with a focused unit test.

## Compatibility

- No public or protected API symbols changed.
- Existing source and binary contracts remain unchanged.
- Product IDs, product-kind IDs, save descriptors, and multiplayer manifests are unchanged.
- Unregistered product/packaging pairs still follow the exact native fallback path.
- Existing packaged-icon registration syntax and first-registration-wins behavior are unchanged.
- The behavior change is limited to registered custom packaging profiles: icons are prepared earlier and late lookups receive a meaningful temporary icon.

## Validation

- MonoMelon solution build: 0 warnings, 0 errors.
- MonoMelon tests: 239/239 passed.
- Il2CppMelon solution build: 0 warnings, 0 errors.
- Il2CppMelon tests: 232/232 passed.
- `git diff --check`: clean.
- Runtime diagnosis confirmed in Schedule I Mono with MoreDrugs; final clean-load visual verification will follow after the active manual-test session closes.

Follow-up to #119.