### PR TITLE
Fix custom shop listings and add icon-only transforms

### DIFF
--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -264,6 +264,11 @@ public sealed class ProductApiCompatibilityTests
                     typeof(bool),
                     typeof(float)
                 }));
+        AssertBuilderMethod(
+            nameof(
+                ProductPresentationProfileBuilder
+                    .WithGeneratedIconTransform),
+            typeof(ProductPresentationTransform));
 
         Assert.NotNull(
             typeof(IconFactory).GetMethod(

--- a/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
@@ -58,6 +58,11 @@ internal static class ProductPresentationProfileApiCompileFixture
                 512,
                 fitToCamera: true,
                 cameraFill: 0.8f)
+            .WithGeneratedIconTransform(
+                new ProductPresentationTransform(
+                    Vector3.zero,
+                    new Vector3(45f, 0f, 0f),
+                    Vector3.one))
             .Build();
     }
 }

--- a/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
@@ -169,6 +169,37 @@ public sealed class ProductPresentationProfileBuilderTests
         Assert.Equal(1.25f, profile.GeneratedIconCameraFill);
     }
 
+#if MONOMELON
+    [Fact]
+    public void GeneratedIconTransformIsSnapshottedSeparatelyFromLoosePresentation()
+    {
+        var looseTransform =
+            new ProductPresentationTransform(
+                Vector3.zero,
+                Vector3.zero,
+                Vector3.one);
+        var iconTransform =
+            new ProductPresentationTransform(
+                new Vector3(0f, 0.1f, 0f),
+                new Vector3(45f, 0f, 0f),
+                Vector3.one * 0.8f);
+
+        ProductPresentationProfile profile =
+            new ProductPresentationProfileBuilder()
+                .WithLooseVisual(() => null, looseTransform)
+                .WithGeneratedIconTransform(iconTransform)
+                .WithGeneratedIconFromLooseVisual()
+                .Build();
+
+        Assert.Same(iconTransform, profile.GeneratedIconTransform);
+        Assert.True(
+            profile.TryGetVisualTransform(
+                ProductPresentationContext.Loose,
+                out ProductPresentationTransform? resolvedLooseTransform));
+        Assert.Same(looseTransform, resolvedLooseTransform);
+    }
+#endif
+
     [Fact]
     public void BuildSnapshotsProvidersAndRequiredContexts()
     {

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -602,10 +602,17 @@ namespace S1API.Internal.Products
             GameObject model = Object.Instantiate(source);
             try
             {
-                ApplyVisualTransform(
-                    model.transform,
-                    profile,
-                    ProductPresentationContext.Loose);
+                if (profile.GeneratedIconTransform != null)
+                {
+                    profile.GeneratedIconTransform.ApplyTo(model.transform);
+                }
+                else
+                {
+                    ApplyVisualTransform(
+                        model.transform,
+                        profile,
+                        ProductPresentationContext.Loose);
+                }
                 Texture2D? renderedTexture =
                     IconFactory.GenerateIcon(
                         model.transform,

--- a/S1API/Internal/Shops/ShopIntegration.cs
+++ b/S1API/Internal/Shops/ShopIntegration.cs
@@ -1,8 +1,10 @@
 #if (IL2CPPMELON)
+using S1Root = Il2CppScheduleOne;
 using S1UIShop = Il2CppScheduleOne.UI.Shop;
 using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using Il2CppInterop.Runtime;
 #elif MONOMELON
+using S1Root = ScheduleOne;
 using S1UIShop = ScheduleOne.UI.Shop;
 using S1ItemFramework = ScheduleOne.ItemFramework;
 using System;
@@ -151,39 +153,55 @@ namespace S1API.Internal.Shops
 
             // Add to shop's internal UI list
             AddToListingUICollection(shop, listingUI);
+            AddToListingPanel(shop, listingUI);
         }
 
         private static void BindListingUIEvents(S1UIShop.ShopInterface shop, S1UIShop.ListingUI listingUI)
         {
 #if IL2CPPMELON
-            // Il2Cpp: Direct Action assignment
-            listingUI.onClicked = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.OpenAmountSelector(listingUI)));
-            listingUI.onDropdownClicked = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.DropdownClicked(listingUI)));
+            listingUI.onAddItem =
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
+                    new System.Action(() => shop.AddItem(listingUI)));
+            listingUI.onRemoveItem =
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
+                    new System.Action(() => shop.RemoveItem(listingUI)));
+            listingUI.onSetAmount =
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action<int>>(
+                    new System.Action<int>(
+                        amount => shop.SetAmount(listingUI, amount)));
+            listingUI.onAdjustAmount =
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action<int>>(
+                    new System.Action<int>(
+                        amount => shop.AdjustAmount(listingUI, amount)));
             listingUI.hoverStart = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.EntryHovered(listingUI)));
             listingUI.hoverEnd = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.EntryUnhovered()));
 #else
