### PR TITLE
feat(products): support convex functional colliders

### DIFF
--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -216,6 +216,10 @@ public sealed class ProductApiCompatibilityTests
                     .WithFunctionalProductVisual),
             typeof(Func<UnityEngine.GameObject>));
         AssertBuilderMethod(
+            nameof(
+                ProductPresentationProfileBuilder
+                    .WithFunctionalProductConvexMeshColliders));
+        AssertBuilderMethod(
             nameof(ProductPresentationProfileBuilder.WithIcon),
             typeof(Func<UnityEngine.Sprite>));
         AssertBuilderMethod(

--- a/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileApiCompileFixture.cs
@@ -21,6 +21,7 @@ internal static class ProductPresentationProfileApiCompileFixture
                 .WithHeldVisual(contextVisual)
                 .WithStationVisual(contextVisual)
                 .WithFunctionalProductVisual(contextVisual)
+                .WithFunctionalProductConvexMeshColliders()
                 .WithIcon(icon)
                 .WithConsumptionPrefab(consumption)
                 .Require(

--- a/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
@@ -177,11 +177,27 @@ public sealed class ProductPresentationProfileBuilderTests
 
         ProductPresentationProfile optedIn =
             builder
+                .WithLooseVisual(() => null)
                 .WithFunctionalProductConvexMeshColliders()
                 .Build();
 
         Assert.False(legacy.UseFunctionalProductConvexMeshColliders);
         Assert.True(optedIn.UseFunctionalProductConvexMeshColliders);
+    }
+
+    [Fact]
+    public void FunctionalProductConvexMeshCollidersRequireAVisualProvider()
+    {
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(
+                () => new ProductPresentationProfileBuilder()
+                    .WithFunctionalProductConvexMeshColliders()
+                    .Build());
+
+        Assert.Contains(
+            "functional-product visual or loose-visual fallback",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
 #if MONOMELON

--- a/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileBuilderTests.cs
@@ -169,6 +169,21 @@ public sealed class ProductPresentationProfileBuilderTests
         Assert.Equal(1.25f, profile.GeneratedIconCameraFill);
     }
 
+    [Fact]
+    public void FunctionalProductConvexMeshCollidersAreOptInAndSnapshotted()
+    {
+        var builder = new ProductPresentationProfileBuilder();
+        ProductPresentationProfile legacy = builder.Build();
+
+        ProductPresentationProfile optedIn =
+            builder
+                .WithFunctionalProductConvexMeshColliders()
+                .Build();
+
+        Assert.False(legacy.UseFunctionalProductConvexMeshColliders);
+        Assert.True(optedIn.UseFunctionalProductConvexMeshColliders);
+    }
+
 #if MONOMELON
     [Fact]
     public void GeneratedIconTransformIsSnapshottedSeparatelyFromLoosePresentation()

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -970,6 +970,11 @@ namespace S1API.Internal.Products
             if (visual.GetComponentInChildren<Collider>(true) != null)
                 return;
 
+            AddBoxCollider(visual);
+        }
+
+        private static void AddBoxCollider(GameObject visual)
+        {
             Renderer[] renderers =
                 visual.GetComponentsInChildren<Renderer>(true);
             if (renderers.Length == 0)
@@ -1020,18 +1025,48 @@ namespace S1API.Internal.Products
             for (int i = 0; i < filters.Length; i++)
             {
                 MeshFilter filter = filters[i];
-                if (filter.sharedMesh == null)
-                    continue;
-
-                MeshCollider collider =
-                    filter.gameObject.AddComponent<MeshCollider>();
-                collider.sharedMesh = filter.sharedMesh;
-                collider.convex = true;
-                added++;
+                if (TryAddConvexMeshCollider(filter))
+                    added++;
             }
 
             if (added == 0)
-                EnsureCollider(visual);
+                AddBoxCollider(visual);
+        }
+
+        private static bool TryAddConvexMeshCollider(MeshFilter filter)
+        {
+            Mesh? mesh = filter.sharedMesh;
+            if (mesh == null ||
+                mesh.bounds.size.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return false;
+            }
+
+            MeshCollider collider =
+                filter.gameObject.AddComponent<MeshCollider>();
+            try
+            {
+                collider.convex = true;
+                collider.sharedMesh = mesh;
+                if (collider.enabled &&
+                    collider.convex &&
+                    collider.sharedMesh != null &&
+                    (!collider.gameObject.activeInHierarchy ||
+                     collider.bounds.size.sqrMagnitude > Mathf.Epsilon))
+                {
+                    return true;
+                }
+            }
+            catch (Exception exception)
+            {
+                MelonLogger.Warning(
+                    $"[ProductPresentationProfile] Could not create a convex " +
+                    $"mesh collider from '{mesh.name}': {exception.Message}");
+            }
+
+            collider.enabled = false;
+            Object.Destroy(collider);
+            return false;
         }
 
         private static T MissingScaffold<T>(

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -376,7 +376,16 @@ namespace S1API.Internal.Products
                     source,
                     profile,
                     ProductPresentationContext.FunctionalProduct);
-            EnsureCollider(functional.Visuals.VisualsContainer.gameObject);
+            if (profile.UseFunctionalProductConvexMeshColliders)
+            {
+                ReplaceWithConvexMeshColliders(
+                    functional.gameObject,
+                    functional.Visuals.VisualsContainer.gameObject);
+            }
+            else
+            {
+                EnsureCollider(functional.Visuals.VisualsContainer.gameObject);
+            }
             return clone;
         }
 
