### PR TITLE
chore(diagnostics): warn when exception tracing is enabled

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -25,6 +25,9 @@ namespace S1API
 
             if (S1APIPreferences.EnableUnityNullReferenceTraceLogging?.Value == true)
             {
+                MelonLogger.Warning(
+                    "[S1API] Exception trace logging is enabled. If you are " +
+                    "not a mod developer, you probably do not need this enabled.");
                 UnityExceptionTraceHook.Install();
             }
         }

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -26,7 +26,7 @@ namespace S1API
             if (S1APIPreferences.EnableUnityNullReferenceTraceLogging?.Value == true)
             {
                 MelonLogger.Warning(
-                    "[S1API] Exception trace logging is enabled. If you are " +
+                    "Exception trace logging is enabled. If you are " +
                     "not a mod developer, you probably do not need this enabled.");
                 UnityExceptionTraceHook.Install();
             }


### PR DESCRIPTION
﻿## Summary

- emit a startup warning when Unity null-reference exception trace logging is enabled
- tell ordinary players that the diagnostic hook is intended for mod development
- leave the default-disabled path silent and unchanged

## Compatibility

This changes no public API, preference key, default value, persistence, or runtime behavior unless `EnableUnityNullReferenceTraceLogging` is explicitly enabled.

## Validation

- MonoMelon build: 0 warnings, 0 errors
- MonoMelon tests: 239 passed
- Il2CppMelon build: 0 warnings, 0 errors
- Il2CppMelon tests: 232 passed
- `git diff --check`: clean
