### PR TITLE
fix(items): refresh late-bound item icons

### DIFF
--- a/S1API.Tests/Items/ItemIconRuntimeContractTests.cs
+++ b/S1API.Tests/Items/ItemIconRuntimeContractTests.cs
@@ -1,0 +1,42 @@
+using S1API.Internal.Items;
+using S1API.Items;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+public sealed class ItemIconRuntimeContractTests
+{
+    [Theory]
+    [InlineData("ifbars.example:item", "ifbars.example:item", true)]
+    [InlineData("IFBARS.EXAMPLE:ITEM", "ifbars.example:item", true)]
+    [InlineData("ifbars.example:other", "ifbars.example:item", false)]
+    [InlineData("", "ifbars.example:item", false)]
+    [InlineData("ifbars.example:item", "", false)]
+    [InlineData(null, "ifbars.example:item", false)]
+    [InlineData("ifbars.example:item", null, false)]
+    public void BoundSlotMatchingUsesStableCaseInsensitiveItemIds(
+        string? candidateItemId,
+        string? targetItemId,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ItemIconRuntime.MatchesItemId(
+                candidateItemId,
+                targetItemId));
+    }
+
+    [Fact]
+    public void ExistingIconPropertyShapeRemainsCompatible()
+    {
+        var property = typeof(ItemDefinition).GetProperty(
+            nameof(ItemDefinition.Icon));
+
+        Assert.NotNull(property);
+        Assert.Equal(typeof(Sprite), property!.PropertyType);
+        Assert.True(property.CanRead);
+        Assert.True(property.CanWrite);
+        Assert.NotNull(property.SetMethod);
+        Assert.True(property.SetMethod!.IsPublic);
+    }
+}