@@ -994,6 +1003,35 @@ namespace S1API.Internal.Products
             BoxCollider collider = visual.AddComponent<BoxCollider>();
             collider.center = bounds.center;
             collider.size = bounds.size;
+        }
+
+        private static void ReplaceWithConvexMeshColliders(
+            GameObject scaffold,
+            GameObject visual)
+        {
+            Collider[] inheritedColliders =
+                scaffold.GetComponentsInChildren<Collider>(true);
+            for (int i = 0; i < inheritedColliders.Length; i++)
+                inheritedColliders[i].enabled = false;
+
+            MeshFilter[] filters =
+                visual.GetComponentsInChildren<MeshFilter>(true);
+            int added = 0;
+            for (int i = 0; i < filters.Length; i++)
+            {
+                MeshFilter filter = filters[i];
+                if (filter.sharedMesh == null)
+                    continue;
+
+                MeshCollider collider =
+                    filter.gameObject.AddComponent<MeshCollider>();
+                collider.sharedMesh = filter.sharedMesh;
+                collider.convex = true;
+                added++;
+            }
+
+            if (added == 0)
+                EnsureCollider(visual);
         }
 
         private static T MissingScaffold<T>(

--- a/S1API/Products/ProductPresentationProfile.cs
+++ b/S1API/Products/ProductPresentationProfile.cs
@@ -26,6 +26,7 @@ namespace S1API.Products
             bool fitGeneratedIconToCamera,
             float generatedIconCameraFill,
             ProductPresentationTransform? generatedIconTransform,
+            bool useFunctionalProductConvexMeshColliders,
             IReadOnlyCollection<ProductPresentationContext> requiredContexts)
         {
             VisualProviders = visualProviders;
@@ -37,6 +38,8 @@ namespace S1API.Products
             FitGeneratedIconToCamera = fitGeneratedIconToCamera;
             GeneratedIconCameraFill = generatedIconCameraFill;
             GeneratedIconTransform = generatedIconTransform;
+            UseFunctionalProductConvexMeshColliders =
+                useFunctionalProductConvexMeshColliders;
             RequiredContexts = requiredContexts;
         }
 
@@ -60,6 +63,8 @@ namespace S1API.Products
         internal float GeneratedIconCameraFill { get; }
 
         internal ProductPresentationTransform? GeneratedIconTransform { get; }
+
+        internal bool UseFunctionalProductConvexMeshColliders { get; }
 
         internal IReadOnlyCollection<ProductPresentationContext> RequiredContexts { get; }
 

--- a/S1API/Products/ProductPresentationProfileBuilder.cs
+++ b/S1API/Products/ProductPresentationProfileBuilder.cs
@@ -28,6 +28,7 @@ namespace S1API.Products
         private bool _fitGeneratedIconToCamera = true;
         private float _generatedIconCameraFill = 0.72f;
         private ProductPresentationTransform? _generatedIconTransform;
+        private bool _useFunctionalProductConvexMeshColliders;
 
         /// <summary>
         /// Sets the shared loose visual provider. Stored, held, station, and functional-product
@@ -165,6 +166,24 @@ namespace S1API.Products
                 ProductPresentationContext.FunctionalProduct,
                 provider,
                 presentationTransform);
+        }
+
+        /// <summary>
+        /// Replaces inherited functional-product colliders with convex mesh colliders
+        /// built from the configured functional visual.
+        /// </summary>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// Use this for compact or non-box-shaped loose products that participate in
+        /// packaging-station physics. The default remains the native scaffold collider
+        /// plus S1API's legacy box-collider fallback so existing mods retain their
+        /// current collision behavior.
+        /// </remarks>
+        public ProductPresentationProfileBuilder
+            WithFunctionalProductConvexMeshColliders()
+        {
+            _useFunctionalProductConvexMeshColliders = true;
+            return this;
         }
 
         /// <summary>
@@ -334,6 +353,7 @@ namespace S1API.Products
                 _fitGeneratedIconToCamera,
                 _generatedIconCameraFill,
                 _generatedIconTransform,