-            // Mono: Reflection-based method invocation
-            var listingClickedMethod = GetShopMethod(shop, "ListingClicked");
-            var dropdownClickedMethod = GetShopMethod(shop, "DropdownClicked");
-            var entryHoveredMethod = GetShopMethod(shop, "EntryHovered");
-            var entryUnhoveredMethod = GetShopMethod(shop, "EntryUnhovered");
+            listingUI.onAddItem = (Action)System.Delegate.Combine(
+                listingUI.onAddItem,
+                (Action)(() => shop.AddItem(listingUI)));
+            listingUI.onRemoveItem = (Action)System.Delegate.Combine(
+                listingUI.onRemoveItem,
+                (Action)(() => shop.RemoveItem(listingUI)));
+            listingUI.onSetAmount = (Action<int>)System.Delegate.Combine(
+                listingUI.onSetAmount,
+                (Action<int>)(amount => shop.SetAmount(listingUI, amount)));
+            listingUI.onAdjustAmount = (Action<int>)System.Delegate.Combine(
+                listingUI.onAdjustAmount,
+                (Action<int>)(amount => shop.AdjustAmount(listingUI, amount)));
 
-            if (listingClickedMethod == null || dropdownClickedMethod == null ||
-                entryHoveredMethod == null || entryUnhoveredMethod == null)
+            MethodInfo? entryHoveredMethod =
+                GetShopMethod(
+                    "EntryHovered",
+                    new[] { typeof(S1UIShop.ListingUI) });
+            MethodInfo? entryUnhoveredMethod =
+                GetShopMethod("EntryUnhovered", Type.EmptyTypes);
+
+            if (entryHoveredMethod == null || entryUnhoveredMethod == null)
             {
-                Logger.Warning($"Shop '{shop.ShopName}' is missing one or more listing event methods.");
+                Logger.Warning(
+                    $"Shop '{shop.ShopName}' is missing one or more hover-detail methods.");
                 return;
             }
