### PR TITLE
feat(products): add effect clear callbacks

### DIFF
--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -115,8 +115,8 @@ public sealed class ProductApiCompatibilityTests
         AssertCallbackRegistration(nameof(ProductManager.SetNpcEffectClearCallback), typeof(NPC));
         AssertCallbackRemoval(nameof(ProductManager.RemoveEffectClearCallback));
         AssertCallbackRemoval(nameof(ProductManager.RemoveNpcEffectClearCallback));
-        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearEffectClearCallbacks), Type.EmptyTypes));
-        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearNpcEffectClearCallbacks), Type.EmptyTypes));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ResetEffectClearCallbacks), Type.EmptyTypes));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ResetNpcEffectClearCallbacks), Type.EmptyTypes));
 
         Assert.Equal(
             typeof(CustomEffectBuilder),

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -7,7 +7,10 @@ using NativeDrugTypeContainer = ScheduleOne.Product.DrugTypeContainer;
 #endif
 
 using S1API.Items;
+using S1API.Entities;
 using S1API.Products;
+using S1API.Properties;
+using S1API.Properties.Interfaces;
 using S1API.Rendering;
 
 namespace S1API.Tests.Products;
@@ -96,6 +99,48 @@ public sealed class ProductApiCompatibilityTests
         Assert.Equal(typeof(DrugType), primaryDrugType.PropertyType);
         Assert.NotNull(drugTypeValues);
         Assert.Equal(typeof(IReadOnlyList<DrugType>), drugTypeValues.PropertyType);
+    }
+
+    [Fact]
+    public void ProductEffectClearCallbackApiIsAdditiveAndApplyOnlySignaturesAreUnchanged()
+    {
+        AssertCallbackRegistration(nameof(ProductManager.SetEffectCallback), typeof(Player));
+        AssertCallbackRegistration(nameof(ProductManager.SetNpcEffectCallback), typeof(NPC));
+        AssertCallbackRemoval(nameof(ProductManager.RemoveEffectCallback));
+        AssertCallbackRemoval(nameof(ProductManager.RemoveNpcEffectCallback));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearEffectCallbacks), Type.EmptyTypes));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearNpcEffectCallbacks), Type.EmptyTypes));
+
+        AssertCallbackRegistration(nameof(ProductManager.SetEffectClearCallback), typeof(Player));
+        AssertCallbackRegistration(nameof(ProductManager.SetNpcEffectClearCallback), typeof(NPC));
+        AssertCallbackRemoval(nameof(ProductManager.RemoveEffectClearCallback));
+        AssertCallbackRemoval(nameof(ProductManager.RemoveNpcEffectClearCallback));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearEffectClearCallbacks), Type.EmptyTypes));
+        Assert.NotNull(typeof(ProductManager).GetMethod(nameof(ProductManager.ClearNpcEffectClearCallbacks), Type.EmptyTypes));
+
+        Assert.Equal(
+            typeof(CustomEffectBuilder),
+            typeof(CustomEffectBuilder).GetMethod(
+                nameof(CustomEffectBuilder.WithBehavior),
+                new[] { typeof(Action<Player>) })!.ReturnType);
+        Assert.Equal(
+            typeof(CustomEffectBuilder),
+            typeof(CustomEffectBuilder).GetMethod(
+                nameof(CustomEffectBuilder.WithNpcBehavior),
+                new[] { typeof(Action<NPC>) })!.ReturnType);
+        Assert.Null(typeof(CustomEffectBuilder).GetMethod(
+            nameof(CustomEffectBuilder.WithBehavior),
+            new[] { typeof(Action<Player>), typeof(Action<Player>) }));
+        Assert.Equal(
+            typeof(CustomEffectBuilder),
+            typeof(CustomEffectBuilder).GetMethod(
+                nameof(CustomEffectBuilder.WithClearBehavior),
+                new[] { typeof(Action<Player>) })!.ReturnType);
+        Assert.Equal(
+            typeof(CustomEffectBuilder),
+            typeof(CustomEffectBuilder).GetMethod(
+                nameof(CustomEffectBuilder.WithNpcClearBehavior),
+                new[] { typeof(Action<NPC>) })!.ReturnType);
     }
 
     [Fact]
@@ -433,5 +478,34 @@ public sealed class ProductApiCompatibilityTests
                 parameterTypes);
         Assert.NotNull(method);
         Assert.Equal(typeof(ProductPresentationProfileBuilder), method.ReturnType);
+    }
+
+    private static void AssertCallbackRegistration(string methodName, Type targetType)
+    {
+        var callbackType = typeof(Action<>).MakeGenericType(targetType);
+
+        foreach (var identifierType in new[] { typeof(string), typeof(PropertyBase) })
+        {
+            var method = typeof(ProductManager).GetMethod(
+                methodName,
+                new[] { identifierType, callbackType, typeof(bool) });
+
+            Assert.NotNull(method);
+            Assert.Equal(typeof(void), method.ReturnType);
+            Assert.Equal("allowDefaultEffect", method.GetParameters()[2].Name);
+            Assert.True(method.GetParameters()[2].IsOptional);
+            Assert.Equal(false, method.GetParameters()[2].DefaultValue);
+        }
+    }
+
+    private static void AssertCallbackRemoval(string methodName)
+    {
+        foreach (var identifierType in new[] { typeof(string), typeof(PropertyBase) })
+        {
+            var method = typeof(ProductManager).GetMethod(methodName, new[] { identifierType });
+
+            Assert.NotNull(method);
+            Assert.Equal(typeof(bool), method.ReturnType);
+        }
     }
 }

