### PR TITLE
feat(console): support short item aliases for give

### DIFF
--- a/S1API.Tests/Console/ConsoleItemAliasRegistryTests.cs
+++ b/S1API.Tests/Console/ConsoleItemAliasRegistryTests.cs
@@ -175,6 +175,7 @@ public sealed class ConsoleItemAliasRegistryTests : IDisposable
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("mod:mdma")]
+    [InlineData("products/mdma")]
     [InlineData("two words")]
     [InlineData("mdma$")]
     public void InvalidAliasesAreRejected(string? alias)

--- a/S1API.Tests/Console/ConsoleItemAliasRegistryTests.cs
+++ b/S1API.Tests/Console/ConsoleItemAliasRegistryTests.cs
@@ -1,0 +1,209 @@
+using S1API.Internal.Console;
+
+namespace S1API.Tests.Console;
+
+public sealed class ConsoleItemAliasRegistryTests : IDisposable
+{
+    private readonly HashSet<string> _registeredItems =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public ConsoleItemAliasRegistryTests()
+    {
+        ConsoleItemAliasRegistry.ResetForTesting();
+        _registeredItems.Add("example.mod:products/mdma");
+        _registeredItems.Add("cash");
+    }
+
+    [Fact]
+    public void RegistrationTrimsAndResolvesCaseInsensitively()
+    {
+        ConsoleItemAliasRegistry.Register(
+            " MDMA ",
+            " example.mod:products/mdma ",
+            ItemExists);
+
+        bool resolved = ConsoleItemAliasRegistry.TryResolveForGive(
+            "mDmA",
+            ItemExists,
+            out string canonicalItemId);
+
+        Assert.True(resolved);
+        Assert.Equal("example.mod:products/mdma", canonicalItemId);
+    }
+
+    [Fact]
+    public void RepeatingEquivalentRegistrationIsIdempotent()
+    {
+        ConsoleItemAliasRegistry.Register(
+            "mdma",
+            "example.mod:products/mdma",
+            ItemExists);
+        ConsoleItemAliasRegistry.Register(
+            "MDMA",
+            "EXAMPLE.MOD:PRODUCTS/MDMA",
+            ItemExists);
+
+        Assert.True(
+            ConsoleItemAliasRegistry.TryResolveForGive(
+                "mdma",
+                ItemExists,
+                out string canonicalItemId));
+        Assert.Equal("example.mod:products/mdma", canonicalItemId);
+    }
+
+    [Fact]
+    public void ConflictingAliasRegistrationFailsDeterministically()
+    {
+        _registeredItems.Add("other.mod:products/mdma");
+        ConsoleItemAliasRegistry.Register(
+            "mdma",
+            "example.mod:products/mdma",
+            ItemExists);
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(() =>
+                ConsoleItemAliasRegistry.Register(
+                    "MDMA",
+                    "other.mod:products/mdma",
+                    ItemExists));
+
+        Assert.Contains(
+            "example.mod:products/mdma",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "other.mod:products/mdma",
+            exception.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NativeItemIdCannotBeShadowed()
+    {
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(() =>
+                ConsoleItemAliasRegistry.Register(
+                    "cash",
+                    "example.mod:products/mdma",
+                    ItemExists));
+
+        Assert.Contains("cannot be shadowed", exception.Message);
+    }
+
+    [Fact]
+    public void MissingCanonicalItemFailsBeforeRegistration()
+    {
+        ArgumentException exception =
+            Assert.Throws<ArgumentException>(() =>
+                ConsoleItemAliasRegistry.Register(
+                    "mdma",
+                    "missing.mod:products/mdma",
+                    ItemExists));
+
+        Assert.Equal("canonicalItemId", exception.ParamName);
+        Assert.False(
+            ConsoleItemAliasRegistry.TryResolveForGive(
+                "mdma",
+                ItemExists,
+                out _));
+    }
+
+    [Fact]
+    public void NativeItemRegisteredLaterTakesPrecedence()
+    {
+        ConsoleItemAliasRegistry.Register(
+            "mdma",
+            "example.mod:products/mdma",
+            ItemExists);
+        _registeredItems.Add("mdma");
+
+        Assert.False(
+            ConsoleItemAliasRegistry.TryResolveForGive(
+                "mdma",
+                ItemExists,
+                out string canonicalItemId));
+        Assert.Equal(string.Empty, canonicalItemId);
+    }
+
+    [Fact]
+    public void MissingTargetAtExecutionPreservesVanillaLookup()
+    {
+        ConsoleItemAliasRegistry.Register(
+            "mdma",
+            "example.mod:products/mdma",
+            ItemExists);
+        _registeredItems.Remove("example.mod:products/mdma");
+
+        Assert.False(
+            ConsoleItemAliasRegistry.TryResolveForGive(
+                "mdma",
+                ItemExists,
+                out string canonicalItemId));
+        Assert.Equal(string.Empty, canonicalItemId);
+    }
+
+    [Fact]
+    public void UnknownAliasPreservesVanillaLookup()
+    {
+        Assert.False(
+            ConsoleItemAliasRegistry.TryResolveForGive(
+                "unknown",
+                ItemExists,
+                out string canonicalItemId));
+        Assert.Equal(string.Empty, canonicalItemId);
+    }
+
+    [Fact]
+    public void ResolvingAliasPreservesQuantityArgument()
+    {
+        ConsoleItemAliasRegistry.Register(
+            "mdma",
+            "example.mod:products/mdma",
+            ItemExists);
+        List<string> args = ["mdma", "5"];
+
+        args[0] = ConsoleItemAliasRegistry.ResolveItemCodeForGive(
+            args[0],
+            ItemExists);
+
+        Assert.Equal("example.mod:products/mdma", args[0]);
+        Assert.Equal("5", args[1]);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("mod:mdma")]
+    [InlineData("two words")]
+    [InlineData("mdma$")]
+    public void InvalidAliasesAreRejected(string? alias)
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            ConsoleItemAliasRegistry.Register(
+                alias!,
+                "example.mod:products/mdma",
+                ItemExists));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptyCanonicalIdsAreRejected(string? canonicalItemId)
+    {
+        Assert.ThrowsAny<ArgumentException>(() =>
+            ConsoleItemAliasRegistry.Register(
+                "mdma",
+                canonicalItemId!,
+                ItemExists));
+    }
+
+    public void Dispose()
+    {
+        ConsoleItemAliasRegistry.ResetForTesting();
+    }
+
+    private bool ItemExists(string itemId) =>
+        _registeredItems.Contains(itemId);
+}

--- a/S1API.Tests/Console/ConsoleItemAliasesApiCompatibilityTests.cs
+++ b/S1API.Tests/Console/ConsoleItemAliasesApiCompatibilityTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using S1API.Console;
+
+namespace S1API.Tests.Console;
+
+public sealed class ConsoleItemAliasesApiCompatibilityTests
+{
+    [Fact]
+    public void RegisterRetainsTheDocumentedPublicShape()
+    {
+        Type type = typeof(ConsoleItemAliases);
+        Assert.True(type.IsPublic);
+        Assert.True(type.IsAbstract);
+        Assert.True(type.IsSealed);
+
+        MethodInfo register = type.GetMethod(
+            nameof(ConsoleItemAliases.Register),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(string), typeof(string) },
+            modifiers: null)!;
+
+        Assert.NotNull(register);
+        Assert.Equal(typeof(void), register.ReturnType);
+        ParameterInfo[] parameters = register.GetParameters();
+        Assert.Equal("alias", parameters[0].Name);
+        Assert.Equal("canonicalItemId", parameters[1].Name);
+    }
+}

