### PR TITLE
feat(products): add custom consumption profiles

### DIFF
--- a/S1API.Tests/Products/CustomProductManifestDataTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestDataTests.cs
@@ -136,6 +136,8 @@ public sealed class CustomProductManifestDataTests
         upper.OwnerId = lower.OwnerId.ToUpperInvariant();
         upper.ProductKindId = lower.ProductKindId.ToUpperInvariant();
         upper.ProviderId = lower.ProviderId!.ToUpperInvariant();
+        upper.ConsumptionProfileProviderId =
+            lower.ConsumptionProfileProviderId.ToUpperInvariant();
         upper.RepresentationTemplateId =
             lower.RepresentationTemplateId.ToUpperInvariant();
         upper.PresentationProfileId =
@@ -172,7 +174,9 @@ public sealed class CustomProductManifestDataTests
             .ToArray();
 
         Assert.DoesNotContain("ProviderData", names);
+        Assert.DoesNotContain("ConsumptionProfileProviderData", names);
         Assert.Contains("ProviderId", names);
+        Assert.Contains("ConsumptionProfileProviderId", names);
         Assert.Contains("CompatibilityHash", names);
     }
 
@@ -216,6 +220,8 @@ public sealed class CustomProductManifestDataTests
     [InlineData("DescriptorFormatVersion")]
     [InlineData("PresentationProfileId")]
     [InlineData("PackagingIds")]
+    [InlineData("ConsumptionProfileProviderId")]
+    [InlineData("ConsumptionProfileProviderVersion")]
     public void CompatibilityHashChangesForCompatibilityRelevantMetadata(string field)
     {
         CustomProductManifestEntryData baseline = CreateEntry("example:alpha");
@@ -239,6 +245,12 @@ public sealed class CustomProductManifestDataTests
                 break;
             case "PackagingIds":
                 changed.PackagingIds = new[] { "bag" };
+                break;
+            case "ConsumptionProfileProviderId":
+                changed.ConsumptionProfileProviderId = "example:other-consumption-provider";
+                break;
+            case "ConsumptionProfileProviderVersion":
+                changed.ConsumptionProfileProviderVersion++;
                 break;
         }
 
@@ -277,6 +289,8 @@ public sealed class CustomProductManifestDataTests
             ProviderAvailable = true,
             RepresentationTemplateId = "ogkush",
             PresentationProfileId = "example:" + productId,
+            ConsumptionProfileProviderId = "example:consumption-provider",
+            ConsumptionProfileProviderVersion = 1,
             PackagingIds = new[] { "bag", "jar" },
             CompatibilityHash = new string('a', 64)
         };

--- a/S1API.Tests/Products/CustomProductManifestDataTests.cs
+++ b/S1API.Tests/Products/CustomProductManifestDataTests.cs
@@ -126,6 +126,11 @@ public sealed class CustomProductManifestDataTests
             .Select(index => "package:" + index)
             .ToArray();
         Assert.False(excessivePackaging.IsValid());
+
+        CustomProductManifestEntryData zeroConsumptionProviderVersion =
+            CreateEntry("example:zero-consumption-provider-version");
+        zeroConsumptionProviderVersion.ConsumptionProfileProviderVersion = 0;
+        Assert.False(zeroConsumptionProviderVersion.IsValid());
     }
 
     [Fact]

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -386,6 +386,63 @@ public sealed class ProductApiCompatibilityTests
     }
 
     [Fact]
+    public void ProductConsumptionProfileApiIsAdditiveAndRuntimeAgnostic()
+    {
+        Assert.True(typeof(ProductConsumptionProfile).IsSealed);
+        Assert.True(typeof(ProductConsumptionProfileBuilder).IsSealed);
+        Assert.True(typeof(ProductConsumptionContext).IsSealed);
+        Assert.True(typeof(ProductConsumptionProfileRegistry).IsAbstract);
+        Assert.True(typeof(ProductConsumptionProfileRegistry).IsSealed);
+
+        Assert.Equal(typeof(string), typeof(ProductConsumptionProfile)
+            .GetProperty(nameof(ProductConsumptionProfile.ProviderId))!.PropertyType);
+        Assert.Equal(typeof(int), typeof(ProductConsumptionProfile)
+            .GetProperty(nameof(ProductConsumptionProfile.ProviderVersion))!.PropertyType);
+        Assert.Equal(typeof(string), typeof(ProductConsumptionContext)
+            .GetProperty(nameof(ProductConsumptionContext.ProductId))!.PropertyType);
+        Assert.Equal(typeof(ProductKind), typeof(ProductConsumptionContext)
+            .GetProperty(nameof(ProductConsumptionContext.ProductKind))!.PropertyType);
+
+        Assert.Equal(
+            typeof(ProductConsumptionProfileBuilder),
+            typeof(ProductConsumptionProfileBuilder).GetMethod(
+                nameof(ProductConsumptionProfileBuilder.WithProviderCompatibility),
+                new[] { typeof(string), typeof(int) })!.ReturnType);
+        Assert.Equal(
+            typeof(ProductConsumptionProfileBuilder),
+            typeof(ProductConsumptionProfileBuilder).GetMethod(
+                nameof(ProductConsumptionProfileBuilder.OnPlayerApply),
+                new[] { typeof(Action<ProductConsumptionContext>) })!.ReturnType);
+        foreach (var callbackName in new[]
+                 {
+                     nameof(ProductConsumptionProfileBuilder.OnPlayerClear),
+                     nameof(ProductConsumptionProfileBuilder.OnNpcApply),
+                     nameof(ProductConsumptionProfileBuilder.OnNpcClear)
+                 })
+        {
+            Assert.Equal(
+                typeof(ProductConsumptionProfileBuilder),
+                typeof(ProductConsumptionProfileBuilder).GetMethod(
+                    callbackName,
+                    new[] { typeof(Action<ProductConsumptionContext>) })!.ReturnType);
+        }
+        Assert.Equal(
+            typeof(ProductConsumptionProfile),
+            typeof(ProductConsumptionProfileBuilder).GetMethod(
+                nameof(ProductConsumptionProfileBuilder.Build), Type.EmptyTypes)!.ReturnType);
+        Assert.Equal(
+            typeof(ProductConsumptionProfile),
+            typeof(ProductConsumptionProfileRegistry).GetMethod(
+                nameof(ProductConsumptionProfileRegistry.RegisterForProduct),
+                new[] { typeof(string), typeof(ProductConsumptionProfile) })!.ReturnType);
+        Assert.Equal(
+            typeof(ProductConsumptionProfile),
+            typeof(ProductConsumptionProfileRegistry).GetMethod(
+                nameof(ProductConsumptionProfileRegistry.RegisterForProductKind),
+                new[] { typeof(ProductKind), typeof(ProductConsumptionProfile) })!.ReturnType);
+    }
+
+    [Fact]
     public void ProductKindMetadataApiIsAdditiveAndKeepsOptInDefaults()
     {
         Assert.True(typeof(ProductKindMetadata).IsSealed);

--- a/S1API.Tests/Products/ProductConsumptionProfileApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductConsumptionProfileApiCompileFixture.cs
@@ -1,0 +1,42 @@
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+internal static class ProductConsumptionProfileApiCompileFixture
+{
+    internal static ProductConsumptionProfile CompileRepresentativeCaller(
+        string productId,
+        ProductKind productKind)
+    {
+        ProductConsumptionProfile profile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:consumption", 1)
+            .OnPlayerApply(UsePlayerContext)
+            .OnPlayerClear(UsePlayerContext)
+            .OnNpcApply(UseNpcContext)
+            .OnNpcClear(UseNpcContext)
+            .Build();
+
+        _ = ProductConsumptionProfileRegistry.RegisterForProduct(productId, profile);
+        _ = ProductConsumptionProfileRegistry.RegisterForProductKind(productKind, profile);
+        return profile;
+    }
+
+    private static void UsePlayerContext(ProductConsumptionContext context)
+    {
+        _ = context.Product;
+        _ = context.Definition;
+        _ = context.ProductId;
+        _ = context.ProductKind;
+        _ = context.Quality;
+        _ = context.Properties;
+        _ = context.Player;
+        _ = context.TargetId;
+        _ = context.IsLocalPlayer;
+    }
+
+    private static void UseNpcContext(ProductConsumptionContext context)
+    {
+        _ = context.NPC;
+        _ = context.TargetId;
+    }
+}

--- a/S1API.Tests/Products/ProductConsumptionProfileTests.cs
+++ b/S1API.Tests/Products/ProductConsumptionProfileTests.cs
@@ -29,6 +29,10 @@ public sealed class ProductConsumptionProfileTests : IDisposable
             () => new ProductConsumptionProfileBuilder()
                 .WithProviderCompatibility("example:provider", -1));
 
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ProductConsumptionProfileBuilder()
+                .WithProviderCompatibility("example:provider", 0));
+
         Assert.Throws<InvalidOperationException>(
             () => new ProductConsumptionProfileBuilder()
                 .WithProviderCompatibility("example:provider", 1)
@@ -120,6 +124,15 @@ public sealed class ProductConsumptionProfileTests : IDisposable
             () => ProductConsumptionProfileRegistry.RegisterForProductKind(
                 kind,
                 CreateProfile("example:kind-provider")));
