### PR TITLE
ci(release): preserve attestation with protected beta

### DIFF
--- a/.github/workflows/mlvscan-attestation.yml
+++ b/.github/workflows/mlvscan-attestation.yml
@@ -368,6 +368,11 @@ jobs:
       - name: Commit README badge update
         shell: bash
         run: |
+          if [[ "${{ steps.ref.outputs.target_ref }}" == "beta" ]]; then
+            echo "::notice::Skipping README badge push to protected beta branch"
+            exit 0
+          fi
+
           if git diff --quiet README.md; then
             echo "README badge already up to date"
             exit 0


### PR DESCRIPTION
﻿## Summary

- skip only the README attestation-badge commit when the attestation target is the protected `beta` branch
- keep package upload, scan, attestation publication, and workflow summary behavior unchanged
- preserve badge commits for stable and other unprotected release branches

## Why

The new beta documentation ruleset requires the `documentation` check before every branch update. GitHub does not permit the GitHub Actions integration as a ruleset bypass actor on this personal repository, so the release-attestation workflow's post-release README commit would otherwise fail after a successful attestation.

This keeps the required docs gate strong for every beta update without breaking the upcoming beta prerelease workflow.

## Validation

- change is scoped to the existing badge-commit shell step
- beta exits successfully before creating or pushing a README commit
- all attestation steps before the badge update remain unchanged
- `git diff --check`: clean