--- a/S1API.Tests/Console/ConsoleItemAliasesApiCompileFixture.cs
+++ b/S1API.Tests/Console/ConsoleItemAliasesApiCompileFixture.cs
@@ -1,0 +1,13 @@
+using S1API.Console;
+
+namespace S1API.Tests.Console;
+
+internal static class ConsoleItemAliasesApiCompileFixture
+{
+    internal static void RegisterAlias()
+    {
+        ConsoleItemAliases.Register(
+            alias: "mdma",
+            canonicalItemId: "example.mod:products/mdma");
+    }
+}

--- a/S1API/Console/ConsoleItemAliases.cs
+++ b/S1API/Console/ConsoleItemAliases.cs
@@ -1,0 +1,51 @@
+using S1API.Internal.Console;
+using S1API.Items;
+
+namespace S1API.Console
+{
+    /// <summary>
+    /// Registers short, local aliases for item IDs accepted by the native
+    /// <c>give</c> console command.
+    /// </summary>
+    /// <remarks>
+    /// Aliases are console conveniences only. Given items retain their
+    /// canonical IDs, and aliases are not included in saves, recipes,
+    /// multiplayer manifests, compatibility hashes, or network payloads.
+    /// </remarks>
+    public static class ConsoleItemAliases
+    {
+        /// <summary>
+        /// Registers a short alias for an existing canonical item ID.
+        /// </summary>
+        /// <param name="alias">
+        /// The non-namespaced command token, such as <c>mdma</c>.
+        /// </param>
+        /// <param name="canonicalItemId">
+        /// The existing canonical item ID, such as
+        /// <c>example.mod:products/mdma</c>.
+        /// </param>
+        /// <remarks>
+        /// Call this after the canonical item has been registered. Native item
+        /// IDs always take precedence over aliases. Repeating the same mapping
+        /// is idempotent; attempting to reuse an alias for another item throws.
+        /// </remarks>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when either argument is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown when an argument is empty, the alias is not a safe command
+        /// token, or the canonical item is not registered.
+        /// </exception>
+        /// <exception cref="System.InvalidOperationException">
+        /// Thrown when the alias is already a native item ID or is registered
+        /// for another canonical item.
+        /// </exception>
+        public static void Register(string alias, string canonicalItemId)
+        {
+            ConsoleItemAliasRegistry.Register(
+                alias,
+                canonicalItemId,
+                ItemManager.IsItemRegistered);
+        }
+    }
+}