+
+        Assert.Throws<ArgumentNullException>(
+            () => ProductConsumptionProfileRegistry.RegisterForProductKind(
+                null!,
+                profile));
+        Assert.Throws<ArgumentNullException>(
+            () => ProductConsumptionProfileRegistrationRegistry.RegisterForProductKind(
+                null!,
+                profile));
     }
 
     [Fact]
@@ -161,16 +174,68 @@ public sealed class ProductConsumptionProfileTests : IDisposable
             new[] { "first-apply", "first-clear", "second-apply", "second-clear" },
             calls);
 
+        var failedApplyAttempts = 0;
         var failedClearCount = 0;
         ProductConsumptionProfile failing = new ProductConsumptionProfileBuilder()
             .WithProviderCompatibility("example:failing", 1)
-            .OnPlayerApply(_ => throw new InvalidOperationException("expected"))
+            .OnPlayerApply(_ =>
+            {
+                failedApplyAttempts++;
+                if (failedApplyAttempts == 1)
+                    throw new InvalidOperationException("expected");
+            })
             .OnPlayerClear(_ => failedClearCount++)
             .Build();
         ProductConsumptionProfileDispatcher.DispatchForTesting(target, failing, firstContext, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, failing, firstContext, true, false);
         ProductConsumptionProfileDispatcher.DispatchForTesting(target, failing, firstContext, true, true);
 
-        Assert.Equal(1, failedClearCount);
+        Assert.Equal(2, failedApplyAttempts);
+        Assert.Equal(2, failedClearCount);
+    }
+
+    [Fact]
+    public void ReplacementClearsUsingTheOriginalTargetKind()
+    {
+        ProductKind kind = CreateKind();
+        var playerClears = 0;
+        var npcClears = 0;
+        ProductConsumptionProfile playerProfile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:player", 1)
+            .OnPlayerApply(_ => { })
+            .OnPlayerClear(_ => playerClears++)
+            .OnNpcClear(_ => npcClears++)
+            .Build();
+        ProductConsumptionProfile npcProfile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:npc", 1)
+            .OnNpcApply(_ => { })
+            .Build();
+        object target = new object();
+
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            target, playerProfile, CreateContext("example:player", kind), true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            target, npcProfile, CreateContext("example:npc", kind), false, false);
+
+        Assert.Equal(1, playerClears);
+        Assert.Equal(0, npcClears);
+    }
+
+    [Fact]
+    public void ResetCleansActiveProfilesWithoutRetainingSessionTargets()
+    {
+        var clearCalls = 0;
+        ProductConsumptionProfile profile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:reset", 1)
+            .OnPlayerApply(_ => { })
+            .OnPlayerClear(_ => clearCalls++)
+            .Build();
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), profile, CreateContext("example:reset", CreateKind()), true, false);
+
+        ProductConsumptionProfileDispatcher.ResetForTesting();
+
+        Assert.Equal(1, clearCalls);
     }
 
     [Fact]
@@ -222,6 +287,15 @@ public sealed class ProductConsumptionProfileTests : IDisposable
 
         Assert.Equal(1, playerCalls);
         Assert.Equal(1, npcCalls);
+    }
+
+    [Fact]
+    public void PlayerTargetIdUsesTheStableNativePlayerCode()
+    {
+        Assert.Equal(
+            "76561198000000000",
+            ProductConsumptionProfileDispatcher.GetPlayerTargetIdForTesting("76561198000000000"));
+        Assert.Equal(string.Empty, ProductConsumptionProfileDispatcher.GetPlayerTargetIdForTesting(null!));
     }
 
     [Fact]