--- a/S1API.Tests/Products/ProductEffectCallbackTests.cs
+++ b/S1API.Tests/Products/ProductEffectCallbackTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Runtime.CompilerServices;
+using S1API.Entities;
+using S1API.Entities.NPCs;
+using S1API.Products;
+using S1API.Properties.Interfaces;
+using Xunit;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductEffectCallbackTests : IDisposable
+{
+    public ProductEffectCallbackTests()
+    {
+        ProductManager.ClearEffectCallbacks();
+        ProductManager.ClearNpcEffectCallbacks();
+        ProductManager.ClearEffectClearCallbacks();
+        ProductManager.ClearNpcEffectClearCallbacks();
+    }
+
+    public void Dispose()
+    {
+        ProductManager.ClearEffectCallbacks();
+        ProductManager.ClearNpcEffectCallbacks();
+        ProductManager.ClearEffectClearCallbacks();
+        ProductManager.ClearNpcEffectClearCallbacks();
+    }
+
+    [Fact]
+    public void ExistingApplyOnlyPlayerCallbackRemainsIndependentFromClearCallbacks()
+    {
+        var player = CreatePlayer();
+        var applyCount = 0;
+
+        ProductManager.SetEffectCallback("test_apply_only", _ => applyCount++);
+
+        Assert.True(ProductManager.TryInvokeEffectCallback("TEST_APPLY_ONLY", player, out var allowDefaultApply));
+        Assert.False(allowDefaultApply);
+        Assert.Equal(1, applyCount);
+
+        Assert.False(ProductManager.TryInvokeEffectClearCallback("test_apply_only", player, out var allowDefaultClear));
+        Assert.False(allowDefaultClear);
+    }
+
+    [Fact]
+    public void PlayerClearCallbackInvokesRepeatedlyAndCanAllowNativeFallthrough()
+    {
+        var player = CreatePlayer();
+        var clearCount = 0;
+
+        ProductManager.SetEffectClearCallback("test_player_clear", _ => clearCount++, allowDefaultEffect: true);
+
+        Assert.True(ProductManager.TryInvokeEffectClearCallback("TEST_PLAYER_CLEAR", player, out var allowDefaultFirst));
+        Assert.True(ProductManager.TryInvokeEffectClearCallback("test_player_clear", player, out var allowDefaultSecond));
+
+        Assert.True(allowDefaultFirst);
+        Assert.True(allowDefaultSecond);
+        Assert.Equal(2, clearCount);
+    }
+
+    [Fact]
+    public void NpcClearCallbackInvokesAndCanAllowNativeFallthrough()
+    {
+        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+        var clearCount = 0;
+
+        ProductManager.SetNpcEffectClearCallback("test_npc_clear", _ => clearCount++, allowDefaultEffect: true);
+
+        Assert.True(ProductManager.TryInvokeNpcEffectClearCallback("TEST_NPC_CLEAR", npc, out var allowDefaultClear));
+        Assert.True(allowDefaultClear);
+        Assert.Equal(1, clearCount);
+    }
+
+    [Fact]
+    public void MissingClearCallbackUsesNativeFallthrough()
+    {
+        var player = CreatePlayer();
+        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+
+        Assert.False(ProductManager.TryInvokeEffectClearCallback("missing", player, out var playerAllowDefault));
+        Assert.False(ProductManager.TryInvokeNpcEffectClearCallback("missing", npc, out var npcAllowDefault));
+
+        Assert.False(playerAllowDefault);
+        Assert.False(npcAllowDefault);
+    }
+
+    [Fact]
+    public void ClearCallbackRegistrationReplacesPriorCallbackAndRemovesCleanly()
+    {
+        var player = CreatePlayer();
+        var firstCount = 0;
+        var replacementCount = 0;
+
+        ProductManager.SetEffectClearCallback("test_duplicate", _ => firstCount++);
+        ProductManager.SetEffectClearCallback("TEST_DUPLICATE", _ => replacementCount++);
+
+        Assert.True(ProductManager.TryInvokeEffectClearCallback("test_duplicate", player, out _));
+        Assert.Equal(0, firstCount);
+        Assert.Equal(1, replacementCount);
+        Assert.True(ProductManager.RemoveEffectClearCallback("test_duplicate"));
+        Assert.False(ProductManager.RemoveEffectClearCallback("test_duplicate"));
+        Assert.False(ProductManager.TryInvokeEffectClearCallback("test_duplicate", player, out _));
+    }
+
+    [Fact]
+    public void ClearCallbackExceptionsAreSurfacedToTheLifecyclePatchAndDoNotCorruptRegistration()
+    {
+        var player = CreatePlayer();
+        ProductManager.SetEffectClearCallback("test_exception", _ => throw new InvalidOperationException("expected"));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ProductManager.TryInvokeEffectClearCallback("test_exception", player, out _));
+
+        var recoveryCount = 0;
+        ProductManager.SetEffectClearCallback("test_exception", _ => recoveryCount++);
+
+        Assert.True(ProductManager.TryInvokeEffectClearCallback("test_exception", player, out _));
+        Assert.Equal(1, recoveryCount);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void ClearCallbackRegistrationRejectsInvalidEffectIds(string effectId)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            ProductManager.SetEffectClearCallback(effectId, _ => { }));
+        Assert.Throws<ArgumentException>(() =>
+            ProductManager.SetNpcEffectClearCallback(effectId, _ => { }));
+        Assert.False(ProductManager.RemoveEffectClearCallback(effectId));
+        Assert.False(ProductManager.RemoveNpcEffectClearCallback(effectId));
+    }
+
+    [Fact]
+    public void ClearCallbackRegistrationRejectsNullInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.SetEffectClearCallback("test", null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.SetNpcEffectClearCallback("test", null!));
+        Assert.Throws<ArgumentException>(() =>
+            ProductManager.SetEffectClearCallback((string)null!, _ => { }));
+        Assert.Throws<ArgumentException>(() =>
+            ProductManager.SetNpcEffectClearCallback((string)null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.SetEffectClearCallback((PropertyBase)null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.SetNpcEffectClearCallback((PropertyBase)null!, _ => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.RemoveEffectClearCallback((PropertyBase)null!));
+        Assert.Throws<ArgumentNullException>(() =>
+            ProductManager.RemoveNpcEffectClearCallback((PropertyBase)null!));
+    }
+
+    private static Player CreatePlayer() =>
+        (Player)RuntimeHelpers.GetUninitializedObject(typeof(Player));
+}

--- a/S1API.Tests/Products/ProductEffectCallbackTests.cs
+++ b/S1API.Tests/Products/ProductEffectCallbackTests.cs
@@ -14,16 +14,16 @@ public sealed class ProductEffectCallbackTests : IDisposable
     {
         ProductManager.ClearEffectCallbacks();
         ProductManager.ClearNpcEffectCallbacks();
-        ProductManager.ClearEffectClearCallbacks();
-        ProductManager.ClearNpcEffectClearCallbacks();
+        ProductManager.ResetEffectClearCallbacks();
+        ProductManager.ResetNpcEffectClearCallbacks();
     }
 
     public void Dispose()
     {
         ProductManager.ClearEffectCallbacks();
         ProductManager.ClearNpcEffectCallbacks();
-        ProductManager.ClearEffectClearCallbacks();
-        ProductManager.ClearNpcEffectClearCallbacks();
+        ProductManager.ResetEffectClearCallbacks();
+        ProductManager.ResetNpcEffectClearCallbacks();
     }
 
     [Fact]
@@ -100,6 +100,22 @@ public sealed class ProductEffectCallbackTests : IDisposable
         Assert.True(ProductManager.RemoveEffectClearCallback("test_duplicate"));
         Assert.False(ProductManager.RemoveEffectClearCallback("test_duplicate"));
         Assert.False(ProductManager.TryInvokeEffectClearCallback("test_duplicate", player, out _));
+    }
+
+    [Fact]
+    public void ResetClearCallbacksRemovesPlayerAndNpcRegistrations()
+    {
+        var player = CreatePlayer();
+        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+
+        ProductManager.SetEffectClearCallback("test_reset_player", _ => { });
+        ProductManager.SetNpcEffectClearCallback("test_reset_npc", _ => { });
+
+        ProductManager.ResetEffectClearCallbacks();
+        ProductManager.ResetNpcEffectClearCallbacks();
+
+        Assert.False(ProductManager.TryInvokeEffectClearCallback("test_reset_player", player, out _));
+        Assert.False(ProductManager.TryInvokeNpcEffectClearCallback("test_reset_npc", npc, out _));
     }
 
     [Fact]