--- a/S1API/Internal/Console/ConsoleItemAliasRegistry.cs
+++ b/S1API/Internal/Console/ConsoleItemAliasRegistry.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+
+namespace S1API.Internal.Console
+{
+    /// <summary>
+    /// INTERNAL: Process-lifetime console alias registration and resolution.
+    /// </summary>
+    internal static class ConsoleItemAliasRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, string> Aliases =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        internal static void Register(
+            string alias,
+            string canonicalItemId,
+            Func<string, bool> itemExists)
+        {
+            if (itemExists == null)
+                throw new ArgumentNullException(nameof(itemExists));
+
+            string normalizedAlias = NormalizeAlias(alias);
+            string normalizedCanonicalItemId =
+                NormalizeCanonicalItemId(canonicalItemId);
+
+            lock (Gate)
+            {
+                if (IsIdempotentOrThrow(
+                        normalizedAlias,
+                        normalizedCanonicalItemId))
+                    return;
+            }
+
+            if (!itemExists(normalizedCanonicalItemId))
+            {
+                throw new ArgumentException(
+                    $"Canonical item ID '{normalizedCanonicalItemId}' is not " +
+                    "registered. Register the item before its console alias.",
+                    nameof(canonicalItemId));
+            }
+
+            if (itemExists(normalizedAlias))
+            {
+                throw new InvalidOperationException(
+                    $"Console item alias '{normalizedAlias}' is already a " +
+                    "native or canonical item ID and cannot be shadowed.");
+            }
+
+            lock (Gate)
+            {
+                if (IsIdempotentOrThrow(
+                        normalizedAlias,
+                        normalizedCanonicalItemId))
+                    return;
+
+                Aliases.Add(normalizedAlias, normalizedCanonicalItemId);
+            }
+        }
+
+        internal static bool TryResolveForGive(
+            string itemCode,
+            Func<string, bool> itemExists,
+            out string canonicalItemId)
+        {
+            canonicalItemId = string.Empty;
+            if (string.IsNullOrWhiteSpace(itemCode) || itemExists == null)
+                return false;
+
+            string normalizedItemCode = itemCode.Trim();
+            if (itemExists(normalizedItemCode))
+                return false;
+
+            string? registeredCanonicalItemId;
+            lock (Gate)
+            {
+                if (!Aliases.TryGetValue(
+                        normalizedItemCode,
+                        out registeredCanonicalItemId))
+                {
+                    return false;
+                }
+            }
+
+            if (registeredCanonicalItemId == null ||
+                !itemExists(registeredCanonicalItemId))
+                return false;
+
+            canonicalItemId = registeredCanonicalItemId;
+            return true;
+        }
+
+        internal static string ResolveItemCodeForGive(
+            string itemCode,
+            Func<string, bool> itemExists)
+        {
+            return TryResolveForGive(
+                itemCode,
+                itemExists,
+                out string canonicalItemId)
+                ? canonicalItemId
+                : itemCode;
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+                Aliases.Clear();
+        }
+
+        private static string NormalizeAlias(string alias)
+        {
+            if (alias == null)
+                throw new ArgumentNullException(nameof(alias));
+
+            string normalized = alias.Trim();
+            if (normalized.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Console item aliases cannot be empty or whitespace.",
+                    nameof(alias));
+            }
+
+            for (int i = 0; i < normalized.Length; i++)
+            {
+                char character = normalized[i];
+                if (IsAsciiLetterOrDigit(character) ||
+                    character == '.' ||
+                    character == '_' ||
+                    character == '-' ||
+                    character == '/')
+                {
+                    continue;
+                }
+
+                throw new ArgumentException(
+                    $"Console item alias contains invalid character " +
+                    $"'{character}' at position {i}. Use ASCII letters, " +
+                    "digits, '.', '_', '-', or '/'; aliases do not include a " +
+                    "namespace.",
+                    nameof(alias));
+            }
+
+            return normalized;
+        }
+
+        private static bool IsIdempotentOrThrow(
+            string alias,
+            string canonicalItemId)
+        {
+            if (!Aliases.TryGetValue(
+                    alias,
+                    out string? existingCanonicalItemId))
+            {
+                return false;
+            }
+
+            if (string.Equals(
+                    existingCanonicalItemId,
+                    canonicalItemId,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            throw new InvalidOperationException(
+                $"Console item alias '{alias}' is already registered for " +
+                $"'{existingCanonicalItemId}' and cannot also target " +
+                $"'{canonicalItemId}'.");
+        }
+
+        private static string NormalizeCanonicalItemId(string canonicalItemId)
+        {
+            if (canonicalItemId == null)
+                throw new ArgumentNullException(nameof(canonicalItemId));
+
+            string normalized = canonicalItemId.Trim();
+            if (normalized.Length == 0)
+            {
+                throw new ArgumentException(
+                    "Canonical item IDs cannot be empty or whitespace.",
+                    nameof(canonicalItemId));
+            }
+
+            return normalized;
+        }
+
+        private static bool IsAsciiLetterOrDigit(char character)
+        {
+            return character >= 'a' && character <= 'z'
+                   || character >= 'A' && character <= 'Z'
+                   || character >= '0' && character <= '9';
+        }
+    }
+}