--- a/S1API.Tests/Products/ProductConsumptionProfileTests.cs
+++ b/S1API.Tests/Products/ProductConsumptionProfileTests.cs
@@ -1,0 +1,291 @@
+using System;
+using S1API.Internal.Products;
+using S1API.Products;
+
+namespace S1API.Tests.Products;
+
+[Collection(CustomProductRegistryCollection.Name)]
+public sealed class ProductConsumptionProfileTests : IDisposable
+{
+    public ProductConsumptionProfileTests()
+    {
+        ProductConsumptionProfileRegistrationRegistry.ResetForTesting();
+        ProductConsumptionProfileDispatcher.ResetForTesting();
+    }
+
+    public void Dispose()
+    {
+        ProductConsumptionProfileRegistrationRegistry.ResetForTesting();
+        ProductConsumptionProfileDispatcher.ResetForTesting();
+    }
+
+    [Fact]
+    public void BuilderRequiresProviderCompatibilityAndAtLeastOneCallback()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => new ProductConsumptionProfileBuilder().Build());
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ProductConsumptionProfileBuilder()
+                .WithProviderCompatibility("example:provider", -1));
+
+        Assert.Throws<InvalidOperationException>(
+            () => new ProductConsumptionProfileBuilder()
+                .WithProviderCompatibility("example:provider", 1)
+                .Build());
+
+        Assert.Throws<ArgumentNullException>(
+            () => new ProductConsumptionProfileBuilder().OnPlayerApply(null!));
+    }
+
+    [Fact]
+    public void BuilderSnapshotIsImmutableAcrossLaterBuilderMutations()
+    {
+        var firstCalls = 0;
+        var secondCalls = 0;
+        var builder = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:provider", 1)
+            .OnPlayerApply(_ => firstCalls++);
+        ProductConsumptionProfile first = builder.Build();
+        ProductConsumptionProfile second = builder
+            .WithProviderCompatibility("example:provider", 2)
+            .OnPlayerApply(_ => secondCalls++)
+            .Build();
+        ProductConsumptionContext context = CreateContext("example:product", CreateKind());
+
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), first, context, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), second, context, true, false);
+
+        Assert.Equal(1, first.ProviderVersion);
+        Assert.Equal(2, second.ProviderVersion);
+        Assert.Equal(1, firstCalls);
+        Assert.Equal(1, secondCalls);
+    }
+
+    [Fact]
+    public void ProductRegistrationOverridesLogicalKindIncludingGeneratedMixes()
+    {
+        ProductKind kind = CreateKind();
+        ProductConsumptionProfile kindProfile = CreateProfile("example:kind-provider");
+        ProductConsumptionProfile productProfile = CreateProfile("example:product-provider");
+        string sourceId = CreateId();
+        string generatedId = CreateId();
+
+        ProductConsumptionProfileRegistry.RegisterForProductKind(kind, kindProfile);
+        ProductConsumptionProfileRegistry.RegisterForProduct(sourceId, productProfile);
+
+        Assert.True(ProductConsumptionProfileRegistrationRegistry.TryResolve(
+            sourceId,
+            kind.Id,
+            out ProductConsumptionProfileRegistration? sourceRegistration));
+        Assert.Same(productProfile, sourceRegistration!.Profile);
+
+        Assert.True(ProductConsumptionProfileRegistrationRegistry.TryResolve(
+            generatedId,
+            kind.Id,
+            out ProductConsumptionProfileRegistration? generatedRegistration));
+        Assert.Same(kindProfile, generatedRegistration!.Profile);
+    }
+
+    [Fact]
+    public void RegistrationIsCaseInsensitiveIdempotentAndRejectsReplacement()
+    {
+        string productId = CreateId();
+        ProductConsumptionProfile profile = CreateProfile("example:provider");
+
+        ProductConsumptionProfile first =
+            ProductConsumptionProfileRegistry.RegisterForProduct(productId, profile);
+        ProductConsumptionProfile repeated =
+            ProductConsumptionProfileRegistry.RegisterForProduct(
+                productId.ToUpperInvariant(),
+                profile);
+
+        Assert.Same(profile, first);
+        Assert.Same(first, repeated);
+        Assert.Throws<InvalidOperationException>(
+            () => ProductConsumptionProfileRegistry.RegisterForProduct(
+                productId,
+                CreateProfile("example:other-provider")));
+
+        ProductKind kind = CreateKind();
+        Assert.Same(
+            profile,
+            ProductConsumptionProfileRegistry.RegisterForProductKind(kind, profile));
+        Assert.Same(
+            profile,
+            ProductConsumptionProfileRegistry.RegisterForProductKind(kind, profile));
+        Assert.Throws<InvalidOperationException>(
+            () => ProductConsumptionProfileRegistry.RegisterForProductKind(
+                kind,
+                CreateProfile("example:kind-provider")));
+    }
+
+    [Fact]
+    public void UnregisteredProductsAndKindsHaveNoProfileResolution()
+    {
+        Assert.False(ProductConsumptionProfileRegistrationRegistry.TryResolve(
+            "example:unregistered-product",
+            "example:unregistered-kind",
+            out ProductConsumptionProfileRegistration? registration));
+        Assert.Null(registration);
+    }
+
+    [Fact]
+    public void PlayerLifecycleIsOrderedIdempotentAndCleansUpFailedApply()
+    {
+        ProductKind kind = CreateKind();
+        var calls = new System.Collections.Generic.List<string>();
+        ProductConsumptionProfile first = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:first", 1)
+            .OnPlayerApply(_ => calls.Add("first-apply"))
+            .OnPlayerClear(_ => calls.Add("first-clear"))
+            .Build();
+        ProductConsumptionProfile second = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:second", 1)
+            .OnPlayerApply(_ => calls.Add("second-apply"))
+            .OnPlayerClear(_ => calls.Add("second-clear"))
+            .Build();
+        object target = new object();
+        ProductConsumptionContext firstContext = CreateContext("example:first-product", kind);
+        ProductConsumptionContext secondContext = CreateContext("example:second-product", kind);
+
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, first, firstContext, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, first, firstContext, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, second, secondContext, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, second, secondContext, true, true);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, second, secondContext, true, true);
+
+        Assert.Equal(
+            new[] { "first-apply", "first-clear", "second-apply", "second-clear" },
+            calls);
+
+        var failedClearCount = 0;
+        ProductConsumptionProfile failing = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:failing", 1)
+            .OnPlayerApply(_ => throw new InvalidOperationException("expected"))
+            .OnPlayerClear(_ => failedClearCount++)
+            .Build();
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, failing, firstContext, true, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, failing, firstContext, true, true);
+
+        Assert.Equal(1, failedClearCount);
+    }
+
+    [Fact]
+    public void NpcLifecycleUsesDedicatedCallbacksAndContextReportsTargetKind()
+    {
+        ProductKind kind = CreateKind();
+        var applyCount = 0;
+        var clearCount = 0;
+        ProductConsumptionProfile profile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:npc", 2)
+            .OnNpcApply(context =>
+            {
+                Assert.Null(context.Player);
+                applyCount++;
+            })
+            .OnNpcClear(_ => clearCount++)
+            .Build();
+        ProductConsumptionContext context = CreateContext("example:npc-product", kind);
+        object target = new object();
+
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, profile, context, false, false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(target, profile, context, false, true);
+
+        Assert.Equal(1, applyCount);
+        Assert.Equal(1, clearCount);
+        Assert.False(context.IsLocalPlayer);
+        Assert.Equal("test-target", context.TargetId);
+    }
+
+    [Fact]
+    public void PlayerCallbacksAreLocalOnlyWhileNpcCallbacksRemainObserverVisible()
+    {
+        ProductKind kind = CreateKind();
+        var playerCalls = 0;
+        var npcCalls = 0;
+        ProductConsumptionProfile profile = new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility("example:visibility", 1)
+            .OnPlayerApply(_ => playerCalls++)
+            .OnNpcApply(_ => npcCalls++)
+            .Build();
+        ProductConsumptionContext context = CreateContext("example:visibility-product", kind);
+
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), profile, context, true, false, isLocalPlayer: false);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), profile, context, true, false, isLocalPlayer: true);
+        ProductConsumptionProfileDispatcher.DispatchForTesting(
+            new object(), profile, context, false, false);
+
+        Assert.Equal(1, playerCalls);
+        Assert.Equal(1, npcCalls);
+    }
+
+    [Fact]
+    public void ManifestProviderIdentityAndVersionAreCompatibilityRelevant()
+    {
+        CustomProductManifestEntryData baseline = CreateManifestEntry();
+        CustomProductManifestEntryData changed = CreateManifestEntry();
+        changed.ConsumptionProfileProviderVersion++;
+
+        Assert.NotEqual(
+            CustomProductManifestData.ComputeManifestHash(new[] { baseline }),
+            CustomProductManifestData.ComputeManifestHash(new[] { changed }));
+
+        var host = new CustomProductManifestData { Entries = new[] { baseline } };
+        var local = new CustomProductManifestData { Entries = new[] { changed } };
+        Assert.Contains(
+            "consumption profile",
+            CustomProductManifestData.DescribeCompatibilityMismatch(host, local),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ProductConsumptionProfile CreateProfile(string providerId)
+    {
+        return new ProductConsumptionProfileBuilder()
+            .WithProviderCompatibility(providerId, 1)
+            .OnPlayerApply(_ => { })
+            .Build();
+    }
+
+    private static ProductConsumptionContext CreateContext(string productId, ProductKind kind)
+    {
+        return new ProductConsumptionContext(productId, kind, null, null, "test-target");
+    }
+
+    private static ProductKind CreateKind()
+    {
+        return new ProductKindBuilder(CreateId())
+            .WithCompatibilityDrugType(DrugType.MDMA)
+            .Build();
+    }
+
+    private static CustomProductManifestEntryData CreateManifestEntry()
+    {
+        return new CustomProductManifestEntryData
+        {
+            ProductId = "example:product",
+            OwnerId = "example",
+            ProductKindId = "example:kind",
+            CompatibilityDrugType = (int)DrugType.MDMA,
+            DescriptorFormatVersion = CustomProductSavePersistence.CurrentFormatVersion,
+            ProviderId = "example:save-provider",
+            ProviderVersion = 1,
+            ProviderAvailable = true,
+            RepresentationTemplateId = "ogkush",
+            PresentationProfileId = string.Empty,
+            ConsumptionProfileProviderId = "example:consumption-provider",
+            ConsumptionProfileProviderVersion = 1,
+            PackagingIds = Array.Empty<string>(),
+            CompatibilityHash = new string('a', 64)
+        };
+    }
+
+    private static string CreateId()
+    {
+        return $"s1api-consumption-tests:{Guid.NewGuid():N}";
+    }
+}

--- a/S1API/Internal/Patches/ProductEffectPatches.cs
+++ b/S1API/Internal/Patches/ProductEffectPatches.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Reflection;
 using HarmonyLib;
 using S1API.Entities;
+using S1API.Internal.Products;
 using S1API.Logging;
 using S1API.Properties;
 using S1API.Products;
@@ -95,7 +96,7 @@ namespace S1API.Internal.Patches
                 return true;
 
             var effects = ResolveEffects(__instance);
-            if (effects == null)
+            if (effects == null && !ProductConsumptionProfileDispatcher.HasRegisteredProfile(__instance))
                 return true;
 
             var localPlayer = Player.All.FirstOrDefault(p => p.IsLocal);
@@ -110,7 +111,7 @@ namespace S1API.Internal.Patches
 
             var invokedEffectIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            for (var i = 0; i < effects.Count; i++)
+            for (var i = 0; effects != null && i < effects.Count; i++)
             {
                 var effect = effects[i];
                 if (effect == null)
@@ -159,6 +160,24 @@ namespace S1API.Internal.Patches
                     Logger.Error($"Exception while invoking effect {lifecycle} callback for '{effectId}': {ex.Message}");
                     Logger.Error(ex.StackTrace ?? string.Empty);
                 }
+            }
+
+            if (targetPlayer != null)
+            {
+                ProductConsumptionProfileDispatcher.DispatchPlayer(
+                    __instance,
+                    targetPlayer,
+                    localPlayer!,
+                    isClear);
+            }
+            else if (targetNpc != null)
+            {
+                ProductConsumptionProfileDispatcher.DispatchNpc(
+                    __instance,
+                    targetNpc,
+                    ResolveApiNpc(targetNpc),
+                    targetNpc.ID ?? string.Empty,
+                    isClear);
             }
 
             return false;

--- a/S1API/Internal/Patches/ProductEffectPatches.cs
+++ b/S1API/Internal/Patches/ProductEffectPatches.cs
@@ -96,9 +96,6 @@ namespace S1API.Internal.Patches
                 return true;
 
             var effects = ResolveEffects(__instance);
-            if (effects == null && !ProductConsumptionProfileDispatcher.HasRegisteredProfile(__instance))
-                return true;
-
             var localPlayer = Player.All.FirstOrDefault(p => p.IsLocal);
             var targetPlayer = target as S1PlayerScripts.Player;
             var targetNpc = target as S1NPCs.NPC;
@@ -108,6 +105,22 @@ namespace S1API.Internal.Patches
 
             if (targetPlayer != null && (localPlayer == null || targetPlayer != localPlayer.S1Player))
                 return true;
+
+            NPC? apiNpc = targetNpc != null
+                ? ResolveApiNpc(targetNpc)
+                : null;
+            ProductConsumptionContext? consumptionContext = null;
+            ProductConsumptionProfileRegistration? consumptionRegistration = null;
+            if (effects == null && !ProductConsumptionProfileDispatcher.TryResolveRegisteredContext(
+                    __instance,
+                    targetPlayer != null ? localPlayer : null,
+                    apiNpc,
+                    targetNpc?.ID ?? string.Empty,
+                    out consumptionContext,
+                    out consumptionRegistration))
+            {
+                return true;
+            }
 
             var invokedEffectIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -138,8 +151,6 @@ namespace S1API.Internal.Patches
                     }
                     else
                     {
-                        var apiNpc = ResolveApiNpc(targetNpc);
-
                         var allowDefaultEffect = false;
                         var handled = apiNpc != null &&
                                       (isClear
@@ -168,16 +179,20 @@ namespace S1API.Internal.Patches
                     __instance,
                     targetPlayer,
                     localPlayer!,
-                    isClear);
+                    isClear,
+                    consumptionContext,
+                    consumptionRegistration);
             }
             else if (targetNpc != null)
             {
                 ProductConsumptionProfileDispatcher.DispatchNpc(
                     __instance,
                     targetNpc,
-                    ResolveApiNpc(targetNpc),
+                    apiNpc,
                     targetNpc.ID ?? string.Empty,
-                    isClear);
+                    isClear,
+                    consumptionContext,
+                    consumptionRegistration);
             }
 
             return false;

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -433,7 +433,8 @@ namespace S1API.Internal.Products
                   !CustomProductManifestData.IsBoundedIdentifier(ConsumptionProfileProviderId)) ||
                  (ConsumptionProfileProviderId.Length == 0 &&
                   ConsumptionProfileProviderVersion != 0) ||