--- a/S1API/Internal/Items/ItemIconRuntime.cs
+++ b/S1API/Internal/Items/ItemIconRuntime.cs
@@ -1,0 +1,113 @@
+#if IL2CPPMELON
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1UI = Il2CppScheduleOne.UI;
+using S1UIShop = Il2CppScheduleOne.UI.Shop;
+#elif MONOMELON
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1UI = ScheduleOne.UI;
+using S1UIShop = ScheduleOne.UI.Shop;
+#endif
+
+using System;
+using S1API.Logging;
+using UnityEngine;
+
+namespace S1API.Internal.Items
+{
+    /// <summary>
+    /// Keeps already-bound native UI synchronized with late item icon changes.
+    /// </summary>
+    internal static class ItemIconRuntime
+    {
+        private static readonly Log Logger = new Log("ItemIconRuntime");
+
+        internal static void SetIcon(
+            S1ItemFramework.ItemDefinition definition,
+            Sprite icon)
+        {
+            definition.Icon = icon;
+            RefreshVisibleUis(definition);
+        }
+
+        internal static void RefreshVisibleUis(
+            S1ItemFramework.ItemDefinition definition)
+        {
+            if (definition == null)
+                return;
+
+            RefreshBoundItemSlots(definition.ID);
+            RefreshBoundShopListings(definition.ID, definition.Icon);
+        }
+
+        private static void RefreshBoundItemSlots(string itemId)
+        {
+            try
+            {
+                S1UI.ItemSlotUI[] slotUis =
+                    UnityEngine.Object.FindObjectsOfType<S1UI.ItemSlotUI>(
+                        includeInactive: true);
+                for (int index = 0; index < slotUis.Length; index++)
+                {
+                    S1UI.ItemSlotUI slotUi = slotUis[index];
+                    if (slotUi == null ||
+                        !MatchesItemId(
+                            slotUi.assignedSlot?.ItemInstance?.ID,
+                            itemId))
+                    {
+                        continue;
+                    }
+
+                    slotUi.UpdateUI();
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Warning(
+                    $"Could not refresh bound item slots for " +
+                    $"'{itemId}': {exception.Message}");
+            }
+        }
+
+        private static void RefreshBoundShopListings(
+            string itemId,
+            Sprite icon)
+        {
+            try
+            {
+                S1UIShop.ListingUI[] listingUis =
+                    UnityEngine.Object.FindObjectsOfType<S1UIShop.ListingUI>(
+                        includeInactive: true);
+                for (int index = 0; index < listingUis.Length; index++)
+                {
+                    S1UIShop.ListingUI listingUi = listingUis[index];
+                    if (listingUi == null ||
+                        listingUi.Icon == null ||
+                        !MatchesItemId(
+                            listingUi.Listing?.Item?.ID,
+                            itemId))
+                    {
+                        continue;
+                    }
+
+                    listingUi.Icon.sprite = icon;
+                }
+            }
+            catch (Exception exception)
+            {
+                Logger.Warning(
+                    $"Could not refresh bound shop listings for " +
+                    $"'{itemId}': {exception.Message}");
+            }
+        }
+
+        internal static bool MatchesItemId(
+            string? candidateItemId,
+            string? targetItemId) =>
+            !string.IsNullOrWhiteSpace(candidateItemId) &&
+            !string.IsNullOrWhiteSpace(targetItemId) &&
+            string.Equals(
+                candidateItemId,
+                targetItemId,
+                StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/S1API/Items/ItemDefinition.cs
+++ b/S1API/Items/ItemDefinition.cs
@@ -8,6 +8,7 @@ using S1CoreItemFramework = ScheduleOne.Core.Items.Framework;
 
 using UnityEngine;
 using S1API.Internal.Abstraction;
+using S1API.Internal.Items;
 
 namespace S1API.Items
 {
@@ -80,12 +81,13 @@ namespace S1API.Items
         }
 
         /// <summary>
-        /// The icon for this item.
+        /// The icon for this item. Assigning a new icon also refreshes
+        /// already-bound inventory and shop UI for this item.
         /// </summary>
         public Sprite Icon
         {
             get => S1ItemDefinition.Icon;
-            set => S1ItemDefinition.Icon = value;
+            set => ItemIconRuntime.SetIcon(S1ItemDefinition, value);
         }
 
         /// <summary>

--- a/S1API/Rendering/IconFactory.cs
+++ b/S1API/Rendering/IconFactory.cs
@@ -272,8 +272,13 @@ namespace S1API.Rendering
         /// <param name="size">The size of the square icon (default 512).</param>
         /// <param name="bakeSkinnedMeshes">If true, bakes SkinnedMeshRenderers to static MeshRenderers to ensure correct bounds (default true).</param>
         /// <returns>A Sprite containing the icon, or null if generation failed.</returns>
-        public static Sprite? GenerateIconSprite(Transform model, int size = 512, bool bakeSkinnedMeshes = true) =>
-            ImageUtils.TextureToSprite(GenerateIcon(model, size, bakeSkinnedMeshes));
+        public static Sprite? GenerateIconSprite(
+            Transform model,
+            int size = 512,
+            bool bakeSkinnedMeshes = true) =>
+            CreateDurableIconSprite(
+                GenerateIcon(model, size, bakeSkinnedMeshes),
+                model != null ? model.name : "Item");
 
         /// <summary>
         /// Generates a preview sprite with explicit native-camera framing controls.
@@ -299,13 +304,14 @@ namespace S1API.Rendering
             bool bakeSkinnedMeshes,
             bool fitToCamera,
             float cameraFill = 0.72f) =>
-            ImageUtils.TextureToSprite(
+            CreateDurableIconSprite(
                 GenerateIcon(
                     model,
                     size,
                     bakeSkinnedMeshes,
                     fitToCamera,
-                    cameraFill));
+                    cameraFill),
+                model != null ? model.name : "Item");
 
         /// <summary>
         /// Generates an icon as a Sprite for a packaging ID and product ID.
@@ -313,8 +319,12 @@ namespace S1API.Rendering
         /// <param name="packagingID">The ID of the packaging visuals to use.</param>
         /// <param name="productID">The ID of the product to display in the packaging.</param>
         /// <returns>A Sprite containing the packaging icon, or null if generation failed.</returns>
-        public static Sprite? GeneratePackagingIconSprite(string packagingID, string productID) =>
-            ImageUtils.TextureToSprite(GeneratePackagingIcon(packagingID, productID));
+        public static Sprite? GeneratePackagingIconSprite(
+            string packagingID,
+            string productID) =>
+            CreateDurableIconSprite(
+                GeneratePackagingIcon(packagingID, productID),
+                $"{packagingID}_{productID}");
 
         #region Accessory Icon Generation
 
@@ -379,13 +389,64 @@ namespace S1API.Rendering
         {
             GenerateAccessoryIcon(accessoryPath, texture =>
             {
-                callback?.Invoke(ImageUtils.TextureToSprite(texture));
+                callback?.Invoke(
+                    CreateDurableIconSprite(
+                        texture,
+                        string.IsNullOrWhiteSpace(accessoryPath)
+                            ? "Accessory"
+                            : accessoryPath));
             }, accessoryColor, size);
         }
 
         #endregion
 
         #region Private Helper Methods
+
+        private static Sprite? CreateDurableIconSprite(
+            Texture2D? renderedTexture,
+            string name)
+        {
+            if (renderedTexture == null)
+                return null;
+
+            try
+            {
+                byte[]? encoded = renderedTexture.EncodeToPNG();
+                if (encoded == null || encoded.Length == 0)
+                {
+                    Logger.Error(
+                        $"Generated icon texture for '{name}' could not be " +
+                        "encoded into a durable UI texture.");
+                    return null;
+                }
+
+                Sprite? icon = ImageUtils.LoadImageRaw(encoded);
+                if (icon == null)
+                {
+                    Logger.Error(
+                        $"Generated icon texture for '{name}' could not be " +
+                        "decoded into a durable UI sprite.");
+                    return null;
+                }
+
+                icon.name = $"{name}_Icon";
+                icon.texture.name = $"{name}_IconTexture";
+                icon.texture.filterMode = FilterMode.Bilinear;
+                icon.texture.wrapMode = TextureWrapMode.Clamp;
+                return icon;
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    $"Generated icon texture for '{name}' could not be " +
+                    $"normalized: {exception.Message}");
+                return null;
+            }
+            finally
+            {
+                UnityEngine.Object.Destroy(renderedTexture);
+            }
+        }
 
         /// <summary>
         /// Internal state tracking for SkinnedMeshRenderer baking.

--- a/S1API/docs/item-icons.md
+++ b/S1API/docs/item-icons.md
@@ -1,13 +1,14 @@
 # Item Icons
 
-S1API supports loading item icons from embedded resources or AssetBundles.
+S1API supports loading item icons from embedded resources or AssetBundles and
+capturing icons from runtime models.
 
 ## From Embedded Resources
 
 Load sprites from embedded resources in your mod assembly with `ImageUtils`:
 
 ```csharp
-using S1API.Internal.Utils;
+using S1API.Utils;
 using System.Reflection;
 using UnityEngine;
 
@@ -44,10 +45,38 @@ var item = ItemCreator.CreateBuilder()
     .Build();
 ```
 
+## From a Runtime Model
+
+Use `IconFactory.GenerateIconSprite` when your item model is already loaded:
+
+```csharp
+using S1API.Rendering;
+
+var icon = IconFactory.GenerateIconSprite(itemModel.transform);
+if (icon != null)
+{
+    itemDefinition.Icon = icon;
+}
+```
+
+The sprite overloads return a durable UI sprite. S1API normalizes the native
+capture before returning it, so mod code does not need to encode and reload the
+captured texture.
+
+Assigning `ItemDefinition.Icon` also refreshes inventory slots and shop listings
+that are already displaying that item. This covers icons generated after a save
+has restored existing stacks. Mod code does not need to force an inventory move
+or manually refresh those UIs.
+
+The lower-level `IconFactory.GenerateIcon` texture overloads remain available
+when direct texture ownership is required. Callers own textures returned by
+those overloads.
+
 ## Tips
 
 - Prefer square icons at 128x128 or larger
 - Load and validate sprites before building the item definition
+- Prefer `GenerateIconSprite` over manually converting a generated texture
 - Use embedded resources for small self-contained mods
 - Use AssetBundles when the icon ships alongside other art assets
 


### PR DESCRIPTION
## Summary

- normalize all `IconFactory` sprite captures into durable UI-owned textures
- refresh already-bound inventory slots and shop listings when `ItemDefinition.Icon` changes
- document the framework-owned late icon workflow and retain the lower-level caller-owned texture APIs
- add contract coverage for stable case-insensitive item matching and the existing public `Icon` property shape

## Root cause

A saved item stack can bind its native fallback icon before a mod finishes capturing its custom runtime icon. Updating the item definition later does not make an already-bound `ItemSlotUI` redraw, so the fallback remains visible until the player moves or combines the stack. Mods were also forced to repeat a PNG encode/reload workaround because a sprite created directly over the transient native capture was not durable enough for later UI use.

## Compatibility

This is behavioral and additive only: no public signatures, item IDs, save formats, or network formats change. The existing `ItemDefinition.Icon` property remains read/write, lower-level `GenerateIcon` texture overloads retain caller ownership, and the packaging-specific refresh added by PR #130 remains in place for per-instance composite icons.

## Validation

- Mono build: zero warnings/errors
- Mono tests: 273/273
- IL2CPP build: zero warnings/errors
- IL2CPP tests: 265/265
- documentation coverage: 81.40% (minimum 80%)
- visible copied-save smoke on Mono and IL2CPP, combined locally with PR #132 for MoreDrugs compatibility
  - pre-existing MDMA Crystal stack had the generated icon before any drag/move
  - live item-slot refresh passed after movement
  - exported icon PNG and in-game hotbar captures were visually inspected in both runtimes
  - original saves and Mods directories were restored; smoke sources and evidence remain local only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Item icon updates now refresh visible inventory slots and shop listings automatically.
  * Added support for generating durable UI-ready icons from runtime models, accessories, and packaging.
  * Icon matching is case-insensitive and handles missing identifiers safely.

* **Documentation**
  * Added guidance and examples for acquiring icons from runtime models and assigning them to item definitions.
  * Updated icon generation recommendations and namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->