--- a/S1API/Internal/Console/ConsoleItemAliasRegistry.cs
+++ b/S1API/Internal/Console/ConsoleItemAliasRegistry.cs
@@ -127,8 +127,7 @@ namespace S1API.Internal.Console
                 if (IsAsciiLetterOrDigit(character) ||
                     character == '.' ||
                     character == '_' ||
-                    character == '-' ||
-                    character == '/')
+                    character == '-')
                 {
                     continue;
                 }
@@ -136,7 +135,7 @@ namespace S1API.Internal.Console
                 throw new ArgumentException(
                     $"Console item alias contains invalid character " +
                     $"'{character}' at position {i}. Use ASCII letters, " +
-                    "digits, '.', '_', '-', or '/'; aliases do not include a " +
+                    "digits, '.', '_', or '-'; aliases do not include a " +
                     "namespace.",
                     nameof(alias));
             }

--- a/S1API/Internal/Patches/ConsolePatches.cs
+++ b/S1API/Internal/Patches/ConsolePatches.cs
@@ -9,6 +9,11 @@ using S1API.Internal.Utils;
 using UnityEngine;
 using Object = UnityEngine.Object;
 #if MONOMELON
+using GiveCommandArguments = System.Collections.Generic.List<string>;
+#elif IL2CPPMELON
+using GiveCommandArguments = Il2CppSystem.Collections.Generic.List<string>;
+#endif
+#if MONOMELON
 using S1Console = ScheduleOne.Console;
 using S1CommandListScreen = ScheduleOne.CommandListScreen;
 using TMPro;