-                 ConsumptionProfileProviderVersion < 0 ||
+                 (ConsumptionProfileProviderId.Length != 0 &&
+                  ConsumptionProfileProviderVersion <= 0) ||
                  (ProviderId != null && !CustomProductManifestData.IsBoundedIdentifier(ProviderId)) ||
                  !Enum.IsDefined(typeof(DrugType), CompatibilityDrugType) ||
                  (ProviderId == null && ProviderVersion != 0) ||

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -15,7 +15,7 @@ namespace S1API.Internal.Products
     /// </summary>
     internal sealed class CustomProductManifestData
     {
-        internal const int CurrentProtocolVersion = 2;
+        internal const int CurrentProtocolVersion = 3;
         internal const int MaximumEntryCount = 256;
         internal const int MaximumPayloadLength = 65536;
         internal const int MaximumIdentifierLength = 256;
@@ -370,6 +370,8 @@ namespace S1API.Internal.Products
         public bool ProviderAvailable;
         public string RepresentationTemplateId = string.Empty;
         public string PresentationProfileId = string.Empty;
+        public string ConsumptionProfileProviderId = string.Empty;
+        public int ConsumptionProfileProviderVersion;
         public string[] PackagingIds = Array.Empty<string>();
         public string CompatibilityHash = string.Empty;
 
@@ -390,6 +392,11 @@ namespace S1API.Internal.Products
                 registration.ProductId,
                 metadata.ProductKind.Id,
                 out string presentationProfileId);
+            ProductConsumptionProfileRegistrationRegistry.TryGetManifestIdentity(
+                registration.ProductId,
+                metadata.ProductKind.Id,
+                out string consumptionProfileProviderId,
+                out int consumptionProfileProviderVersion);
 
             var entry = new CustomProductManifestEntryData
             {
@@ -405,6 +412,8 @@ namespace S1API.Internal.Products
                     descriptor.ProviderVersion),
                 RepresentationTemplateId = descriptor.RepresentationTemplateId,
                 PresentationProfileId = presentationProfileId,
+                ConsumptionProfileProviderId = consumptionProfileProviderId,
+                ConsumptionProfileProviderVersion = consumptionProfileProviderVersion,
                 PackagingIds = packagingIds.ToArray()
             };
             entry.CompatibilityHash = ComputeCompatibilityHash(entry, descriptor);
@@ -419,6 +428,12 @@ namespace S1API.Internal.Products
                  !CustomProductManifestData.IsBoundedIdentifier(RepresentationTemplateId) ||
                  PresentationProfileId == null ||
                  PresentationProfileId.Length > CustomProductManifestData.MaximumIdentifierLength ||
+                 ConsumptionProfileProviderId == null ||
+                 (ConsumptionProfileProviderId.Length != 0 &&
+                  !CustomProductManifestData.IsBoundedIdentifier(ConsumptionProfileProviderId)) ||
+                 (ConsumptionProfileProviderId.Length == 0 &&
+                  ConsumptionProfileProviderVersion != 0) ||
+                 ConsumptionProfileProviderVersion < 0 ||
                  (ProviderId != null && !CustomProductManifestData.IsBoundedIdentifier(ProviderId)) ||
                  !Enum.IsDefined(typeof(DrugType), CompatibilityDrugType) ||
                  (ProviderId == null && ProviderVersion != 0) ||
@@ -463,6 +478,8 @@ namespace S1API.Internal.Products
             Append(builder, ProviderAvailable ? "1" : "0");
             AppendIdentifier(builder, RepresentationTemplateId);
             AppendIdentifier(builder, PresentationProfileId);
+            AppendIdentifier(builder, ConsumptionProfileProviderId);
+            Append(builder, ConsumptionProfileProviderVersion.ToString(CultureInfo.InvariantCulture));
             for (int i = 0; i < PackagingIds.Length; i++)
                 AppendIdentifier(builder, PackagingIds[i]);
             if (includeHash)
@@ -517,6 +534,14 @@ namespace S1API.Internal.Products
                     StringComparison.OrdinalIgnoreCase))
             {
                 return "presentation profile registration differs";
+            }
+            if (!string.Equals(
+                    ConsumptionProfileProviderId,
+                    local.ConsumptionProfileProviderId,
+                    StringComparison.OrdinalIgnoreCase) ||
+                ConsumptionProfileProviderVersion != local.ConsumptionProfileProviderVersion)
+            {
+                return "consumption profile provider compatibility differs";
             }
             if (PackagingIds.Length != local.PackagingIds.Length)
                 return "packaging registration set differs";