--- a/S1API/Internal/Patches/ProductEffectPatches.cs
+++ b/S1API/Internal/Patches/ProductEffectPatches.cs
@@ -32,7 +32,7 @@ namespace S1API.Internal.Patches
         private static Dictionary<string, Type>? _npcWrapperTypeById;
 
         /// <summary>
-        /// Targets only the base ProductItemInstance ApplyEffectsToPlayer and ApplyEffectsToNPC implementations.
+        /// Targets only the base ProductItemInstance apply and clear implementations.
         /// Subclass overrides (e.g., WeedInstance) will run their custom logic and then call base,
         /// which is intercepted here to route through callbacks.
         /// </summary>
@@ -55,6 +55,18 @@ namespace S1API.Internal.Patches
                     BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
                     null,
                     new[] { npcType },
+                    null),
+                baseType.GetMethod(
+                    "ClearEffectsFromPlayer",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { playerType },
+                    null),
+                baseType.GetMethod(
+                    "ClearEffectsFromNPC",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    null,
+                    new[] { npcType },
                     null)
             }
             .Where(method => method != null)
@@ -62,16 +74,22 @@ namespace S1API.Internal.Patches
         }
 
         /// <summary>
-        /// Intercepts product effect application for players and NPCs and executes callbacks per effect ID.
-        /// Unhandled effects fall back to base game behavior (effect.ApplyToPlayer).
+        /// Intercepts product effect application and clearing for players and NPCs and executes callbacks per effect ID.
+        /// Unhandled effects fall back to their native apply or clear behavior.
         /// </summary>
         /// <param name="__instance">The product instance applying effects.</param>
         /// <param name="__0">The first argument (player or NPC receiving effects).</param>