@@ -33,21 +38,13 @@ namespace S1API.Internal.Patches
         /// Resolves a short item alias before the native give command performs
         /// its ordinary registry lookup.
         /// </summary>
-#if MONOMELON
+#if MONOMELON || IL2CPPMELON
         [HarmonyPatch(
             typeof(S1Console.AddItemToInventoryCommand),
             nameof(S1Console.AddItemToInventoryCommand.Execute))]
         [HarmonyPrefix]
         private static void ResolveGiveItemAlias(
-            System.Collections.Generic.List<string> args)
-#elif IL2CPPMELON
-        [HarmonyPatch(
-            typeof(S1Console.AddItemToInventoryCommand),
-            nameof(S1Console.AddItemToInventoryCommand.Execute))]
-        [HarmonyPrefix]
-        private static void ResolveGiveItemAlias(
-            Il2CppSystem.Collections.Generic.List<string> args)
-#endif
+            GiveCommandArguments args)
         {
             if (args == null || args.Count == 0 || args[0] == null)
                 return;
@@ -56,6 +53,7 @@ namespace S1API.Internal.Patches
                 args[0],
                 ItemManager.IsItemRegistered);
         }
+#endif
 
         /// <summary>
         /// Discover and register custom console commands derived from BaseConsoleCommand.

--- a/S1API/Internal/Patches/ConsolePatches.cs
+++ b/S1API/Internal/Patches/ConsolePatches.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
 using S1API.Console;