--- a/S1API/Internal/Products/ProductConsumptionProfileDispatcher.cs
+++ b/S1API/Internal/Products/ProductConsumptionProfileDispatcher.cs
@@ -1,0 +1,299 @@
+#if (IL2CPPMELON)
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using S1API.Entities;
+using S1API.Logging;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Dispatches intrinsic custom-product consumption behavior.</summary>
+    internal static class ProductConsumptionProfileDispatcher
+    {
+        private sealed class ActiveProfile
+        {
+            internal ActiveProfile(
+                ProductConsumptionProfile profile,
+                ProductConsumptionContext context)
+            {
+                Profile = profile;
+                Context = context;
+            }
+
+            internal ProductConsumptionProfile Profile { get; }
+
+            internal ProductConsumptionContext Context { get; }
+        }
+
+        private sealed class ReferenceComparer : IEqualityComparer<object>
+        {
+            bool IEqualityComparer<object>.Equals(object? left, object? right) =>
+                ReferenceEquals(left, right);
+
+            public int GetHashCode(object value) =>
+                RuntimeHelpers.GetHashCode(value);
+        }
+
+        private static readonly Log Logger = new Log("ProductConsumptionProfileDispatcher");
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<object, ActiveProfile> ActiveProfiles =
+            new Dictionary<object, ActiveProfile>(new ReferenceComparer());
+
+        internal static void DispatchPlayer(
+            S1Product.ProductItemInstance productInstance,
+            object nativePlayer,
+            Player player,
+            bool isClear)
+        {
+            Dispatch(
+                productInstance,
+                nativePlayer,
+                player,
+                null,
+                player.Name,
+                isClear);
+        }
+
+        internal static void DispatchNpc(
+            S1Product.ProductItemInstance productInstance,
+            object nativeNpc,
+            NPC? npc,
+            string targetId,
+            bool isClear)
+        {
+            Dispatch(
+                productInstance,
+                nativeNpc,
+                null,
+                npc,
+                targetId,
+                isClear);
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+                ActiveProfiles.Clear();
+        }
+
+        internal static void DispatchForTesting(
+            object nativeTarget,
+            ProductConsumptionProfile profile,
+            ProductConsumptionContext context,
+            bool isPlayer,
+            bool isClear,
+            bool isLocalPlayer = true)
+        {
+            if (isPlayer && !isLocalPlayer)
+                return;
+
+            if (isClear)
+                Clear(nativeTarget, context, isPlayer);
+            else
+                ApplyResolved(nativeTarget, profile, context, isPlayer);
+        }
+
+        internal static bool HasRegisteredProfile(
+            S1Product.ProductItemInstance productInstance)
+        {
+            if (!TryCreateContext(productInstance, null, null, string.Empty, out ProductConsumptionContext? context) ||
+                context == null)
+            {
+                return false;
+            }
+
+            return ProductConsumptionProfileRegistrationRegistry.TryResolve(
+                context.ProductId,
+                context.ProductKind.Id,
+                out _);
+        }
+
+        private static void Dispatch(
+            S1Product.ProductItemInstance productInstance,
+            object nativeTarget,
+            Player? player,
+            NPC? npc,
+            string targetId,
+            bool isClear)
+        {
+            if (productInstance == null || nativeTarget == null)
+                return;
+
+            if (!TryCreateContext(
+                    productInstance,
+                    player,
+                    npc,
+                    targetId,
+                    out ProductConsumptionContext? context))
+            {
+                return;
+            }
+
+            if (context == null)
+                return;
+
+            if (isClear)
+            {
+                Clear(nativeTarget, context, player != null);
+                return;
+            }
+
+            Apply(nativeTarget, context, player != null);
+        }
+
+        private static bool TryCreateContext(
+            S1Product.ProductItemInstance productInstance,
+            Player? player,
+            NPC? npc,
+            string targetId,
+            out ProductConsumptionContext? context)
+        {
+            context = null;
+            try
+            {
+                var product = new ProductInstance(productInstance);
+                if (!(product.Definition is CustomProductDefinition definition))
+                    return false;
+
+                context = new ProductConsumptionContext(
+                    product,
+                    definition,
+                    player,
+                    npc,
+                    targetId ?? string.Empty);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(
+                    "Could not resolve a custom product consumption context: " +
+                    exception.GetType().Name);
+                return false;
+            }
+        }
+
+        private static void Apply(
+            object nativeTarget,
+            ProductConsumptionContext context,
+            bool isPlayer)
+        {
+            if (!ProductConsumptionProfileRegistrationRegistry.TryResolve(
+                    context.ProductId,
+                    context.ProductKind.Id,
+                    out ProductConsumptionProfileRegistration? registration) ||
+                registration == null)
+            {
+                return;
+            }
+
+            ApplyResolved(nativeTarget, registration.Profile, context, isPlayer);
+        }
+
+        private static void ApplyResolved(
+            object nativeTarget,
+            ProductConsumptionProfile profile,
+            ProductConsumptionContext context,
+            bool isPlayer)
+        {
+            ActiveProfile? previous;
+            lock (Gate)
+            {
+                if (ActiveProfiles.TryGetValue(nativeTarget, out previous) &&
+                    string.Equals(
+                        previous.Context.ProductId,
+                        context.ProductId,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    ReferenceEquals(previous.Profile, profile))
+                {
+                    return;
+                }
+
+                ActiveProfiles[nativeTarget] = new ActiveProfile(profile, context);
+            }
+
+            if (previous != null)
+                InvokeClear(previous.Profile, previous.Context, isPlayer);
+
+            InvokeApply(profile, context, isPlayer);
+        }
+
+        private static void Clear(
+            object nativeTarget,
+            ProductConsumptionContext context,
+            bool isPlayer)
+        {
+            ActiveProfile? active;
+            lock (Gate)
+            {
+                if (!ActiveProfiles.TryGetValue(nativeTarget, out active) ||
+                    !string.Equals(
+                        active.Context.ProductId,
+                        context.ProductId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                ActiveProfiles.Remove(nativeTarget);
+            }
+
+            InvokeClear(active.Profile, active.Context, isPlayer);
+        }
+
+        private static void InvokeApply(
+            ProductConsumptionProfile profile,
+            ProductConsumptionContext context,
+            bool isPlayer)
+        {
+            Action<ProductConsumptionContext>? callback = isPlayer
+                ? profile.OnPlayerApply
+                : profile.OnNpcApply;
+            Invoke(callback, profile, context, isPlayer ? "player apply" : "NPC apply");
+        }
+
+        private static void InvokeClear(
+            ProductConsumptionProfile profile,
+            ProductConsumptionContext context,
+            bool isPlayer)
+        {
+            Action<ProductConsumptionContext>? callback = isPlayer
+                ? profile.OnPlayerClear
+                : profile.OnNpcClear;
+            Invoke(callback, profile, context, isPlayer ? "player clear" : "NPC clear");
+        }
+
+        private static void Invoke(
+            Action<ProductConsumptionContext>? callback,
+            ProductConsumptionProfile profile,
+            ProductConsumptionContext context,
+            string lifecycle)
+        {
+            if (callback == null)
+                return;
+
+            try
+            {
+                callback(context);
+            }
+            catch (Exception exception)
+            {
+                try
+                {
+                    Logger.Error(
+                        "Consumption profile '" + profile.ProviderId + "' " + lifecycle +
+                        " callback failed for product '" + context.ProductId + "': " +
+                        exception.GetType().Name);
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductConsumptionProfileDispatcher.cs
+++ b/S1API/Internal/Products/ProductConsumptionProfileDispatcher.cs
@@ -1,13 +1,16 @@
 #if (IL2CPPMELON)
 using S1Product = Il2CppScheduleOne.Product;
+using S1PlayerScripts = Il2CppScheduleOne.PlayerScripts;
 #elif MONOMELON
 using S1Product = ScheduleOne.Product;
+using S1PlayerScripts = ScheduleOne.PlayerScripts;
 #endif
 
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using S1API.Entities;
+using S1API.Lifecycle;
 using S1API.Logging;
 using S1API.Products;
 
@@ -20,44 +23,46 @@ namespace S1API.Internal.Products
         {
             internal ActiveProfile(
                 ProductConsumptionProfile profile,
-                ProductConsumptionContext context)
+                ProductConsumptionContext context,
+                bool isPlayer)
             {
                 Profile = profile;
                 Context = context;
+                IsPlayer = isPlayer;
             }
 
             internal ProductConsumptionProfile Profile { get; }
 
             internal ProductConsumptionContext Context { get; }
-        }
 
-        private sealed class ReferenceComparer : IEqualityComparer<object>
-        {
-            bool IEqualityComparer<object>.Equals(object? left, object? right) =>
-                ReferenceEquals(left, right);
+            internal bool IsPlayer { get; }
 
-            public int GetHashCode(object value) =>
-                RuntimeHelpers.GetHashCode(value);
+            internal bool IsActive { get; set; } = true;
         }
 
         private static readonly Log Logger = new Log("ProductConsumptionProfileDispatcher");
         private static readonly object Gate = new object();
-        private static readonly Dictionary<object, ActiveProfile> ActiveProfiles =
-            new Dictionary<object, ActiveProfile>(new ReferenceComparer());
+        private static ConditionalWeakTable<object, ActiveProfile> ActiveProfiles = new();
+        private static readonly List<WeakReference<ActiveProfile>> ActiveProfileReferences = new();
+        private static bool _lifecycleHooksRegistered;
 
         internal static void DispatchPlayer(
             S1Product.ProductItemInstance productInstance,
             object nativePlayer,
             Player player,
-            bool isClear)
+            bool isClear,
+            ProductConsumptionContext? resolvedContext = null,
+            ProductConsumptionProfileRegistration? resolvedRegistration = null)
         {
             Dispatch(
                 productInstance,
                 nativePlayer,
                 player,
                 null,
-                player.Name,
-                isClear);
+                GetPlayerTargetId(player.S1Player),
+                isClear,
+                resolvedContext,
+                resolvedRegistration);
         }
 
         internal static void DispatchNpc(
@@ -65,7 +70,9 @@ namespace S1API.Internal.Products
             object nativeNpc,
             NPC? npc,
             string targetId,
-            bool isClear)
+            bool isClear,
+            ProductConsumptionContext? resolvedContext = null,
+            ProductConsumptionProfileRegistration? resolvedRegistration = null)
         {
             Dispatch(
                 productInstance,
@@ -73,14 +80,18 @@ namespace S1API.Internal.Products
                 null,
                 npc,
                 targetId,
-                isClear);
+                isClear,
+                resolvedContext,
+                resolvedRegistration);
         }
 
         internal static void ResetForTesting()
         {
-            lock (Gate)
-                ActiveProfiles.Clear();
+            ResetActiveProfiles();
         }
+
+        internal static string GetPlayerTargetIdForTesting(string playerCode) =>
+            GetPlayerTargetId(playerCode);
 
         internal static void DispatchForTesting(
             object nativeTarget,
@@ -99,11 +110,16 @@ namespace S1API.Internal.Products
                 ApplyResolved(nativeTarget, profile, context, isPlayer);
         }
 
-        internal static bool HasRegisteredProfile(
-            S1Product.ProductItemInstance productInstance)
+        internal static bool TryResolveRegisteredContext(
+            S1Product.ProductItemInstance productInstance,
+            Player? player,
+            NPC? npc,
+            string targetId,
+            out ProductConsumptionContext? context,
+            out ProductConsumptionProfileRegistration? registration)
         {
-            if (!TryCreateContext(productInstance, null, null, string.Empty, out ProductConsumptionContext? context) ||
-                context == null)
+            registration = null;
+            if (!TryCreateContext(productInstance, player, npc, targetId, out context) || context == null)
             {
                 return false;
             }
@@ -111,7 +127,7 @@ namespace S1API.Internal.Products
             return ProductConsumptionProfileRegistrationRegistry.TryResolve(
                 context.ProductId,
                 context.ProductKind.Id,
-                out _);
+                out registration);
         }
 
         private static void Dispatch(
@@ -120,17 +136,20 @@ namespace S1API.Internal.Products
             Player? player,
             NPC? npc,
             string targetId,
-            bool isClear)
+            bool isClear,
+            ProductConsumptionContext? resolvedContext,
+            ProductConsumptionProfileRegistration? resolvedRegistration)
         {
             if (productInstance == null || nativeTarget == null)
                 return;
 
-            if (!TryCreateContext(
-                    productInstance,
-                    player,
-                    npc,
-                    targetId,
-                    out ProductConsumptionContext? context))
+            ProductConsumptionContext? context = resolvedContext;
+            if (context == null && !TryCreateContext(
+                productInstance,
+                player,
+                npc,
+                targetId,
+                out context))
             {
                 return;
             }
@@ -144,7 +163,7 @@ namespace S1API.Internal.Products
                 return;
             }
 
-            Apply(nativeTarget, context, player != null);
+            Apply(nativeTarget, context, player != null, resolvedRegistration);
         }
 
         private static bool TryCreateContext(
@@ -181,16 +200,21 @@ namespace S1API.Internal.Products
         private static void Apply(
             object nativeTarget,
             ProductConsumptionContext context,
-            bool isPlayer)
+            bool isPlayer,
+            ProductConsumptionProfileRegistration? resolvedRegistration)
         {
-            if (!ProductConsumptionProfileRegistrationRegistry.TryResolve(
+            ProductConsumptionProfileRegistration? registration = resolvedRegistration;
+            if (registration == null &&
+                !ProductConsumptionProfileRegistrationRegistry.TryResolve(
                     context.ProductId,
                     context.ProductKind.Id,
-                    out ProductConsumptionProfileRegistration? registration) ||
-                registration == null)
+                    out registration))
             {
                 return;
             }
+
+            if (registration == null)
+                return;
 
             ApplyResolved(nativeTarget, registration.Profile, context, isPlayer);
         }
