### PR TITLE
ci(docs): require the 80% documentation coverage gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,8 +22,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.event.pull_request.number) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   documentation:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  documentation:
+    name: documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout S1API
@@ -281,7 +282,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: documentation
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/npc-prefabs'
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
﻿## Summary

- give the documentation workflow job the stable, explicit `documentation` check name
- retain the existing public API documentation analyzer at an 80% minimum
- run PR documentation checks in per-PR concurrency groups so unrelated PRs cannot cancel one another
- cancel only stale runs from newer commits on the same PR while keeping Pages deployments globally serialized
- update the Pages deployment dependency to the renamed job

The analyzer exits nonzero below 80%, so the `documentation` check fails before any Pages artifact can be published. After this lands, the `beta` branch rule will require this named check so failed or missing documentation coverage blocks merges.

## Validation

- MonoMelon S1API build: 0 warnings, 0 errors
- DocFX metadata generation: completed (four known local assembly-resolution warnings)
- DocFX site build: 0 warnings, 0 errors
- documentation analyzer: 81.39% (2,930/3,600), minimum 80%
- live workflow observation confirmed the old global group cancelled an unrelated queued PR run; the new group is unique per PR
- `git diff --check`: clean