+                _useFunctionalProductConvexMeshColliders,
                 new List<ProductPresentationContext>(_requiredContexts).AsReadOnly());
         }
 

--- a/S1API/Products/ProductPresentationProfileBuilder.cs
+++ b/S1API/Products/ProductPresentationProfileBuilder.cs
@@ -178,6 +178,8 @@ namespace S1API.Products
         /// packaging-station physics. The default remains the native scaffold collider
         /// plus S1API's legacy box-collider fallback so existing mods retain their
         /// current collision behavior.
+        /// A functional-product visual or loose-visual fallback must be configured
+        /// before <see cref="Build"/>.
         /// </remarks>
         public ProductPresentationProfileBuilder
             WithFunctionalProductConvexMeshColliders()
@@ -411,6 +413,17 @@ namespace S1API.Products
 
         private void ValidateRequiredProviders()
         {
+            if (_useFunctionalProductConvexMeshColliders &&
+                !_visualProviders.ContainsKey(
+                    ProductPresentationContext.FunctionalProduct) &&
+                !_visualProviders.ContainsKey(
+                    ProductPresentationContext.Loose))
+            {
+                throw new InvalidOperationException(
+                    "Functional-product convex mesh colliders require a " +
+                    "functional-product visual or loose-visual fallback before Build().");
+            }
+
             foreach (ProductPresentationContext context in _requiredContexts)
             {
                 bool configured;

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -138,6 +138,7 @@ GameObject pillVisual = LoadPillVisual();
 ProductPresentationProfile pillProfile =
     new ProductPresentationProfileBuilder()
         .WithLooseVisual(() => pillVisual)
+        .WithFunctionalProductConvexMeshColliders()
         .WithGeneratedIconFromLooseVisual(size: 512)
         .Require(
             ProductPresentationContext.Stored,
@@ -186,6 +187,13 @@ stored-item, equippable, station-item, and functional-product scaffolds,
 replacing only their family-specific visual setter. This keeps native storage
 footprints, station modules, draggable behavior, first-person equip behavior,
 and consumption wiring intact.
+
+Compact or non-box-shaped products can opt into
+`WithFunctionalProductConvexMeshColliders()`. S1API then disables the cloned
+template's inherited colliders and builds convex colliders from the custom
+functional visual's mesh filters. This is intended for dynamic loose-product
+physics in packaging stations. The option is disabled by default so existing
+profiles retain their original scaffold and box-fallback collision behavior.
 
 For runtime-imported GLB sources, keep one reusable source active beneath a
 persistent root positioned outside the playable scene; providers should return

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -192,8 +192,11 @@ Compact or non-box-shaped products can opt into
 `WithFunctionalProductConvexMeshColliders()`. S1API then disables the cloned
 template's inherited colliders and builds convex colliders from the custom
 functional visual's mesh filters. This is intended for dynamic loose-product
-physics in packaging stations. The option is disabled by default so existing
-profiles retain their original scaffold and box-fallback collision behavior.
+physics in packaging stations. Configure a functional-product visual or
+loose-visual fallback before enabling it. Meshes that Unity cannot retain as
+usable convex colliders fall back to a bounds-based box collider. The option is
+disabled by default so existing profiles retain their original scaffold and
+box-fallback collision behavior.
 
 For runtime-imported GLB sources, keep one reusable source active beneath a
 persistent root positioned outside the playable scene; providers should return


### PR DESCRIPTION
## Summary

- add an opt-in `WithFunctionalProductConvexMeshColliders()` presentation setting
- replace inherited functional-product collision geometry with convex mesh colliders from the custom visual only when opted in
- preserve the existing scaffold and box-fallback path by default
- document the packaging-station use case

Closes #131.

## Validation

- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 266 passed
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 258 passed
- MonoMelon and Il2CppMelon solution builds — succeeded with zero warnings/errors
- DocFX build — succeeded (only existing unresolved external assembly warnings)
- public API documentation coverage — 81.36% (minimum 80%)

Real packaging-station physics remains a manual consumer-mod test because it depends on runtime-imported meshes and the native Unity scene.

## Compatibility

- **Source:** additive builder method; existing calls are unchanged.
- **Binary:** no existing public signature or member shape changed.
- **Behavior:** opt-in only; omitted/default behavior keeps inherited scaffold collision and the legacy box fallback exactly as before.
- **Save/network:** no IDs, descriptors, payloads, or serialization paths changed.
- **Runtime parity:** the public contract, default snapshot, and opted-in snapshot are covered in both Mono and IL2CPP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in option to use convex mesh colliders for functional product visuals.
  * Convex colliders are generated from visual meshes, with a fallback to existing collision behavior when needed.
  * Existing behavior remains unchanged unless the option is enabled.

* **Documentation**
  * Updated custom product guidance with configuration examples and usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->