+        /// <param name="__originalMethod">The native product lifecycle method being intercepted.</param>
         /// <returns><c>false</c> when handled here; <c>true</c> to run original method.</returns>
         [HarmonyPrefix]
-        private static bool ApplyEffects_Prefix(S1Product.ProductItemInstance __instance, object __0)
+        private static bool ProductEffects_Prefix(
+            S1Product.ProductItemInstance __instance,
+            object __0,
+            MethodBase __originalMethod)
         {
             var target = __0;
+            var isClear = __originalMethod?.Name == "ClearEffectsFromPlayer" ||
+                          __originalMethod?.Name == "ClearEffectsFromNPC";
 
             if (__instance == null || target == null)
                 return true;
@@ -106,23 +124,39 @@ namespace S1API.Internal.Patches
                 {
                     if (targetPlayer != null)
                     {
-                        var handled = ProductManager.TryInvokeEffectCallback(effectId, localPlayer!, out var allowDefaultEffect);
+                        var handled = isClear
+                            ? ProductManager.TryInvokeEffectClearCallback(effectId, localPlayer!, out var allowDefaultEffect)
+                            : ProductManager.TryInvokeEffectCallback(effectId, localPlayer!, out allowDefaultEffect);
                         if (!handled || allowDefaultEffect)
-                            effect.ApplyToPlayer(targetPlayer);
+                        {
+                            if (isClear)
+                                effect.ClearFromPlayer(targetPlayer);
+                            else
+                                effect.ApplyToPlayer(targetPlayer);
+                        }
                     }
                     else
                     {
                         var apiNpc = ResolveApiNpc(targetNpc);
 
                         var allowDefaultEffect = false;
-                        var handled = apiNpc != null && ProductManager.TryInvokeNpcEffectCallback(effectId, apiNpc, out allowDefaultEffect);
+                        var handled = apiNpc != null &&
+                                      (isClear
+                                          ? ProductManager.TryInvokeNpcEffectClearCallback(effectId, apiNpc, out allowDefaultEffect)
+                                          : ProductManager.TryInvokeNpcEffectCallback(effectId, apiNpc, out allowDefaultEffect));
                         if (!handled || allowDefaultEffect)
-                            effect.ApplyToNPC(targetNpc);
+                        {
+                            if (isClear)
+                                effect.ClearFromNPC(targetNpc);
+                            else
+                                effect.ApplyToNPC(targetNpc);
+                        }
                     }
                 }
                 catch (Exception ex)
                 {
-                    Logger.Error($"Exception while invoking effect callback for '{effectId}': {ex.Message}");
+                    var lifecycle = isClear ? "clear" : "apply";
+                    Logger.Error($"Exception while invoking effect {lifecycle} callback for '{effectId}': {ex.Message}");
                     Logger.Error(ex.StackTrace ?? string.Empty);
                 }
             }

--- a/S1API/Products/ProductManager.cs
+++ b/S1API/Products/ProductManager.cs
@@ -42,8 +42,36 @@ namespace S1API.Products
             internal bool AllowDefaultEffect { get; }
         }
 
+        private sealed class EffectClearCallbackRegistration
+        {
+            internal EffectClearCallbackRegistration(Action<Player> callback, bool allowDefaultEffect)
+            {
+                Callback = callback;
+                AllowDefaultEffect = allowDefaultEffect;
+            }
+
+            internal Action<Player> Callback { get; }
+
+            internal bool AllowDefaultEffect { get; }
+        }
+
+        private sealed class NpcEffectClearCallbackRegistration
+        {
+            internal NpcEffectClearCallbackRegistration(Action<NPC> callback, bool allowDefaultEffect)
+            {
+                Callback = callback;
+                AllowDefaultEffect = allowDefaultEffect;
+            }
+
+            internal Action<NPC> Callback { get; }
+
+            internal bool AllowDefaultEffect { get; }
+        }
+
         private static readonly Dictionary<string, EffectCallbackRegistration> EffectCallbacks = new Dictionary<string, EffectCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
         private static readonly Dictionary<string, NpcEffectCallbackRegistration> NpcEffectCallbacks = new Dictionary<string, NpcEffectCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, EffectClearCallbackRegistration> EffectClearCallbacks = new Dictionary<string, EffectClearCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, NpcEffectClearCallbackRegistration> NpcEffectClearCallbacks = new Dictionary<string, NpcEffectClearCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Minimum price for any product (1).
@@ -255,6 +283,148 @@ namespace S1API.Products
             NpcEffectCallbacks.Clear();
 
         /// <summary>