@@ -201,7 +225,9 @@ namespace S1API.Internal.Products
             ProductConsumptionContext context,
             bool isPlayer)
         {
+            EnsureLifecycleHooks();
             ActiveProfile? previous;
+            var active = new ActiveProfile(profile, context, isPlayer);
             lock (Gate)
             {
                 if (ActiveProfiles.TryGetValue(nativeTarget, out previous) &&
@@ -214,13 +240,24 @@ namespace S1API.Internal.Products
                     return;
                 }
 
-                ActiveProfiles[nativeTarget] = new ActiveProfile(profile, context);
+                if (previous != null)
+                {
+                    previous.IsActive = false;
+                    ActiveProfiles.Remove(nativeTarget);
+                }
+
+                ActiveProfiles.Add(nativeTarget, active);
+                ActiveProfileReferences.Add(new WeakReference<ActiveProfile>(active));
             }
 
             if (previous != null)
-                InvokeClear(previous.Profile, previous.Context, isPlayer);
+                InvokeClear(previous.Profile, previous.Context, previous.IsPlayer);
 
-            InvokeApply(profile, context, isPlayer);
+            if (!InvokeApply(profile, context, isPlayer))
+            {
+                RemoveActiveProfile(nativeTarget, active);
+                InvokeClear(profile, context, isPlayer);
+            }
         }
 
         private static void Clear(
@@ -241,12 +278,13 @@ namespace S1API.Internal.Products
                 }
 
                 ActiveProfiles.Remove(nativeTarget);
+                active.IsActive = false;
             }
 
-            InvokeClear(active.Profile, active.Context, isPlayer);
+            InvokeClear(active.Profile, active.Context, active.IsPlayer);
         }
 
-        private static void InvokeApply(
+        private static bool InvokeApply(
             ProductConsumptionProfile profile,
             ProductConsumptionContext context,
             bool isPlayer)
@@ -254,10 +292,10 @@ namespace S1API.Internal.Products
             Action<ProductConsumptionContext>? callback = isPlayer
                 ? profile.OnPlayerApply
                 : profile.OnNpcApply;
-            Invoke(callback, profile, context, isPlayer ? "player apply" : "NPC apply");
+            return Invoke(callback, profile, context, isPlayer ? "player apply" : "NPC apply");
         }
 
-        private static void InvokeClear(
+        private static bool InvokeClear(
             ProductConsumptionProfile profile,
             ProductConsumptionContext context,
             bool isPlayer)
@@ -265,21 +303,22 @@ namespace S1API.Internal.Products
             Action<ProductConsumptionContext>? callback = isPlayer
                 ? profile.OnPlayerClear
                 : profile.OnNpcClear;
-            Invoke(callback, profile, context, isPlayer ? "player clear" : "NPC clear");
+            return Invoke(callback, profile, context, isPlayer ? "player clear" : "NPC clear");
         }
 
-        private static void Invoke(
+        private static bool Invoke(
             Action<ProductConsumptionContext>? callback,
             ProductConsumptionProfile profile,
             ProductConsumptionContext context,
             string lifecycle)
         {
             if (callback == null)
-                return;
+                return true;
 
             try
             {
                 callback(context);
+                return true;
             }
             catch (Exception exception)
             {
@@ -293,7 +332,93 @@ namespace S1API.Internal.Products
                 catch
                 {
                 }
+
+                return false;
             }
+        }
+
+        private static string GetPlayerTargetId(S1PlayerScripts.Player player) =>
+            GetPlayerTargetId(player?.PlayerCode);
+
+        private static string GetPlayerTargetId(string? playerCode) =>
+            playerCode ?? string.Empty;
+
+        private static void EnsureLifecycleHooks()
+        {
+            lock (Gate)
+            {
+                if (_lifecycleHooksRegistered)
+                    return;
+
+                GameLifecycle.OnPreLoad += ResetActiveProfiles;
+                GameLifecycle.OnPreSceneChange += ResetActiveProfiles;
+                Player.PlayerDespawned += OnPlayerDespawned;
+                _lifecycleHooksRegistered = true;
+            }
+        }
+
+        private static void OnPlayerDespawned(Player player)
+        {
+            if (player == null)
+                return;
+
+            RemoveActiveProfile(player.S1Player);
+        }
+
+        private static void RemoveActiveProfile(object nativeTarget, ActiveProfile expected)
+        {
+            lock (Gate)
+            {
+                if (ActiveProfiles.TryGetValue(nativeTarget, out ActiveProfile? current) &&
+                    ReferenceEquals(current, expected))
+                {
+                    current.IsActive = false;
+                    ActiveProfiles.Remove(nativeTarget);
+                }
+            }
+        }
+
+        private static void RemoveActiveProfile(object nativeTarget)
+        {
+            ActiveProfile? active;
+            lock (Gate)
+            {
+                if (!ActiveProfiles.TryGetValue(nativeTarget, out active))
+                    return;
+
+                active.IsActive = false;
+                ActiveProfiles.Remove(nativeTarget);
+            }
+
+            InvokeClear(active.Profile, active.Context, active.IsPlayer);
+        }
+
+        private static void ResetActiveProfiles()
+        {
+            var activeProfiles = new List<ActiveProfile>();
+            lock (Gate)
+            {
+                for (var index = ActiveProfileReferences.Count - 1; index >= 0; index--)
+                {
+                    if (!ActiveProfileReferences[index].TryGetTarget(out ActiveProfile? active))
+                    {
+                        ActiveProfileReferences.RemoveAt(index);
+                        continue;
+                    }
+
+                    if (active.IsActive)
+                    {
+                        active.IsActive = false;
+                        activeProfiles.Add(active);
+                    }
+                }
+
+                ActiveProfiles = new ConditionalWeakTable<object, ActiveProfile>();
+                ActiveProfileReferences.Clear();
+            }
+
+            foreach (ActiveProfile active in activeProfiles)
+                InvokeClear(active.Profile, active.Context, active.IsPlayer);
         }
     }
 }

--- a/S1API/Internal/Products/ProductConsumptionProfileRegistration.cs
+++ b/S1API/Internal/Products/ProductConsumptionProfileRegistration.cs
@@ -1,0 +1,20 @@
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Associates a consumption profile with a stable resolution key.</summary>
+    internal sealed class ProductConsumptionProfileRegistration
+    {
+        internal ProductConsumptionProfileRegistration(
+            string key,
+            ProductConsumptionProfile profile)
+        {
+            Key = key;
+            Profile = profile;
+        }
+
+        internal string Key { get; }
+
+        internal ProductConsumptionProfile Profile { get; }
+    }
+}

--- a/S1API/Internal/Products/ProductConsumptionProfileRegistrationRegistry.cs
+++ b/S1API/Internal/Products/ProductConsumptionProfileRegistrationRegistry.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>INTERNAL: Stores immutable custom-product consumption profile registrations.</summary>
+    internal static class ProductConsumptionProfileRegistrationRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, ProductConsumptionProfileRegistration>
+            ProductProfiles = new Dictionary<string, ProductConsumptionProfileRegistration>(
+                StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, ProductConsumptionProfileRegistration>
+            KindProfiles = new Dictionary<string, ProductConsumptionProfileRegistration>(
+                StringComparer.OrdinalIgnoreCase);
+
+        internal static ProductConsumptionProfile RegisterForProduct(
+            string productId,
+            ProductConsumptionProfile profile)
+        {
+            return Register(
+                ProductProfiles,
+                "product ID",
+                ProductKindId.Normalize(productId, nameof(productId)),
+                profile);
+        }
+
+        internal static ProductConsumptionProfile RegisterForProductKind(
+            ProductKind productKind,
+            ProductConsumptionProfile profile)
+        {
+            return Register(KindProfiles, "product-kind ID", productKind.Id, profile);
+        }
+
+        internal static bool TryResolve(
+            string productId,
+            string productKindId,
+            out ProductConsumptionProfileRegistration? registration)
+        {
+            lock (Gate)
+            {
+                if (ProductProfiles.TryGetValue(productId, out registration))
+                    return true;
+
+                return KindProfiles.TryGetValue(productKindId, out registration);
+            }
+        }
+
+        internal static bool TryGetManifestIdentity(
+            string productId,
+            string productKindId,
+            out string providerId,
+            out int providerVersion)
+        {
+            if (TryResolve(productId, productKindId, out ProductConsumptionProfileRegistration? registration) &&
+                registration != null)
+            {
+                providerId = registration.Profile.ProviderId;
+                providerVersion = registration.Profile.ProviderVersion;
+                return true;
+            }
+
+            providerId = string.Empty;
+            providerVersion = 0;
+            return false;
+        }
+
+        internal static void ResetForTesting()
+        {
+            lock (Gate)
+            {
+                ProductProfiles.Clear();
+                KindProfiles.Clear();
+            }
+        }
+
+        private static ProductConsumptionProfile Register(
+            Dictionary<string, ProductConsumptionProfileRegistration> registrations,
+            string keyDescription,
+            string key,
+            ProductConsumptionProfile profile)
+        {
+            if (profile == null)
+                throw new ArgumentNullException(nameof(profile));
+
+            ProductConsumptionProfileRegistration registration;
+            lock (Gate)
+            {
+                if (registrations.TryGetValue(key, out ProductConsumptionProfileRegistration? existing))
+                {
+                    if (ReferenceEquals(existing.Profile, profile))
+                        return existing.Profile;
+
+                    throw new InvalidOperationException(
+                        "Consumption profile " + keyDescription + " '" + key +
+                        "' is already registered by provider '" + existing.Profile.ProviderId +
+                        "'. Reuse the existing profile or choose another stable key.");
+                }
+
+                registration = new ProductConsumptionProfileRegistration(key, profile);
+                registrations.Add(key, registration);
+            }
+
+            CustomProductManifestRuntime.RefreshHostManifestIfReady();
+            return registration.Profile;
+        }
+    }
+}

