### PR TITLE
chore(release): prepare S1API 3.1.0-beta.6

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -9,7 +9,7 @@ using S1API.Internal.Products;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.5", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.6", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.0-beta.5</Version>
+        <Version>3.1.0-beta.6</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
﻿## Summary

- bump the package version from `3.1.0-beta.5` to `3.1.0-beta.6`
- keep the Melon metadata version synchronized with the package version

After this PR merges, the merge commit will be tagged `v3.1.0-beta.6` and published as a GitHub-only prerelease.

## Release scope

This prerelease consolidates the custom-product foundation added since beta.5, including logical product kinds, lifecycle registration, presentation and packaging profiles, generic product creation, save recovery, multiplayer manifests, mixing profiles, chemistry-station fixes, packaged icon recovery, and console item aliases. It also includes the strengthened documentation coverage gate and the enabled exception-trace warning.

## Validation

- MonoMelon build: 0 warnings, 0 errors
- MonoMelon tests: 259 passed
- Il2CppMelon build: 0 warnings, 0 errors
- Il2CppMelon tests: 252 passed
- version is `3.1.0-beta.6` in both `S1API.csproj` and `MelonInfo`
- `git diff --check`: clean