+        /// Registers or replaces a callback for when a product effect is cleared from the local player.
+        /// The callback can optionally allow the base game clear behavior to run as well.
+        /// </summary>
+        /// <param name="property">The product effect/property to override.</param>
+        /// <param name="callback">The callback to invoke with the local player when the effect clears.</param>
+        /// <param name="allowDefaultEffect">
+        /// If <c>true</c>, the base game effect is also cleared.
+        /// If <c>false</c>, only the callback runs for this effect.
+        /// </param>
+        public static void SetEffectClearCallback(PropertyBase property, Action<Player> callback, bool allowDefaultEffect = false)
+        {
+            if (property == null)
+                throw new ArgumentNullException(nameof(property));
+
+            SetEffectClearCallback(property.ID, callback, allowDefaultEffect);
+        }
+
+        /// <summary>
+        /// Registers or replaces a callback for when a product effect ID is cleared from the local player.
+        /// The callback can optionally allow the base game clear behavior to run as well.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <param name="callback">The callback to invoke with the local player when the effect clears.</param>
+        /// <param name="allowDefaultEffect">
+        /// If <c>true</c>, the base game effect is also cleared.
+        /// If <c>false</c>, only the callback runs for this effect.
+        /// </param>
+        public static void SetEffectClearCallback(string effectId, Action<Player> callback, bool allowDefaultEffect = false)
+        {
+            if (string.IsNullOrWhiteSpace(effectId))
+                throw new ArgumentException("Effect ID cannot be null or whitespace.", nameof(effectId));
+
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            EffectClearCallbacks[effectId] = new EffectClearCallbackRegistration(callback, allowDefaultEffect);
+        }
+
+        /// <summary>
+        /// Removes a player effect clear callback by property.
+        /// </summary>
+        /// <param name="property">The product effect/property to remove.</param>
+        /// <returns><c>true</c> if a callback was removed; otherwise <c>false</c>.</returns>
+        public static bool RemoveEffectClearCallback(PropertyBase property)
+        {
+            if (property == null)
+                throw new ArgumentNullException(nameof(property));
+
+            return RemoveEffectClearCallback(property.ID);
+        }
+
+        /// <summary>
+        /// Removes a player effect clear callback by effect ID.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <returns><c>true</c> if a callback was removed; otherwise <c>false</c>.</returns>
+        public static bool RemoveEffectClearCallback(string effectId)
+        {
+            if (string.IsNullOrWhiteSpace(effectId))
+                return false;
+
+            return EffectClearCallbacks.Remove(effectId);
+        }
+
+        /// <summary>
+        /// Removes all registered player product effect clear callbacks.
+        /// </summary>
+        public static void ClearEffectClearCallbacks() =>
+            EffectClearCallbacks.Clear();
+
+        /// <summary>
+        /// Registers or replaces a callback for when a product effect is cleared from an NPC.
+        /// The callback can optionally allow the base game clear behavior to run as well.
+        /// </summary>
+        /// <param name="property">The product effect/property to override.</param>
+        /// <param name="callback">The callback to invoke with the target NPC when the effect clears.</param>
+        /// <param name="allowDefaultEffect">
+        /// If <c>true</c>, the base game effect is also cleared.
+        /// If <c>false</c>, only the callback runs for this effect.
+        /// </param>
+        public static void SetNpcEffectClearCallback(PropertyBase property, Action<NPC> callback, bool allowDefaultEffect = false)
+        {
+            if (property == null)
+                throw new ArgumentNullException(nameof(property));
+
+            SetNpcEffectClearCallback(property.ID, callback, allowDefaultEffect);
+        }
+
+        /// <summary>
+        /// Registers or replaces a callback for when a product effect ID is cleared from an NPC.
+        /// The callback can optionally allow the base game clear behavior to run as well.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <param name="callback">The callback to invoke with the target NPC when the effect clears.</param>
+        /// <param name="allowDefaultEffect">
+        /// If <c>true</c>, the base game effect is also cleared.
+        /// If <c>false</c>, only the callback runs for this effect.
+        /// </param>
+        public static void SetNpcEffectClearCallback(string effectId, Action<NPC> callback, bool allowDefaultEffect = false)
+        {
+            if (string.IsNullOrWhiteSpace(effectId))
+                throw new ArgumentException("Effect ID cannot be null or whitespace.", nameof(effectId));
+
+            if (callback == null)
+                throw new ArgumentNullException(nameof(callback));
+
+            NpcEffectClearCallbacks[effectId] = new NpcEffectClearCallbackRegistration(callback, allowDefaultEffect);
+        }
+
+        /// <summary>
+        /// Removes an NPC effect clear callback by property.
+        /// </summary>
+        /// <param name="property">The product effect/property to remove.</param>
+        /// <returns><c>true</c> if a callback was removed; otherwise <c>false</c>.</returns>
+        public static bool RemoveNpcEffectClearCallback(PropertyBase property)
+        {
+            if (property == null)
+                throw new ArgumentNullException(nameof(property));
+
+            return RemoveNpcEffectClearCallback(property.ID);
+        }
+
+        /// <summary>
+        /// Removes an NPC effect clear callback by effect ID.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <returns><c>true</c> if a callback was removed; otherwise <c>false</c>.</returns>
+        public static bool RemoveNpcEffectClearCallback(string effectId)
+        {
+            if (string.IsNullOrWhiteSpace(effectId))
+                return false;
+
+            return NpcEffectClearCallbacks.Remove(effectId);
+        }
+
+        /// <summary>
+        /// Removes all registered NPC product effect clear callbacks.
+        /// </summary>
+        public static void ClearNpcEffectClearCallbacks() =>
+            NpcEffectClearCallbacks.Clear();
+
+        /// <summary>
         /// INTERNAL: Tries to invoke a registered product effect callback.
         /// </summary>
         /// <param name="effectId">The product effect ID.</param>