--- a/S1API/Internal/Products/ProductConsumptionProfileRegistrationRegistry.cs
+++ b/S1API/Internal/Products/ProductConsumptionProfileRegistrationRegistry.cs
@@ -30,6 +30,9 @@ namespace S1API.Internal.Products
             ProductKind productKind,
             ProductConsumptionProfile profile)
         {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+
             return Register(KindProfiles, "product-kind ID", productKind.Id, profile);
         }
 

--- a/S1API/Products/ProductConsumptionContext.cs
+++ b/S1API/Products/ProductConsumptionContext.cs
@@ -10,7 +10,7 @@ namespace S1API.Products
     /// <remarks>
     /// Player callbacks are invoked only for the local player. NPC callbacks can receive an
     /// unavailable <see cref="NPC"/> wrapper for game-owned NPCs; use <see cref="TargetId"/>
-    /// when behavior only needs the native target identifier.
+    /// when behavior only needs the stable native target identifier.
     /// </remarks>
     public sealed class ProductConsumptionContext
     {
@@ -101,7 +101,7 @@ namespace S1API.Products
         public NPC? NPC { get; }
 
         /// <summary>
-        /// Gets the target identifier supplied by the native consumption lifecycle.
+        /// Gets the stable native target identifier: a player code for players or the NPC ID for NPCs.
         /// </summary>
         public string TargetId { get; }
 

--- a/S1API/Products/ProductConsumptionContext.cs
+++ b/S1API/Products/ProductConsumptionContext.cs
@@ -1,0 +1,114 @@
+using System.Collections.Generic;
+using S1API.Entities;
+using S1API.Properties.Interfaces;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Describes one intrinsic consumption lifecycle transition for a registered custom product.
+    /// </summary>
+    /// <remarks>
+    /// Player callbacks are invoked only for the local player. NPC callbacks can receive an
+    /// unavailable <see cref="NPC"/> wrapper for game-owned NPCs; use <see cref="TargetId"/>
+    /// when behavior only needs the native target identifier.
+    /// </remarks>
+    public sealed class ProductConsumptionContext
+    {
+        private readonly string _productId;
+        private readonly ProductKind _productKind;
+        private readonly Quality _quality;
+        private readonly IReadOnlyList<PropertyBase> _properties;
+
+        internal ProductConsumptionContext(
+            ProductInstance product,
+            CustomProductDefinition definition,
+            Player? player,
+            NPC? npc,
+            string targetId)
+        {
+            Product = product;
+            Definition = definition;
+            _productId = definition.ID;
+            _productKind = definition.ProductKind;
+            _quality = product.Quality;
+            _properties = product.Properties;
+            Player = player;
+            NPC = npc;
+            TargetId = targetId;
+        }
+
+        internal ProductConsumptionContext(
+            string productId,
+            ProductKind productKind,
+            Player? player,
+            NPC? npc,
+            string targetId)
+        {
+            Product = null!;
+            Definition = null!;
+            _productId = productId;
+            _productKind = productKind;
+            _quality = Quality.Standard;
+            _properties = System.Array.Empty<PropertyBase>();
+            Player = player;
+            NPC = npc;
+            TargetId = targetId;
+        }
+
+        /// <summary>
+        /// Gets the consumed product instance.
+        /// </summary>
+        public ProductInstance Product { get; }
+
+        /// <summary>
+        /// Gets the registered custom product definition.
+        /// </summary>
+        public CustomProductDefinition Definition { get; }
+
+        /// <summary>
+        /// Gets the stable product identifier.
+        /// </summary>
+        public string ProductId =>
+            _productId;
+
+        /// <summary>
+        /// Gets the logical product kind retained by generated mixed products.
+        /// </summary>
+        public ProductKind ProductKind =>
+            _productKind;
+
+        /// <summary>
+        /// Gets the consumed product quality.
+        /// </summary>
+        public Quality Quality =>
+            _quality;
+
+        /// <summary>
+        /// Gets the ordinary product properties applied alongside this profile.
+        /// </summary>
+        public IReadOnlyList<PropertyBase> Properties =>
+            _properties;
+
+        /// <summary>
+        /// Gets the local player for player callbacks, or <see langword="null"/> for NPC callbacks.
+        /// </summary>
+        public Player? Player { get; }
+
+        /// <summary>
+        /// Gets the S1API NPC wrapper when one is available, or <see langword="null"/> for a
+        /// game-owned NPC without an S1API wrapper.
+        /// </summary>
+        public NPC? NPC { get; }
+
+        /// <summary>
+        /// Gets the target identifier supplied by the native consumption lifecycle.
+        /// </summary>
+        public string TargetId { get; }
+
+        /// <summary>
+        /// Gets whether this transition targets the local player.
+        /// </summary>
+        public bool IsLocalPlayer =>
+            Player != null;
+    }
+}

--- a/S1API/Products/ProductConsumptionProfile.cs
+++ b/S1API/Products/ProductConsumptionProfile.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Defines intrinsic consumption behavior for registered custom products.
+    /// </summary>
+    /// <remarks>
+    /// Profiles are immutable. Their callbacks run in addition to ordinary product-property effects
+    /// and only for product definitions registered through S1API.
+    /// </remarks>
+    public sealed class ProductConsumptionProfile
+    {
+        internal ProductConsumptionProfile(
+            string providerId,
+            int providerVersion,
+            Action<ProductConsumptionContext>? onPlayerApply,
+            Action<ProductConsumptionContext>? onPlayerClear,
+            Action<ProductConsumptionContext>? onNpcApply,
+            Action<ProductConsumptionContext>? onNpcClear)
+        {
+            ProviderId = providerId;
+            ProviderVersion = providerVersion;
+            OnPlayerApply = onPlayerApply;
+            OnPlayerClear = onPlayerClear;
+            OnNpcApply = onNpcApply;
+            OnNpcClear = onNpcClear;
+        }
+
+        /// <summary>
+        /// Gets the stable, namespaced identity of the provider that owns this behavior.
+        /// </summary>
+        public string ProviderId { get; }
+
+        /// <summary>
+        /// Gets the provider-defined compatibility version for this behavior.
+        /// </summary>
+        public int ProviderVersion { get; }
+
+        internal Action<ProductConsumptionContext>? OnPlayerApply { get; }
+
+        internal Action<ProductConsumptionContext>? OnPlayerClear { get; }
+
+        internal Action<ProductConsumptionContext>? OnNpcApply { get; }
+
+        internal Action<ProductConsumptionContext>? OnNpcClear { get; }
+    }
+}

--- a/S1API/Products/ProductConsumptionProfileBuilder.cs
+++ b/S1API/Products/ProductConsumptionProfileBuilder.cs
@@ -1,0 +1,115 @@
+using System;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Builds an immutable intrinsic consumption profile for custom products.
+    /// </summary>
+    public sealed class ProductConsumptionProfileBuilder
+    {
+        private string? _providerId;
+        private int _providerVersion;
+        private Action<ProductConsumptionContext>? _onPlayerApply;
+        private Action<ProductConsumptionContext>? _onPlayerClear;
+        private Action<ProductConsumptionContext>? _onNpcApply;
+        private Action<ProductConsumptionContext>? _onNpcClear;
+
+        /// <summary>
+        /// Sets the stable identity and compatibility version for this profile provider.
+        /// </summary>
+        /// <param name="providerId">A stable, namespaced provider identifier.</param>
+        /// <param name="providerVersion">A non-negative compatibility version.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductConsumptionProfileBuilder WithProviderCompatibility(
+            string providerId,
+            int providerVersion)
+        {
+            if (providerVersion < 0)
+                throw new ArgumentOutOfRangeException(nameof(providerVersion));
+
+            _providerId = ProductKindId.Normalize(providerId, nameof(providerId));
+            _providerVersion = providerVersion;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets behavior to run after ordinary effects apply to the local consuming player.
+        /// </summary>
+        /// <param name="callback">The callback to run for the local player.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductConsumptionProfileBuilder OnPlayerApply(
+            Action<ProductConsumptionContext> callback)
+        {
+            _onPlayerApply = callback ?? throw new ArgumentNullException(nameof(callback));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets behavior to run after ordinary effects clear from the local consuming player.
+        /// </summary>
+        /// <param name="callback">The callback to run for the local player.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductConsumptionProfileBuilder OnPlayerClear(
+            Action<ProductConsumptionContext> callback)
+        {
+            _onPlayerClear = callback ?? throw new ArgumentNullException(nameof(callback));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets behavior to run after ordinary effects apply to an NPC consumer.
+        /// </summary>
+        /// <param name="callback">The callback to run for the NPC consumer.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductConsumptionProfileBuilder OnNpcApply(
+            Action<ProductConsumptionContext> callback)
+        {
+            _onNpcApply = callback ?? throw new ArgumentNullException(nameof(callback));
+            return this;
+        }
+
+        /// <summary>
+        /// Sets behavior to run after ordinary effects clear from an NPC consumer.
+        /// </summary>
+        /// <param name="callback">The callback to run for the NPC consumer.</param>
+        /// <returns>This builder for method chaining.</returns>
+        public ProductConsumptionProfileBuilder OnNpcClear(
+            Action<ProductConsumptionContext> callback)
+        {
+            _onNpcClear = callback ?? throw new ArgumentNullException(nameof(callback));
+            return this;
+        }
+
+        /// <summary>
+        /// Builds the configured immutable consumption profile.
+        /// </summary>
+        /// <returns>The immutable consumption profile.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when provider compatibility or at least one lifecycle callback was not configured.
+        /// </exception>
+        public ProductConsumptionProfile Build()
+        {
+            if (_providerId == null)
+            {
+                throw new InvalidOperationException(
+                    "WithProviderCompatibility must be called before Build().");
+            }
+
+            if (_onPlayerApply == null && _onPlayerClear == null &&
+                _onNpcApply == null && _onNpcClear == null)
+            {
+                throw new InvalidOperationException(
+                    "Configure at least one consumption lifecycle callback before Build().");
+            }
+
+            return new ProductConsumptionProfile(
+                _providerId,
+                _providerVersion,
+                _onPlayerApply,
+                _onPlayerClear,
+                _onNpcApply,
+                _onNpcClear);
+        }
+    }
+}