-
-            listingUI.onClicked = (Action)System.Delegate.Combine(
-                listingUI.onClicked,
-                (Action)(() => listingClickedMethod.Invoke(shop, new object[] { listingUI }))
-            );
-
-            listingUI.onDropdownClicked = (Action)System.Delegate.Combine(
-                listingUI.onDropdownClicked,
-                (Action)(() => dropdownClickedMethod.Invoke(shop, new object[] { listingUI }))
-            );
 
             listingUI.hoverStart = (Action)System.Delegate.Combine(
                 listingUI.hoverStart,
@@ -201,6 +219,9 @@ namespace S1API.Internal.Shops
         {
             try
             {
+#if IL2CPPMELON
+                shop.listingUI.Add(listingUI);
+#else
                 // Access the private listingUI field via reflection
                 var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
                     "listingUI",
@@ -209,17 +230,33 @@ namespace S1API.Internal.Shops
 
                 if (listingUIField != null)
                 {
-#if IL2CPPMELON
-                    var listingUIList = listingUIField.GetValue(shop) as Il2CppSystem.Collections.Generic.List<S1UIShop.ListingUI>;
-#else
                     var listingUIList = listingUIField.GetValue(shop) as System.Collections.Generic.List<S1UIShop.ListingUI>;
-#endif
                     listingUIList?.Add(listingUI);
                 }
+#endif
             }
             catch (System.Exception ex)
             {
                 Logger.Warning($"Could not add ListingUI to shop's internal collection: {ex.Message}");
+            }
+        }
+
+        private static void AddToListingPanel(
+            S1UIShop.ShopInterface shop,
+            S1UIShop.ListingUI listingUI)
+        {
+            try
+            {
+#if IL2CPPMELON
+                shop.listingPanel?.AddSelectable(listingUI.Selectable);
+#else
+                GetListingPanel(shop)?.AddSelectable(listingUI.Selectable);
+#endif
+            }
+            catch (System.Exception ex)
+            {
+                Logger.Warning(
+                    $"Could not add ListingUI to the shop navigation panel: {ex.Message}");
             }
         }
 
@@ -269,27 +306,27 @@ namespace S1API.Internal.Shops
 
             try
             {
+#if IL2CPPMELON
+                var listingUIList = shop.listingUI;
+#else
                 var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
                     "listingUI",
                     BindingFlags.NonPublic | BindingFlags.Instance
                 );
-
-                if (listingUIField != null)
-                {
-#if IL2CPPMELON
-                    var listingUIList = listingUIField.GetValue(shop) as Il2CppSystem.Collections.Generic.List<S1UIShop.ListingUI>;
-#else
-                    var listingUIList = listingUIField.GetValue(shop) as System.Collections.Generic.List<S1UIShop.ListingUI>;
+                var listingUIList =
+                    listingUIField?.GetValue(shop) as
+                        System.Collections.Generic.List<S1UIShop.ListingUI>;
 #endif
-                    if (listingUIList != null)
+
+                if (listingUIList != null)
+                {
+                    foreach (var listingUI in listingUIList)
                     {
-                        foreach (var listingUI in listingUIList)
+                        if (listingUI?.Listing == listing &&
+                            listingUI.Icon != null)
                         {
-                            if (listingUI?.Listing == listing && listingUI.Icon != null)
-                            {
-                                listingUI.Icon.sprite = newIcon;
-                                updatedCount++;
-                            }
+                            listingUI.Icon.sprite = newIcon;
+                            updatedCount++;
                         }
                     }
                 }
@@ -306,44 +343,35 @@ namespace S1API.Internal.Shops
         {
             try
             {
+#if IL2CPPMELON
+                var listingUIList = shop.listingUI;
+#else
                 var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
                     "listingUI",
                     BindingFlags.NonPublic | BindingFlags.Instance
                 );
-
-                if (listingUIField != null)
-                {
-#if IL2CPPMELON
-                    var listingUIList = listingUIField.GetValue(shop) as Il2CppSystem.Collections.Generic.List<S1UIShop.ListingUI>;
-                    if (listingUIList != null)
-                    {
-                        for (int i = listingUIList.Count - 1; i >= 0; i--)
-                        {
-                            var ui = listingUIList[i];
-                            if (ui?.Listing == listing)
-                            {
-                                if (ui.gameObject != null)
-                                    UnityEngine.Object.Destroy(ui.gameObject);
-                                listingUIList.RemoveAt(i);
-                            }
-                        }
-                    }
-#else
-                    var listingUIList = listingUIField.GetValue(shop) as System.Collections.Generic.List<S1UIShop.ListingUI>;
-                    if (listingUIList != null)
-                    {
-                        for (int i = listingUIList.Count - 1; i >= 0; i--)
-                        {
-                            var ui = listingUIList[i];
-                            if (ui?.Listing == listing)
-                            {
-                                if (ui.gameObject != null)
-                                    UnityEngine.Object.Destroy(ui.gameObject);
-                                listingUIList.RemoveAt(i);
-                            }
-                        }
-                    }
+                var listingUIList =
+                    listingUIField?.GetValue(shop) as
+                        System.Collections.Generic.List<S1UIShop.ListingUI>;
 #endif
+
+                if (listingUIList != null)
+                {
+                    for (int i = listingUIList.Count - 1; i >= 0; i--)
+                    {
+                        var ui = listingUIList[i];
+                        if (ui?.Listing == listing)
+                        {
+#if IL2CPPMELON
+                                shop.listingPanel?.RemoveSelectable(ui.Selectable);
+#else
+                                GetListingPanel(shop)?.RemoveSelectable(ui.Selectable);
+#endif
+                            if (ui.gameObject != null)
+                                UnityEngine.Object.Destroy(ui.gameObject);
+                            listingUIList.RemoveAt(i);
+                        }
+                    }
                 }
             }
             catch (System.Exception ex)
@@ -353,12 +381,26 @@ namespace S1API.Internal.Shops
         }
 
 #if MONOMELON
-        private static MethodInfo? GetShopMethod(S1UIShop.ShopInterface shop, string methodName)
+        private static MethodInfo? GetShopMethod(
+            string methodName,
+            Type[] parameterTypes)
         {
             return typeof(S1UIShop.ShopInterface).GetMethod(
                 methodName,
-                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                types: parameterTypes,
+                modifiers: null
             );
+        }
+
+        private static S1Root.UIPanel? GetListingPanel(
+            S1UIShop.ShopInterface shop)
+        {
+            FieldInfo? field = typeof(S1UIShop.ShopInterface).GetField(
+                "listingPanel",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return field?.GetValue(shop) as S1Root.UIPanel;
         }
 #endif
     }

--- a/S1API/Internal/Shops/ShopIntegration.cs
+++ b/S1API/Internal/Shops/ShopIntegration.cs
@@ -26,6 +26,21 @@ namespace S1API.Internal.Shops
     {
         private static readonly Log Logger = new Log("ShopIntegration");
 
+#if MONOMELON
+        private const BindingFlags InstanceMemberFlags =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        private static readonly FieldInfo? ListingUIField =
+            typeof(S1UIShop.ShopInterface).GetField(
+                "listingUI",
+                InstanceMemberFlags);
+
+        private static readonly FieldInfo? ListingPanelField =
+            typeof(S1UIShop.ShopInterface).GetField(
+                "listingPanel",
+                InstanceMemberFlags);
+#endif
+
         /// <summary>
         /// Adds an item to a shop with full UI creation and event binding.
         /// </summary>
@@ -159,22 +174,38 @@ namespace S1API.Internal.Shops
         private static void BindListingUIEvents(S1UIShop.ShopInterface shop, S1UIShop.ListingUI listingUI)
         {
 #if IL2CPPMELON
-            listingUI.onAddItem =
+            listingUI.onAddItem = Il2CppSystem.Delegate.Combine(
+                listingUI.onAddItem,
                 DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
-                    new System.Action(() => shop.AddItem(listingUI)));
-            listingUI.onRemoveItem =
+                    new System.Action(() => shop.AddItem(listingUI))))
+                .Cast<Il2CppSystem.Action>();
+            listingUI.onRemoveItem = Il2CppSystem.Delegate.Combine(
+                listingUI.onRemoveItem,
                 DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
-                    new System.Action(() => shop.RemoveItem(listingUI)));
-            listingUI.onSetAmount =
+                    new System.Action(() => shop.RemoveItem(listingUI))))
+                .Cast<Il2CppSystem.Action>();
+            listingUI.onSetAmount = Il2CppSystem.Delegate.Combine(
+                listingUI.onSetAmount,
                 DelegateSupport.ConvertDelegate<Il2CppSystem.Action<int>>(
                     new System.Action<int>(
-                        amount => shop.SetAmount(listingUI, amount)));
-            listingUI.onAdjustAmount =
+                        amount => shop.SetAmount(listingUI, amount))))
+                .Cast<Il2CppSystem.Action<int>>();
+            listingUI.onAdjustAmount = Il2CppSystem.Delegate.Combine(
+                listingUI.onAdjustAmount,
                 DelegateSupport.ConvertDelegate<Il2CppSystem.Action<int>>(
                     new System.Action<int>(
-                        amount => shop.AdjustAmount(listingUI, amount)));
-            listingUI.hoverStart = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.EntryHovered(listingUI)));
-            listingUI.hoverEnd = DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(new System.Action(() => shop.EntryUnhovered()));
+                        amount => shop.AdjustAmount(listingUI, amount))))
+                .Cast<Il2CppSystem.Action<int>>();
+            listingUI.hoverStart = Il2CppSystem.Delegate.Combine(
+                listingUI.hoverStart,
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
+                    new System.Action(() => shop.EntryHovered(listingUI))))
+                .Cast<Il2CppSystem.Action>();
+            listingUI.hoverEnd = Il2CppSystem.Delegate.Combine(
+                listingUI.hoverEnd,
+                DelegateSupport.ConvertDelegate<Il2CppSystem.Action>(
+                    new System.Action(() => shop.EntryUnhovered())))
+                .Cast<Il2CppSystem.Action>();
 #else
             listingUI.onAddItem = (Action)System.Delegate.Combine(
                 listingUI.onAddItem,
@@ -222,17 +253,7 @@ namespace S1API.Internal.Shops
 #if IL2CPPMELON
                 shop.listingUI.Add(listingUI);
 #else
-                // Access the private listingUI field via reflection
-                var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
-                    "listingUI",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-
-                if (listingUIField != null)
-                {
-                    var listingUIList = listingUIField.GetValue(shop) as System.Collections.Generic.List<S1UIShop.ListingUI>;
-                    listingUIList?.Add(listingUI);
-                }
+                GetListingUIList(shop)?.Add(listingUI);
 #endif
             }
             catch (System.Exception ex)