@@ -291,6 +461,50 @@ namespace S1API.Products
                 return false;
 
             if (!NpcEffectCallbacks.TryGetValue(effectId, out var registration) || registration?.Callback == null)
+                return false;
+
+            allowDefaultEffect = registration.AllowDefaultEffect;
+            registration.Callback(npc);
+            return true;
+        }
+
+        /// <summary>
+        /// INTERNAL: Tries to invoke a registered player product effect clear callback.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <param name="player">The local player wrapper to pass into the callback.</param>
+        /// <param name="allowDefaultEffect">Outputs whether the base game effect should also be cleared.</param>
+        /// <returns><c>true</c> if a callback was found and invoked; otherwise <c>false</c>.</returns>
+        internal static bool TryInvokeEffectClearCallback(string effectId, Player player, out bool allowDefaultEffect)
+        {
+            allowDefaultEffect = false;
+
+            if (string.IsNullOrWhiteSpace(effectId) || player == null)
+                return false;
+
+            if (!EffectClearCallbacks.TryGetValue(effectId, out var registration) || registration?.Callback == null)
+                return false;
+
+            allowDefaultEffect = registration.AllowDefaultEffect;
+            registration.Callback(player);
+            return true;
+        }
+
+        /// <summary>
+        /// INTERNAL: Tries to invoke a registered NPC product effect clear callback.
+        /// </summary>
+        /// <param name="effectId">The product effect ID.</param>
+        /// <param name="npc">The NPC wrapper to pass into the callback.</param>
+        /// <param name="allowDefaultEffect">Outputs whether the base game effect should also be cleared.</param>
+        /// <returns><c>true</c> if a callback was found and invoked; otherwise <c>false</c>.</returns>
+        internal static bool TryInvokeNpcEffectClearCallback(string effectId, NPC npc, out bool allowDefaultEffect)
+        {
+            allowDefaultEffect = false;
+
+            if (string.IsNullOrWhiteSpace(effectId) || npc == null)
+                return false;
+
+            if (!NpcEffectClearCallbacks.TryGetValue(effectId, out var registration) || registration?.Callback == null)
                 return false;
 
             allowDefaultEffect = registration.AllowDefaultEffect;

--- a/S1API/Products/ProductManager.cs
+++ b/S1API/Products/ProductManager.cs
@@ -16,62 +16,23 @@ namespace S1API.Products
     /// </summary>
     public static class ProductManager
     {
-        private sealed class EffectCallbackRegistration
+        private sealed class EffectCallbackRegistration<T>
         {
-            internal EffectCallbackRegistration(Action<Player> callback, bool allowDefaultEffect)
+            internal EffectCallbackRegistration(Action<T> callback, bool allowDefaultEffect)
             {
                 Callback = callback;
                 AllowDefaultEffect = allowDefaultEffect;
             }
 
-            internal Action<Player> Callback { get; }
+            internal Action<T> Callback { get; }
 
             internal bool AllowDefaultEffect { get; }
         }
 
-        private sealed class NpcEffectCallbackRegistration
-        {
-            internal NpcEffectCallbackRegistration(Action<NPC> callback, bool allowDefaultEffect)
-            {
-                Callback = callback;
-                AllowDefaultEffect = allowDefaultEffect;
-            }
-
-            internal Action<NPC> Callback { get; }
-
-            internal bool AllowDefaultEffect { get; }
-        }
-
-        private sealed class EffectClearCallbackRegistration
-        {
-            internal EffectClearCallbackRegistration(Action<Player> callback, bool allowDefaultEffect)
-            {
-                Callback = callback;
-                AllowDefaultEffect = allowDefaultEffect;
-            }
-
-            internal Action<Player> Callback { get; }
-
-            internal bool AllowDefaultEffect { get; }
-        }
-
-        private sealed class NpcEffectClearCallbackRegistration
-        {
-            internal NpcEffectClearCallbackRegistration(Action<NPC> callback, bool allowDefaultEffect)
-            {
-                Callback = callback;
-                AllowDefaultEffect = allowDefaultEffect;
-            }
-
-            internal Action<NPC> Callback { get; }
-
-            internal bool AllowDefaultEffect { get; }
-        }
-
-        private static readonly Dictionary<string, EffectCallbackRegistration> EffectCallbacks = new Dictionary<string, EffectCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
-        private static readonly Dictionary<string, NpcEffectCallbackRegistration> NpcEffectCallbacks = new Dictionary<string, NpcEffectCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
-        private static readonly Dictionary<string, EffectClearCallbackRegistration> EffectClearCallbacks = new Dictionary<string, EffectClearCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
-        private static readonly Dictionary<string, NpcEffectClearCallbackRegistration> NpcEffectClearCallbacks = new Dictionary<string, NpcEffectClearCallbackRegistration>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, EffectCallbackRegistration<Player>> EffectCallbacks = new Dictionary<string, EffectCallbackRegistration<Player>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, EffectCallbackRegistration<NPC>> NpcEffectCallbacks = new Dictionary<string, EffectCallbackRegistration<NPC>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, EffectCallbackRegistration<Player>> EffectClearCallbacks = new Dictionary<string, EffectCallbackRegistration<Player>>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, EffectCallbackRegistration<NPC>> NpcEffectClearCallbacks = new Dictionary<string, EffectCallbackRegistration<NPC>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Minimum price for any product (1).
@@ -176,7 +137,7 @@ namespace S1API.Products
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));
 