--- a/S1API/Products/ProductConsumptionProfileBuilder.cs
+++ b/S1API/Products/ProductConsumptionProfileBuilder.cs
@@ -19,13 +19,13 @@ namespace S1API.Products
         /// Sets the stable identity and compatibility version for this profile provider.
         /// </summary>
         /// <param name="providerId">A stable, namespaced provider identifier.</param>
-        /// <param name="providerVersion">A non-negative compatibility version.</param>
+        /// <param name="providerVersion">A positive compatibility version.</param>
         /// <returns>This builder for method chaining.</returns>
         public ProductConsumptionProfileBuilder WithProviderCompatibility(
             string providerId,
             int providerVersion)
         {
-            if (providerVersion < 0)
+            if (providerVersion <= 0)
                 throw new ArgumentOutOfRangeException(nameof(providerVersion));
 
             _providerId = ProductKindId.Normalize(providerId, nameof(providerId));

--- a/S1API/Products/ProductConsumptionProfileRegistry.cs
+++ b/S1API/Products/ProductConsumptionProfileRegistry.cs
@@ -1,0 +1,49 @@
+using System;
+using S1API.Internal.Products;
+
+namespace S1API.Products
+{
+    /// <summary>
+    /// Registers process-lifetime intrinsic consumption profiles for custom products.
+    /// </summary>
+    /// <remarks>
+    /// Product IDs and product-kind IDs are case-insensitive. A product-specific profile takes
+    /// deterministic precedence over a product-kind profile. Register matching providers on every
+    /// multiplayer peer before custom-product manifest validation begins.
+    /// </remarks>
+    public static class ProductConsumptionProfileRegistry
+    {
+        /// <summary>
+        /// Registers a profile for one stable custom product ID.
+        /// </summary>
+        /// <param name="productId">The stable, namespaced product ID.</param>
+        /// <param name="profile">The immutable consumption profile.</param>
+        /// <returns>The registered profile, or the existing profile on an idempotent call.</returns>
+        public static ProductConsumptionProfile RegisterForProduct(
+            string productId,
+            ProductConsumptionProfile profile)
+        {
+            return ProductConsumptionProfileRegistrationRegistry.RegisterForProduct(
+                productId,
+                profile);
+        }
+
+        /// <summary>
+        /// Registers a profile for every registered custom product of one logical product kind.
+        /// </summary>
+        /// <param name="productKind">The immutable logical product kind.</param>
+        /// <param name="profile">The immutable consumption profile.</param>
+        /// <returns>The registered profile, or the existing profile on an idempotent call.</returns>
+        public static ProductConsumptionProfile RegisterForProductKind(
+            ProductKind productKind,
+            ProductConsumptionProfile profile)
+        {
+            if (productKind == null)
+                throw new ArgumentNullException(nameof(productKind));
+
+            return ProductConsumptionProfileRegistrationRegistry.RegisterForProductKind(
+                productKind,
+                profile);
+        }
+    }
+}

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -21,6 +21,8 @@ If you want customer preference configuration, see `S1API/docs/products-system.m
 - `S1API.Products.ProductPresentationProfileBuilder`: configures mod-owned loose presentation contexts
 - `S1API.Products.ProductPresentationTransform`: overrides a cloned context visual's local transform
 - `S1API.Products.ProductPresentationProfileRegistry`: registers profiles by stable product ID or logical product kind
+- `S1API.Products.ProductConsumptionProfileBuilder`: configures intrinsic custom-product consumption callbacks
+- `S1API.Products.ProductConsumptionProfileRegistry`: registers consumption profiles by stable product ID or logical product kind
 - `S1API.Products.PackagingDefinition`: packaging definition wrapper
 - `S1API.Products.Quality`: API-safe quality enum
 
@@ -212,6 +214,41 @@ ProductManager.SetNpcEffectClearCallback(Property.Sneaky, npc =>
 
 Use `ProductManager.RemoveNpcEffectClearCallback(...)` or `ProductManager.ResetNpcEffectClearCallbacks()` to remove
 registered NPC clear callbacks.
+
+## Intrinsic custom-product consumption profiles
+
+Use a consumption profile for behavior that belongs to a registered custom product or logical
+`ProductKind`, rather than to a visible product property. Profiles run after ordinary property effects
+at the native apply/clear lifecycle points. A product-ID registration overrides a product-kind
+registration; kind registrations also cover generated mixed products that retain that kind.
+
+```csharp
+using S1API.Products;
+
+var profile = new ProductConsumptionProfileBuilder()
+    .WithProviderCompatibility("examplemod:mdma-consumption", 1)
+    .OnPlayerApply(context =>
+    {
+        // Player callbacks are local-only, so camera and audio state stays local.
+    })
+    .OnPlayerClear(context =>
+    {
+        // Cleanup must be safe when the game clears a product repeatedly.
+    })
+    .OnNpcApply(context =>
+    {
+        // NPC wrappers can be unavailable for game-owned NPCs; TargetId remains available.
+    })
+    .OnNpcClear(context => { })
+    .Build();
+
+ProductConsumptionProfileRegistry.RegisterForProductKind(customKind, profile);
+```
+
+The provider ID and version are scalar multiplayer compatibility data. Register the same profile
+provider on every peer before custom-product manifest validation; S1API never serializes callbacks,
+Unity objects, assets, or transient camera/audio state. Active profile state is not restored across
+save/load, reconnect, or late join.
 
 ## Creating product instances
 

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -248,7 +248,9 @@ ProductConsumptionProfileRegistry.RegisterForProductKind(customKind, profile);
 The provider ID and version are scalar multiplayer compatibility data. Register the same profile
 provider on every peer before custom-product manifest validation; S1API never serializes callbacks,
 Unity objects, assets, or transient camera/audio state. Active profile state is not restored across
-save/load, reconnect, or late join.
+save/load, reconnect, or late join. If an apply callback fails, S1API immediately attempts its clear
+callback and permits the next native apply lifecycle call to retry. `TargetId` is the native stable
+player code for players and the native NPC ID for NPCs; it is not a display name.
 
 ## Creating product instances
 


### PR DESCRIPTION
Closes #135

## Summary

- Adds opt-in immutable `ProductConsumptionProfile` registrations for stable product IDs and logical `ProductKind` values, with deterministic product-ID precedence and mixed-product kind fallback.
- Dispatches profile callbacks after ordinary property effects at the merged #134 apply/clear seams; tracks active ownership for idempotent clear, replacement cleanup, and isolated callback failures.
- Gates player callbacks to the local player, keeps NPC callbacks observer-visible, and adds scalar provider identity/version to custom-product manifest compatibility (protocol 3).

## Compatibility

- **Source / binary:** additive public types and members only; existing #134 clear-callback APIs and prior surfaces are unchanged and reflected by compatibility tests plus a compile fixture.
- **Behavioral:** native products and custom products without a registered profile retain the existing native/#134 dispatch path. Ordinary property effects run first; profile failures are logged and do not corrupt that pipeline.
- **Save:** no product save descriptor or transient profile-effect state is serialized. Active callback ownership is intentionally not restored after save/load, reconnect, or late join.
- **Network:** custom-product manifest protocol advances to 3 with scalar consumption-provider ID/version. Peers with mismatched or absent profile compatibility reject before custom-product gameplay proceeds; delegates/assets are never serialized.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 298 passed
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 290 passed
- `docfx docfx.json` from `S1API/` — succeeded (four pre-existing local assembly-reference warnings)
- `dotnet run --project tools/S1APIDocumentationCoverage/S1APIDocumentationCoverage.csproj --configuration Release -- --api-directory S1API/api --minimum 80` — 81.57% (2,970/3,641)

## Notes

The focused Mono and generated IL2CPP wrapper preflight verified the four base `ProductItemInstance` apply/clear seams. No real-game smoke, save/reconnect, late-join, or two-client multiplayer session was run in this change; those remain the review/runtime validation gap. No proprietary game artifacts or smoke sources are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumption profiles for custom products, with provider compatibility metadata and player/NPC apply and clear callbacks.
  * Added APIs to build and register profiles for specific products or product kinds.
  * Added profile resolution, lifecycle handling, callback visibility rules, and registration precedence support.
  * Included consumption profile compatibility information in product manifests.

* **Documentation**
  * Added guidance for configuring and registering intrinsic custom-product consumption profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->