@@ -309,13 +330,7 @@ namespace S1API.Internal.Shops
 #if IL2CPPMELON
                 var listingUIList = shop.listingUI;
 #else
-                var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
-                    "listingUI",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                var listingUIList =
-                    listingUIField?.GetValue(shop) as
-                        System.Collections.Generic.List<S1UIShop.ListingUI>;
+                var listingUIList = GetListingUIList(shop);
 #endif
 
                 if (listingUIList != null)
@@ -346,13 +361,7 @@ namespace S1API.Internal.Shops
 #if IL2CPPMELON
                 var listingUIList = shop.listingUI;
 #else
-                var listingUIField = typeof(S1UIShop.ShopInterface).GetField(
-                    "listingUI",
-                    BindingFlags.NonPublic | BindingFlags.Instance
-                );
-                var listingUIList =
-                    listingUIField?.GetValue(shop) as
-                        System.Collections.Generic.List<S1UIShop.ListingUI>;
+                var listingUIList = GetListingUIList(shop);
 #endif
 
                 if (listingUIList != null)
@@ -363,9 +372,9 @@ namespace S1API.Internal.Shops
                         if (ui?.Listing == listing)
                         {
 #if IL2CPPMELON
-                                shop.listingPanel?.RemoveSelectable(ui.Selectable);
+                            shop.listingPanel?.RemoveSelectable(ui.Selectable);
 #else
-                                GetListingPanel(shop)?.RemoveSelectable(ui.Selectable);
+                            GetListingPanel(shop)?.RemoveSelectable(ui.Selectable);
 #endif
                             if (ui.gameObject != null)
                                 UnityEngine.Object.Destroy(ui.gameObject);
@@ -387,20 +396,24 @@ namespace S1API.Internal.Shops
         {
             return typeof(S1UIShop.ShopInterface).GetMethod(
                 methodName,
-                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance,
+                InstanceMemberFlags,
                 binder: null,
                 types: parameterTypes,
                 modifiers: null
             );
         }
 
+        private static System.Collections.Generic.List<S1UIShop.ListingUI>?
+            GetListingUIList(S1UIShop.ShopInterface shop)
+        {
+            return ListingUIField?.GetValue(shop) as
+                System.Collections.Generic.List<S1UIShop.ListingUI>;
+        }
+
         private static S1Root.UIPanel? GetListingPanel(
             S1UIShop.ShopInterface shop)
         {
-            FieldInfo? field = typeof(S1UIShop.ShopInterface).GetField(
-                "listingPanel",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            return field?.GetValue(shop) as S1Root.UIPanel;
+            return ListingPanelField?.GetValue(shop) as S1Root.UIPanel;
         }
 #endif
     }

--- a/S1API/Products/ProductPresentationProfile.cs
+++ b/S1API/Products/ProductPresentationProfile.cs
@@ -25,6 +25,7 @@ namespace S1API.Products
             int generatedIconSize,
             bool fitGeneratedIconToCamera,
             float generatedIconCameraFill,
+            ProductPresentationTransform? generatedIconTransform,
             IReadOnlyCollection<ProductPresentationContext> requiredContexts)
         {
             VisualProviders = visualProviders;
@@ -35,6 +36,7 @@ namespace S1API.Products
             GeneratedIconSize = generatedIconSize;
             FitGeneratedIconToCamera = fitGeneratedIconToCamera;
             GeneratedIconCameraFill = generatedIconCameraFill;
+            GeneratedIconTransform = generatedIconTransform;
             RequiredContexts = requiredContexts;
         }
 
