### PR TITLE
Fix runtime item persistence across save reloads

### DIFF
--- a/S1API.Tests/Items/RuntimeItemDefinitionRegistryTests.cs
+++ b/S1API.Tests/Items/RuntimeItemDefinitionRegistryTests.cs
@@ -1,0 +1,87 @@
+#if IL2CPPMELON
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+#elif MONOMELON
+using S1ItemFramework = ScheduleOne.ItemFramework;
+#endif
+
+using System.Runtime.CompilerServices;
+using S1API.Internal.Items;
+
+namespace S1API.Tests.Items;
+
+public sealed class RuntimeItemDefinitionRegistryTests : IDisposable
+{
+    private readonly RecordingAdapter _adapter = new();
+
+    public RuntimeItemDefinitionRegistryTests()
+    {
+        RuntimeItemDefinitionRegistry.ResetForTesting(_adapter);
+    }
+
+    public void Dispose()
+    {
+        RuntimeItemDefinitionRegistry.RestoreRuntimeAdapterForTesting();
+    }
+
+    [Fact]
+    public void PreLoadReappliesRetainedDefinitionWhenNativeRegistryRemovedIt()
+    {
+        S1ItemFramework.ItemDefinition definition = CreateDefinition();
+        RuntimeItemDefinitionRegistry.Retain("example.mod:crystals", definition);
+
+        RuntimeItemDefinitionRegistry.InvokePreLoadForTesting();
+
+        Assert.Same(definition, Assert.Single(_adapter.Registered));
+    }
+
+    [Fact]
+    public void PreLoadDoesNotDuplicateDefinitionStillPresentInNativeRegistry()
+    {
+        _adapter.RegisteredIds.Add("example.mod:press");
+        RuntimeItemDefinitionRegistry.Retain(
+            "example.mod:press",
+            CreateDefinition());
+
+        RuntimeItemDefinitionRegistry.InvokePreLoadForTesting();
+
+        Assert.Empty(_adapter.Registered);
+    }
+
+    [Fact]
+    public void ForgottenDefinitionIsNotReapplied()
+    {
+        RuntimeItemDefinitionRegistry.Retain(
+            "example.mod:temporary",
+            CreateDefinition());
+        RuntimeItemDefinitionRegistry.Forget("example.mod:temporary");
+
+        RuntimeItemDefinitionRegistry.InvokePreLoadForTesting();
+
+        Assert.Empty(_adapter.Registered);
+    }
+
+    private static S1ItemFramework.ItemDefinition CreateDefinition()
+    {
+        return (S1ItemFramework.ItemDefinition)
+            RuntimeHelpers.GetUninitializedObject(
+                typeof(S1ItemFramework.StorableItemDefinition));
+    }
+
+    private sealed class RecordingAdapter : IRuntimeItemDefinitionRegistryAdapter
+    {
+        internal HashSet<string> RegisteredIds { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal List<S1ItemFramework.ItemDefinition> Registered { get; } = new();
+
+        public bool IsRegistered(string itemId)
+        {
+            return RegisteredIds.Contains(itemId);
+        }
+
+        public void Register(S1ItemFramework.ItemDefinition definition)
+        {
+            Registered.Add(definition);
+        }
+    }
+}

--- a/S1API.Tests/Products/CustomProductSavePersistenceTests.cs
+++ b/S1API.Tests/Products/CustomProductSavePersistenceTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using S1API.Internal.Products;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductSavePersistenceTests
+{
+    [Fact]
+    public void DescriptorAcceptsVanillaRepresentationTemplateId()
+    {
+        CustomProductSaveDescriptorData data = CreateDescriptor("cocaine");
+        MethodInfo validate = typeof(CustomProductSavePersistence).GetMethod(
+            "TryValidate",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        object?[] arguments = { data, null };
+
+        bool valid = (bool)validate.Invoke(null, arguments)!;
+
+        Assert.True(valid);
+        Assert.NotNull(arguments[1]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DescriptorRejectsEmptyRepresentationTemplateId(string templateId)
+    {
+        CustomProductSaveDescriptorData data = CreateDescriptor(templateId);
+        MethodInfo validate = typeof(CustomProductSavePersistence).GetMethod(
+            "TryValidate",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        object?[] arguments = { data, null };
+
+        bool valid = (bool)validate.Invoke(null, arguments)!;
+
+        Assert.False(valid);
+        Assert.Null(arguments[1]);
+    }
+
+    private static CustomProductSaveDescriptorData CreateDescriptor(
+        string representationTemplateId)
+    {
+        return new CustomProductSaveDescriptorData
+        {
+            ProductId = "example.mod:products/tablet",
+            OwnerId = "example.mod",
+            ProductName = "Tablet",
+            Description = "A custom tablet.",
+            InitialPrice = 100f,
+            LegalStatus = 1,
+            BaseAddictiveness = 0.25f,
+            DefaultQuality = 3,
+            ProductKindId = "example.mod:tablet",
+            CompatibilityDrugType = 2,
+            RepresentationTemplateId = representationTemplateId,
+            PlayerEffectDurationSeconds = 120,
+            NpcEffectDurationSeconds = 180,
+            PropertyIds = new[] { "energizing" },
+            PackagingIds = new[] { "baggie", "jar" },
+            ProviderId = "example.mod:products",
+            ProviderVersion = 1,
+            ProviderData = "tablet",
+        };
+    }
+}

--- a/S1API/Internal/Items/RuntimeItemDefinitionRegistry.cs
+++ b/S1API/Internal/Items/RuntimeItemDefinitionRegistry.cs
@@ -1,0 +1,149 @@
+#if IL2CPPMELON
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Registry = Il2CppScheduleOne.Registry;
+#elif MONOMELON
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Registry = ScheduleOne.Registry;
+#endif
+
+using System;
+using System.Collections.Generic;
+using S1API.Lifecycle;
+
+namespace S1API.Internal.Items
+{
+    internal interface IRuntimeItemDefinitionRegistryAdapter
+    {
+        bool IsRegistered(string itemId);
+
+        void Register(S1ItemFramework.ItemDefinition definition);
+    }
+
+    internal sealed class RuntimeItemDefinitionRegistryAdapter
+        : IRuntimeItemDefinitionRegistryAdapter
+    {
+        internal static readonly RuntimeItemDefinitionRegistryAdapter Instance =
+            new RuntimeItemDefinitionRegistryAdapter();
+
+        private RuntimeItemDefinitionRegistryAdapter()
+        {
+        }
+
+        public bool IsRegistered(string itemId)
+        {
+            return S1Registry.Instance != null && S1Registry.ItemExists(itemId);
+        }
+
+        public void Register(S1ItemFramework.ItemDefinition definition)
+        {
+            if (S1Registry.Instance == null)
+                throw new InvalidOperationException("ScheduleOne.Registry is unavailable.");
+
+            S1Registry.Instance.AddToRegistry(definition);
+        }
+    }
+
+    /// <summary>
+    /// Retains definitions created by S1API builders and reapplies them after the
+    /// native registry removes runtime items during a scene transition.
+    /// </summary>
+    internal static class RuntimeItemDefinitionRegistry
+    {
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, S1ItemFramework.ItemDefinition> Definitions =
+            new Dictionary<string, S1ItemFramework.ItemDefinition>(
+                StringComparer.OrdinalIgnoreCase);
+
+        private static IRuntimeItemDefinitionRegistryAdapter _adapter =
+            RuntimeItemDefinitionRegistryAdapter.Instance;
+        private static bool _hooked;
+
+        internal static void Retain(
+            string itemId,
+            S1ItemFramework.ItemDefinition definition)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+                throw new ArgumentException("Item ID cannot be empty or whitespace.", nameof(itemId));
+            if (ReferenceEquals(definition, null))
+                throw new ArgumentNullException(nameof(definition));
+
+            lock (Gate)
+            {
+                Definitions[itemId] = definition;
+                EnsureHooked();
+            }
+        }
+
+        internal static void Forget(string itemId)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+                return;
+
+            lock (Gate)
+                Definitions.Remove(itemId);
+        }
+
+        private static void EnsureHooked()
+        {
+            if (_hooked)
+                return;
+
+            GameLifecycle.OnPreLoad += ReapplyAll;
+            _hooked = true;
+        }
+
+        private static void ReapplyAll()
+        {
+            KeyValuePair<string, S1ItemFramework.ItemDefinition>[] snapshot;
+            lock (Gate)
+            {
+                snapshot =
+                    new KeyValuePair<string, S1ItemFramework.ItemDefinition>[Definitions.Count];
+                ((ICollection<KeyValuePair<string, S1ItemFramework.ItemDefinition>>)Definitions)
+                    .CopyTo(snapshot, 0);
+            }
+
+            foreach (KeyValuePair<string, S1ItemFramework.ItemDefinition> entry in snapshot)
+            {
+                try
+                {
+                    if (!_adapter.IsRegistered(entry.Key))
+                        _adapter.Register(entry.Value);
+                }
+                catch (Exception exception)
+                {
+                    MelonLoader.MelonLogger.Error(
+                        $"[RuntimeItemDefinitionRegistry] Failed to restore item " +
+                        $"'{entry.Key}' during pre-load: {exception}");
+                }
+            }
+        }
+
+        internal static void ResetForTesting(
+            IRuntimeItemDefinitionRegistryAdapter adapter)
+        {
+            if (adapter == null)
+                throw new ArgumentNullException(nameof(adapter));
+
+            lock (Gate)
+            {
+                if (_hooked)
+                    GameLifecycle.OnPreLoad -= ReapplyAll;
+
+                Definitions.Clear();
+                _adapter = adapter;
+                _hooked = false;
+            }
+        }
+
+        internal static void RestoreRuntimeAdapterForTesting()
+        {
+            ResetForTesting(RuntimeItemDefinitionRegistryAdapter.Instance);
+        }
+
+        internal static void InvokePreLoadForTesting()
+        {
+            ReapplyAll();
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -238,7 +238,8 @@ namespace S1API.Internal.Products
                     !Enum.IsDefined(typeof(global::S1API.Items.LegalStatus), data.LegalStatus) || !Enum.IsDefined(typeof(Quality), data.DefaultQuality) || !Enum.IsDefined(typeof(DrugType), data.CompatibilityDrugType) ||
                     !IsBoundedCollection(data.PropertyIds) || !IsBoundedCollection(data.PackagingIds)) return false;
                 string kindId = ProductKindId.Normalize(data.ProductKindId, nameof(data.ProductKindId));
-                ProductKindId.Normalize(data.RepresentationTemplateId, nameof(data.RepresentationTemplateId));
+                if (string.IsNullOrWhiteSpace(data.RepresentationTemplateId))
+                    return false;
                 descriptor = new CustomProductSaveDescriptor(data.FormatVersion, productId, ownerId, data.ProductName, data.Description, data.InitialPrice, kindId, providerId, data.ProviderVersion, data.ProviderData) { Data = data };
                 return true;
             }

--- a/S1API/Items/ItemManager.cs
+++ b/S1API/Items/ItemManager.cs
@@ -12,6 +12,7 @@ using S1Clothing = ScheduleOne.Clothing;
 using S1Packaging = ScheduleOne.Product.Packaging;
 #endif
 
+using S1API.Internal.Items;
 using S1API.Internal.Utils;
 using S1API.Money;
 using S1API.Products;
@@ -216,7 +217,10 @@ namespace S1API.Items
 
             RemoveFromRuntimeCleanupQueue(definition.S1ItemDefinition, definition.ID);
             S1Registry.Instance.RemoveFromRegistry(definition.S1ItemDefinition);
-            return GetDefinition(itemID) == null;
+            bool removed = GetDefinition(itemID) == null;
+            if (removed)
+                RuntimeItemDefinitionRegistry.Forget(itemID);
+            return removed;
         }
 
         /// <summary>

--- a/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
+++ b/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
@@ -15,6 +15,7 @@ using S1Storage = ScheduleOne.Storage;
 #endif
 using System;
 using System.Collections.Generic;
+using S1API.Internal.Items;
 using S1API.Logging;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -394,6 +395,7 @@ namespace S1API.Items.Storable
 
             // Register with the game's registry
             S1Registry.Instance.AddToRegistry(Definition);
+            RuntimeItemDefinitionRegistry.Retain(Definition.ID, Definition);
 
             // Return wrapper
             return CreateWrapper(Definition);

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -9,7 +9,7 @@ using S1API.Internal.Products;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.6", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.7", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.0-beta.6</Version>
+        <Version>3.1.0-beta.7</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- Retain S1API builder-created runtime item definitions and re-register them at the pre-load lifecycle seam when the native registry has removed them during scene transitions.
- Preserve explicit `ItemManager.UnregisterItem` behavior by forgetting retained entries only after native removal succeeds.
- Accept vanilla representation template IDs in custom-product save descriptors instead of incorrectly requiring a namespaced logical product kind.
- Bump the prerelease version to `3.1.0-beta.7`.

## Root cause

The native registry removes runtime definitions when returning to the menu. Mods that cache their registrations then skip rebuilding them on the next load, so save hydration cannot resolve placed buildables or stored custom items.

## Validation

- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 307 passed.
- Focused Mono and IL2CPP tests for the new registry and descriptor validation — 6 passed in each runtime.
- Real-game smoke: same-process save → menu → reload and fresh-process restart → load, in both Mono and IL2CPP. Each retained the placed tablet press and five stored MDMA crystals.
- The full IL2CPP test run executed all 200 discovered tests successfully, then the test host hit the existing `GameAssembly`-absent finalizer crash from uninitialized wrapper test objects.