### PR TITLE
ci(docs): enforce coverage across maintained branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,15 @@ name: Build and Deploy Documentation
 
 on:
   push:
-    branches: [ master, main, stable, beta, npc-prefabs ]
+    branches-ignore:
+      - 'agent/**'
+      - 'automation/**'
+      - 'dependabot/**'
+      - 'feat/**'
+      - 'fix/**'
+      - 'hotfix/**'
+      - 'release/**'
   pull_request:
-    branches: [ master, main, stable, beta, npc-prefabs ]
   workflow_dispatch:
     inputs:
       assembly_branch:

--- a/.github/workflows/mlvscan-attestation.yml
+++ b/.github/workflows/mlvscan-attestation.yml
@@ -368,10 +368,14 @@ jobs:
       - name: Commit README badge update
         shell: bash
         run: |
-          if [[ "${{ steps.ref.outputs.target_ref }}" == "beta" ]]; then
-            echo "::notice::Skipping README badge push to protected beta branch"
-            exit 0
-          fi
+          case "${{ steps.ref.outputs.target_ref }}" in
+            agent/*|automation/*|dependabot/*|feat/*|fix/*|hotfix/*|release/*)
+              ;;
+            *)
+              echo "::notice::Skipping README badge push because the target branch requires the documentation check"
+              exit 0
+              ;;
+          esac
 
           if git diff --quiet README.md; then
             echo "README badge already up to date"


### PR DESCRIPTION
﻿## Summary

- run the documentation workflow for pull requests targeting any branch
- run push-time documentation checks on every maintained/integration branch while excluding standard disposable work-branch namespaces
- align the release-attestation badge step with that protected-branch boundary

## Enforcement model

After this merges, the repository ruleset will target all branches except:

- `agent/**`
- `automation/**`
- `dependabot/**`
- `feat/**`
- `fix/**`
- `hotfix/**`
- `release/**`

Those exclusions keep ordinary PR branches pushable. Every other branch, including `stable`, `beta`, `npc-prefabs`, and `releases/**`, will require the GitHub Actions `documentation` check at or above 80% before update.

A literal no-exclusion all-branch rule would deadlock normal review iteration: a second commit could not be pushed to a feature branch because that commit cannot possess the required check before it reaches GitHub.

## Release workflow compatibility

The MLVScan attestation remains fully active. Its optional README badge commit is skipped only when the target falls on the protected side of the same boundary, avoiding a post-release direct push that GitHub would reject.

## Validation

- both workflow files parse as YAML
- branch filters and attestation case patterns use the same work-branch namespaces
- `git diff --check`: clean