+using S1API.Internal.Console;
+using S1API.Items;
 using S1API.Internal.Utils;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -26,7 +28,34 @@ namespace S1API.Internal.Patches
     internal static class ConsolePatches
     {
         private static readonly Logging.Log Logger = new Logging.Log("Console");
-        
+
+        /// <summary>
+        /// Resolves a short item alias before the native give command performs
+        /// its ordinary registry lookup.
+        /// </summary>
+#if MONOMELON
+        [HarmonyPatch(
+            typeof(S1Console.AddItemToInventoryCommand),
+            nameof(S1Console.AddItemToInventoryCommand.Execute))]
+        [HarmonyPrefix]
+        private static void ResolveGiveItemAlias(
+            System.Collections.Generic.List<string> args)
+#elif IL2CPPMELON
+        [HarmonyPatch(
+            typeof(S1Console.AddItemToInventoryCommand),
+            nameof(S1Console.AddItemToInventoryCommand.Execute))]
+        [HarmonyPrefix]
+        private static void ResolveGiveItemAlias(
+            Il2CppSystem.Collections.Generic.List<string> args)
+#endif
+        {
+            if (args == null || args.Count == 0 || args[0] == null)
+                return;
+
+            args[0] = ConsoleItemAliasRegistry.ResolveItemCodeForGive(
+                args[0],
+                ItemManager.IsItemRegistered);
+        }
 
         /// <summary>
         /// Discover and register custom console commands derived from BaseConsoleCommand.

--- a/S1API/Products/CustomProductDefinitionBuilder.cs
+++ b/S1API/Products/CustomProductDefinitionBuilder.cs
@@ -10,6 +10,7 @@ using S1Product = ScheduleOne.Product;
 
 using System;
 using System.Collections.Generic;
+using S1API.Console;
 using S1API.Internal.Products;
 using S1API.Internal.Properties;
 using S1API.Items;
@@ -74,6 +75,13 @@ namespace S1API.Products
         /// The immutable logical product kind. Its compatibility drug type is required by native
         /// save and product-item data but does not enable mixing.
         /// </param>
+        /// <remarks>
+        /// Keep this durable ID namespaced for saves and multiplayer. If you do
+        /// not want to type the namespace when testing through the console,
+        /// register the short name with
+        /// <see cref="ConsoleItemAliases"/> after building the
+        /// definition so <c>give &lt;alias&gt;</c> resolves it locally.
+        /// </remarks>
         public CustomProductDefinitionBuilder(string id, ProductKind productKind)
         {
             _id = CustomProductDefinitionBuilderContract.NormalizeId(id);

--- a/S1API/Products/CustomProductItemCreator.cs
+++ b/S1API/Products/CustomProductItemCreator.cs
@@ -1,3 +1,5 @@
+using S1API.Console;
+
 namespace S1API.Products
 {
     /// <summary>
@@ -14,6 +16,14 @@ namespace S1API.Products
         /// required by native save and product-item data.
         /// </param>
         /// <returns>A new custom product definition builder.</returns>
+        /// <remarks>
+        /// Keep this durable ID namespaced for saves and multiplayer. If you do
+        /// not want to type the namespace when testing through the console,
+        /// register the short name with
+        /// <see cref="ConsoleItemAliases"/> after
+        /// <see cref="CustomProductDefinitionBuilder.Build"/> so
+        /// <c>give &lt;alias&gt;</c> resolves it locally.
+        /// </remarks>
         public static CustomProductDefinitionBuilder CreateBuilder(
             string id,
             ProductKind productKind)

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -13,6 +13,7 @@ register the same stable IDs before native item save data is restored.
 
 ```csharp
 using System;
+using S1API.Console;
 using S1API.Items;
 using S1API.Lifecycle;
 using S1API.Products;
@@ -65,8 +66,19 @@ GameLifecycle.OnPreLoad += () =>
             playerSeconds: 120,
             npcSeconds: 180)
         .Build();
+
+    ConsoleItemAliases.Register(
+        alias: "focus-tablet",
+        canonicalItemId: focusTablet.ProductId);
 };
 ```
+
+Don't want to type the namespace in the console? Keep the durable namespaced
+item ID and register the short name with `ConsoleItemAliases` after `Build()`.
+The example above accepts both `give focus-tablet` and
+`give example.mod:products/focus-tablet`. The alias is a local console
+convenience only: created items still use the canonical ID, and aliases are not
+saved, networked, or included in compatibility manifests.
 
 The compatibility drug type remains optional metadata. A generic product needs
 a native execution representation: use compatibility metadata when it is


### PR DESCRIPTION
﻿## Summary

- add `ConsoleItemAliases.Register(alias, canonicalItemId)` for short, console-only item aliases
- resolve aliases only at the native `give` command boundary, preserving the canonical item definition and all durable IDs
- document the convenience API beside custom-product ID creation and in the generic custom-product guide
- add focused behavior, quantity-preservation, compile-shape, and reflection compatibility tests

Closes #122

## Behavior

```csharp
ConsoleItemAliases.Register(
    alias: "mdma",
    canonicalItemId: "ifbars.moredrugs:products/mdma");
```

Both `give mdma 5` and `give ifbars.moredrugs:products/mdma 5` resolve the same canonical item. Native item IDs take precedence; identical registrations are idempotent; conflicts fail deterministically.

Aliases are process-local console metadata. They are not alternate item definitions and do not enter saves, recipes, manifests, compatibility hashes, or network payloads.

## Compatibility audit

- **Public API:** one additive static class and one additive static method; no existing public or protected signatures changed
- **Source compatibility:** existing call syntax is unchanged
- **Binary compatibility:** existing types and members are unchanged
- **Behavior compatibility:** without registered aliases, native `give` receives the original token and follows its existing lookup/error path
- **Persistence/network compatibility:** canonical IDs remain the only identity used by items, saves, multiplayer, recipes, and generated products
- **Runtime scope:** the Harmony prefix targets only `AddItemToInventoryCommand.Execute`; `Registry.GetItem` is not globally patched

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore` ? 0 warnings, 0 errors
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-build --no-restore` ? 258 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore` ? 0 warnings, 0 errors
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-build --no-restore` ? 251 passed
- `docfx build docfx.json` from `S1API/` ? 0 errors; 24 pre-existing unresolved API/xref warnings
- `git diff --check` ? clean

Runtime smoke artifacts remain local-only per repository policy.