@@ -56,6 +58,8 @@ namespace S1API.Products
         internal bool FitGeneratedIconToCamera { get; }
 
         internal float GeneratedIconCameraFill { get; }
+
+        internal ProductPresentationTransform? GeneratedIconTransform { get; }
 
         internal IReadOnlyCollection<ProductPresentationContext> RequiredContexts { get; }
 

--- a/S1API/Products/ProductPresentationProfileBuilder.cs
+++ b/S1API/Products/ProductPresentationProfileBuilder.cs
@@ -241,7 +241,8 @@ namespace S1API.Products
         /// <remarks>
         /// This replaces the loose presentation transform during icon capture without changing
         /// stored, held, station, or world presentation. It may be configured before or after
-        /// <see cref="WithGeneratedIconFromLooseVisual(int)"/>.
+        /// <see cref="WithGeneratedIconFromLooseVisual(int)"/>. It is not used when an explicit
+        /// icon provider is selected with <see cref="WithIcon(Func{Sprite?})"/>.
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         /// Thrown when <paramref name="presentationTransform"/> is <see langword="null"/>.

--- a/S1API/Products/ProductPresentationProfileBuilder.cs
+++ b/S1API/Products/ProductPresentationProfileBuilder.cs
@@ -27,6 +27,7 @@ namespace S1API.Products
         private int _generatedIconSize = 512;
         private bool _fitGeneratedIconToCamera = true;
         private float _generatedIconCameraFill = 0.72f;