-            EffectCallbacks[effectId] = new EffectCallbackRegistration(callback, allowDefaultEffect);
+            EffectCallbacks[effectId] = new EffectCallbackRegistration<Player>(callback, allowDefaultEffect);
         }
 
         /// <summary>
@@ -247,7 +208,7 @@ namespace S1API.Products
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));
 
-            NpcEffectCallbacks[effectId] = new NpcEffectCallbackRegistration(callback, allowDefaultEffect);
+            NpcEffectCallbacks[effectId] = new EffectCallbackRegistration<NPC>(callback, allowDefaultEffect);
         }
 
         /// <summary>
@@ -318,7 +279,7 @@ namespace S1API.Products
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));
 
-            EffectClearCallbacks[effectId] = new EffectClearCallbackRegistration(callback, allowDefaultEffect);
+            EffectClearCallbacks[effectId] = new EffectCallbackRegistration<Player>(callback, allowDefaultEffect);
         }
 
         /// <summary>
@@ -348,9 +309,9 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Removes all registered player product effect clear callbacks.
+        /// Resets all registered player product effect clear callbacks.
         /// </summary>
-        public static void ClearEffectClearCallbacks() =>
+        public static void ResetEffectClearCallbacks() =>
             EffectClearCallbacks.Clear();
 
         /// <summary>
@@ -389,7 +350,7 @@ namespace S1API.Products
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));
 
-            NpcEffectClearCallbacks[effectId] = new NpcEffectClearCallbackRegistration(callback, allowDefaultEffect);
+            NpcEffectClearCallbacks[effectId] = new EffectCallbackRegistration<NPC>(callback, allowDefaultEffect);
         }
 
         /// <summary>
@@ -419,9 +380,9 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Removes all registered NPC product effect clear callbacks.
+        /// Resets all registered NPC product effect clear callbacks.
         /// </summary>
-        public static void ClearNpcEffectClearCallbacks() =>
+        public static void ResetNpcEffectClearCallbacks() =>
             NpcEffectClearCallbacks.Clear();
 
         /// <summary>

--- a/S1API/Properties/CustomEffectBuilder.cs
+++ b/S1API/Properties/CustomEffectBuilder.cs
@@ -45,6 +45,8 @@ namespace S1API.Properties
         private DrugType[]? _drugs;
         private Action<Player>? _playerBehavior;
         private Action<NPC>? _npcBehavior;
+        private Action<Player>? _playerClearBehavior;
+        private Action<NPC>? _npcClearBehavior;
 
         /// <summary>
         /// Sets the effect's identity and display text.
@@ -172,6 +174,30 @@ namespace S1API.Properties
         }
 
         /// <summary>
+        /// Sets the behavior run when this effect is cleared from the local player.
+        /// The callback can be invoked more than once, so it should remove only state owned by this effect.
+        /// </summary>
+        /// <param name="onClear">Callback invoked with the local player when the effect clears.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithClearBehavior(Action<Player> onClear)
+        {
+            _playerClearBehavior = onClear;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the behavior run when this effect is cleared from an NPC.
+        /// The callback can be invoked more than once, so it should remove only state owned by this effect.
+        /// </summary>
+        /// <param name="onClear">Callback invoked with the NPC when the effect clears.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public CustomEffectBuilder WithNpcClearBehavior(Action<NPC> onClear)
+        {
+            _npcClearBehavior = onClear;
+            return this;
+        }
+
+        /// <summary>
         /// Builds and registers the custom effect and returns a token usable anywhere a property is accepted.
         /// </summary>
         /// <returns>A <see cref="CustomEffect"/> token for the created effect.</returns>
@@ -218,6 +244,12 @@ namespace S1API.Properties
 
             if (_npcBehavior != null)
                 ProductManager.SetNpcEffectCallback(_id, _npcBehavior, allowDefaultEffect: false);
+
+            if (_playerClearBehavior != null)
+                ProductManager.SetEffectClearCallback(_id, _playerClearBehavior, allowDefaultEffect: false);
+
+            if (_npcClearBehavior != null)
+                ProductManager.SetNpcEffectClearCallback(_id, _npcClearBehavior, allowDefaultEffect: false);
 
             CustomEffectRegistry.Register(effect, ResolveDrugs(), _mixMapPosition, _mixMapRadius);
 

--- a/S1API/docs/mixing-ingredients.md
+++ b/S1API/docs/mixing-ingredients.md
@@ -126,6 +126,11 @@ var glow = EffectCreator.CreateBuilder()
     {
         // Runs when this effect triggers on the local player.
     })
+    .WithClearBehavior(player =>
+    {
+        // Runs when the native product lifecycle clears this effect from the local player.
+        // Keep this cleanup safe if it is called more than once.
+    })
     .Build();
 
 // Use the custom effect on an ingredient just like a vanilla one:

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -146,6 +146,27 @@ ProductManager.RemoveEffectCallback(Property.Euphoric);
 
 Use `ProductManager.ClearEffectCallbacks()` to remove all registered overrides.
 
+### Player clear callbacks
+
+Register a separate callback to unwind state when the native product lifecycle clears an effect. Clear callbacks
+replace the base clear behavior by default, and should be safe if the game clears the same effect more than once.
+
+```csharp
+ProductManager.SetEffectClearCallback(Property.Euphoric, player =>
+{
+    // Remove only state this effect owns.
+});
+
+// Optional: run the callback AND keep default clear behavior.
+ProductManager.SetEffectClearCallback(Property.Euphoric, player =>
+{
+    // Custom cleanup.
+}, allowDefaultEffect: true);
+```
+
+Use `ProductManager.RemoveEffectClearCallback(...)` or `ProductManager.ClearEffectClearCallbacks()` to remove
+registered player clear callbacks.
+
 ### NPC callbacks
 
 You can also intercept effects applied through `ApplyEffectsToNPC`:
@@ -171,6 +192,20 @@ ProductManager.RemoveNpcEffectCallback(Property.Sneaky);
 ```
 
 Use `ProductManager.ClearNpcEffectCallbacks()` to remove all registered NPC overrides.
+
+### NPC clear callbacks
+
+NPC clear callbacks follow the same lifecycle and default behavior:
+
+```csharp
+ProductManager.SetNpcEffectClearCallback(Property.Sneaky, npc =>
+{
+    // Remove only state this effect owns.
+});
+```
+
+Use `ProductManager.RemoveNpcEffectClearCallback(...)` or `ProductManager.ClearNpcEffectClearCallbacks()` to remove
+registered NPC clear callbacks.
 
 ## Creating product instances
 

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -164,7 +164,7 @@ ProductManager.SetEffectClearCallback(Property.Euphoric, player =>
 }, allowDefaultEffect: true);
 ```
 
-Use `ProductManager.RemoveEffectClearCallback(...)` or `ProductManager.ClearEffectClearCallbacks()` to remove
+Use `ProductManager.RemoveEffectClearCallback(...)` or `ProductManager.ResetEffectClearCallbacks()` to remove
 registered player clear callbacks.
 
 ### NPC callbacks
@@ -202,9 +202,15 @@ ProductManager.SetNpcEffectClearCallback(Property.Sneaky, npc =>
 {
     // Remove only state this effect owns.
 });
+
+// Optional: run the callback AND keep default clear behavior.
+ProductManager.SetNpcEffectClearCallback(Property.Sneaky, npc =>
+{
+    // Custom cleanup.
+}, allowDefaultEffect: true);
 ```
 
-Use `ProductManager.RemoveNpcEffectClearCallback(...)` or `ProductManager.ClearNpcEffectClearCallbacks()` to remove
+Use `ProductManager.RemoveNpcEffectClearCallback(...)` or `ProductManager.ResetNpcEffectClearCallbacks()` to remove
 registered NPC clear callbacks.
 
 ## Creating product instances


### PR DESCRIPTION
## Summary

- add opt-in player and NPC product-effect clear callbacks, including builder helpers for custom effects
- route only the base `ProductItemInstance.ClearEffectsFromPlayer` and `ClearEffectsFromNPC` seams through the existing callback lifecycle
- document clear callback ownership/idempotency and add contract coverage for registrations, dispatch, fallthrough, exceptions, and legacy apply-only APIs

Closes #134

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` (277 passed)
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` (269 passed)
- DocFX generated API metadata; public documentation coverage: 81.47% (2,946/3,616; minimum 80%)

Mono and IL2CPP method shapes were verified locally against the base `ProductItemInstance` clear seams. A real-game player/NPC expiration and replacement smoke remains to be run; no runtime smoke artifacts are included in this PR.

## Compatibility

- **Source/binary:** additive public methods only. Existing apply-only `WithBehavior`, `WithNpcBehavior`, and `ProductManager` callback signatures remain unchanged; no ambiguous builder overload was added.
- **Behavioral:** apply-only registrations remain independent of clear callbacks. Unregistered clear effects use native clearing; registered callbacks retain the existing optional native-fallthrough model and exception isolation per effect.
- **Save/network:** no product/effect IDs, save formats, manifests, or network payloads change.