+        private ProductPresentationTransform? _generatedIconTransform;
 
         /// <summary>
         /// Sets the shared loose visual provider. Stored, held, station, and functional-product
@@ -231,6 +232,30 @@ namespace S1API.Products
         }
 
         /// <summary>
+        /// Sets an icon-only transform for generated loose-visual icons.
+        /// </summary>
+        /// <param name="presentationTransform">
+        /// The cloned visual root transform used only during icon capture.
+        /// </param>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// This replaces the loose presentation transform during icon capture without changing
+        /// stored, held, station, or world presentation. It may be configured before or after
+        /// <see cref="WithGeneratedIconFromLooseVisual(int)"/>.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="presentationTransform"/> is <see langword="null"/>.
+        /// </exception>
+        public ProductPresentationProfileBuilder WithGeneratedIconTransform(
+            ProductPresentationTransform presentationTransform)
+        {
+            _generatedIconTransform =
+                presentationTransform ??
+                throw new ArgumentNullException(nameof(presentationTransform));
+            return this;
+        }
+
+        /// <summary>
         /// Sets the consumption prefab provider.
         /// </summary>
         /// <param name="provider">
@@ -307,6 +332,7 @@ namespace S1API.Products
                 _generatedIconSize,
                 _fitGeneratedIconToCamera,
                 _generatedIconCameraFill,
+                _generatedIconTransform,
                 new List<ProductPresentationContext>(_requiredContexts).AsReadOnly());
         }
 

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -236,8 +236,20 @@ Adjust the framing or preserve the authored scale with the additive overload:
 ```
 
 Set `fitToCamera: false` when the provider's scale is already authored for the
-base-game thumbnail rig. The loose presentation transform controls icon
-rotation; `cameraFill` controls only automatic scale fitting. Direct
+base-game thumbnail rig. By default, the loose presentation transform controls
+icon rotation. Use an icon-only transform when the inventory view needs a
+different angle without changing the world model:
+
+```csharp
+.WithGeneratedIconTransform(
+    new ProductPresentationTransform(
+        Vector3.zero,
+        new Vector3(45f, 0f, 0f),
+        Vector3.one))
+```
+
+The icon-only transform replaces the loose transform during capture;
+`cameraFill` controls only automatic scale fitting. Direct
 `IconFactory.GenerateIcon` and `GenerateIconSprite` overloads expose the same
 framing controls.
 


### PR DESCRIPTION
## Summary
- bind custom shop listings to the current native add/remove/set/adjust cart events
- register custom listing selectables with the shop navigation panel and clean them up on removal
- add an opt-in generated-icon transform so mods can change thumbnail angles without changing world presentation

## Compatibility
- no existing public signatures were removed or changed
- the icon transform is additive and opt-in; existing profiles retain their exact loose-transform behavior
- shop changes are internal and mirror the current native `ShopInterface.CreateListingUI` contract on Mono and IL2CPP

## Validation
- MonoMelon build
- Il2CppMelon build
- full S1API.Tests: Mono 260/260, IL2CPP 252/252
- public API documentation coverage: 81.35% (minimum 80%)
- local-only real-game smoke on Mono and IL2CPP confirmed cart/hover delegates for custom listings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated transform for generated inventory icons.
  * Generated icons can now use a different angle or scale than the product’s standard presentation.

* **Bug Fixes**
  * Corrected generated icon rendering so it uses its dedicated transform when configured.
  * Improved shop listing UI behavior across supported runtime environments.

* **Documentation**
  * Updated custom product guidance with generated icon transform configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->