### PR TITLE
chore(release): prepare 3.1.0-beta.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ coverage-chart.md
 # Coverage history is tracked to show progress over time
 !tools/S1APICoverageAnalyzer/coverage-history.json
 /S1API/.spark-runs
+/.spark-runs

--- a/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
+++ b/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
@@ -1,0 +1,27 @@
+using S1API.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NpcVisibilityPolicyTests
+{
+    [Theory]
+    [InlineData(false, false, false, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, false, true)]
+    [InlineData(true, true, false, false)]
+    [InlineData(true, true, true, true)]
+    public void ResolveSpawnVisibility_PreservesNativeSupplierVisibility(
+        bool isPhysical,
+        bool isSupplier,
+        bool isSupplierMeeting,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPC.ResolveSpawnVisibility(
+                isPhysical,
+                isSupplier,
+                isSupplierMeeting));
+    }
+}

--- a/S1API.Tests/Entities/SupplierDataBuilderDeferredItemTests.cs
+++ b/S1API.Tests/Entities/SupplierDataBuilderDeferredItemTests.cs
@@ -1,0 +1,29 @@
+using S1API.Entities.Supplier;
+
+namespace S1API.Tests.Entities;
+
+public sealed class SupplierDataBuilderDeferredItemTests
+{
+    [Fact]
+    public void WithDeliveryItem_AllowsStableIdBeforeItemRegistration()
+    {
+        var builder = new SupplierDataBuilder();
+
+        SupplierDataBuilder result =
+            builder.WithDeliveryItem("example.mod:ingredients/late-item");
+
+        Assert.Same(builder, result);
+    }
+
+    [Fact]
+    public void WithDeliveryItem_DeduplicatesDeferredIdsIgnoringCase()
+    {
+        var builder = new SupplierDataBuilder()
+            .WithDeliveryItem("example.mod:ingredients/late-item")
+            .WithDeliveryItem("EXAMPLE.MOD:INGREDIENTS/LATE-ITEM");
+
+        var data = builder.BuildInternal();
+
+        Assert.Single(data.DeliveryItemIds);
+    }
+}

--- a/S1API.Tests/Entities/SupplierMeetingDialoguePolicyTests.cs
+++ b/S1API.Tests/Entities/SupplierMeetingDialoguePolicyTests.cs
@@ -1,0 +1,53 @@
+using S1API.Internal.Entities.Suppliers;
+
+namespace S1API.Tests.Entities;
+
+public sealed class SupplierMeetingDialoguePolicyTests
+{
+    [Fact]
+    public void EmptyNativeSupplierUsesFirstDialogueEntries()
+    {
+        SupplierMeetingDialogueBindings bindings =
+            SupplierMeetingDialoguePolicy.ForNativeStart(0, 0);
+
+        Assert.Equal(0, bindings.GreetingOverrideIndex);
+        Assert.Equal(0, bindings.ChoiceIndex);
+    }
+
+    [Fact]
+    public void ConvertedEmployeeTargetsEntriesAppendedBySupplierStart()
+    {
+        SupplierMeetingDialogueBindings bindings =
+            SupplierMeetingDialoguePolicy.ForNativeStart(1, 0);
+
+        Assert.Equal(1, bindings.GreetingOverrideIndex);
+        Assert.Equal(0, bindings.ChoiceIndex);
+    }
+
+    [Fact]
+    public void ExistingCustomEntriesRemainAheadOfSupplierEntries()
+    {
+        SupplierMeetingDialogueBindings bindings =
+            SupplierMeetingDialoguePolicy.ForNativeStart(3, 2);
+
+        Assert.Equal(3, bindings.GreetingOverrideIndex);
+        Assert.Equal(2, bindings.ChoiceIndex);
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, true)]
+    public void DialogueActivatesOnlyForVisibleMeetingSupplier(
+        bool visible,
+        bool isMeeting,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            SupplierMeetingDialoguePolicy.ShouldActivate(
+                visible,
+                isMeeting));
+    }
+}

--- a/S1API.Tests/Stations/ChemistryStationRecipeApiCompileFixture.cs
+++ b/S1API.Tests/Stations/ChemistryStationRecipeApiCompileFixture.cs
@@ -20,4 +20,25 @@ internal static class ChemistryStationRecipeApiCompileFixture
             .WithIngredient(ingredientId, quantity: 1)
             .Build();
     }
+
+    internal static ChemistryStationRecipe CompileProgressionControlledSyntax(
+        string productId,
+        string ingredientId)
+    {
+        ChemistryStationRecipe recipe =
+            new ChemistryStationRecipeBuilder()
+                .WithInitialAvailability(
+                    isDiscovered: false,
+                    isUnlocked: false)
+                .WithProduct(productId, quantity: 5)
+                .WithIngredient(ingredientId, quantity: 1)
+                .Build();
+
+        recipe.SetAvailability(
+            isDiscovered: true,
+            isUnlocked: true);
+        _ = recipe.IsDiscovered;
+        _ = recipe.IsUnlocked;
+        return recipe;
+    }
 }

--- a/S1API.Tests/Stations/ChemistryStationRecipeAvailabilityApiTests.cs
+++ b/S1API.Tests/Stations/ChemistryStationRecipeAvailabilityApiTests.cs
@@ -1,0 +1,35 @@
+using S1API.Stations;
+
+namespace S1API.Tests.Stations;
+
+public sealed class ChemistryStationRecipeAvailabilityApiTests
+{
+    [Fact]
+    public void AvailabilityApiIsAdditiveAndUsesStableSignatures()
+    {
+        Assert.Equal(
+            typeof(ChemistryStationRecipeBuilder),
+            typeof(ChemistryStationRecipeBuilder)
+                .GetMethod(
+                    nameof(ChemistryStationRecipeBuilder.WithInitialAvailability),
+                    new[] { typeof(bool), typeof(bool) })!
+                .ReturnType);
+        Assert.Equal(
+            typeof(void),
+            typeof(ChemistryStationRecipe)
+                .GetMethod(
+                    nameof(ChemistryStationRecipe.SetAvailability),
+                    new[] { typeof(bool), typeof(bool) })!
+                .ReturnType);
+        Assert.Equal(
+            typeof(bool),
+            typeof(ChemistryStationRecipe)
+                .GetProperty(nameof(ChemistryStationRecipe.IsDiscovered))!
+                .PropertyType);
+        Assert.Equal(
+            typeof(bool),
+            typeof(ChemistryStationRecipe)
+                .GetProperty(nameof(ChemistryStationRecipe.IsUnlocked))!
+                .PropertyType);
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -132,6 +132,9 @@ namespace S1API.Entities
         private static readonly System.Collections.Generic.Dictionary<System.Type, DealerDataBuilder.DealerConfigData> TypeToBuiltDealerDefaults = new System.Collections.Generic.Dictionary<System.Type, DealerDataBuilder.DealerConfigData>();
         private static readonly System.Collections.Generic.Dictionary<System.Type, System.Action<SupplierDataBuilder>> TypeToSupplierDefaults = new System.Collections.Generic.Dictionary<System.Type, System.Action<SupplierDataBuilder>>();
         private static readonly System.Collections.Generic.Dictionary<System.Type, SupplierDataBuilder.SupplierConfigData> TypeToBuiltSupplierDefaults = new System.Collections.Generic.Dictionary<System.Type, SupplierDataBuilder.SupplierConfigData>();
+        internal static readonly System.Collections.Generic.HashSet<System.Type>
+            FinalizedCustomNpcTypes =
+                new System.Collections.Generic.HashSet<System.Type>();
         private static readonly System.Collections.Generic.Dictionary<System.Type, (Vector3 position, Quaternion rotation)> TypeToSpawnPosition = new System.Collections.Generic.Dictionary<System.Type, (Vector3, Quaternion)>();
         private static readonly System.Collections.Generic.HashSet<System.Type> CustomerTypes = new System.Collections.Generic.HashSet<System.Type>();
         private static readonly System.Collections.Generic.HashSet<System.Type> DealerTypes = new System.Collections.Generic.HashSet<System.Type>();
@@ -3943,8 +3946,9 @@ namespace S1API.Entities
                     S1NPC.Awareness.Responses = validResponses;
                 }
 
-                // Always set visibility locally first (for host/client consistency)
-                S1NPC.SetVisible(IsPhysical, networked: false);
+                // Suppliers follow the native lifecycle: they remain hidden while idle and
+                // only become visible when the meeting flow places them at a supplier location.
+                S1NPC.SetVisible(ShouldBeVisibleAfterSpawn(), networked: false);
 
                 EnsureMessageConversationReady(resetDefaults: false);
                 
@@ -3952,7 +3956,7 @@ namespace S1API.Entities
                 // This ensures the NPC is fully spawned before the RPC is sent
                 if (InstanceFinder.IsServer)
                 {
-                    MelonCoroutines.Start(DelayedVisibilityRPC(IsPhysical));
+                    MelonCoroutines.Start(DelayedVisibilityRPC());
                 }
 
                 // If this prefab included a Customer, ensure it's initialized; otherwise, respect non-customer NPCs
@@ -4162,6 +4166,7 @@ namespace S1API.Entities
 
                 // Check if all custom NPCs are now ready (finalized)
                 // This sets the CustomNpcsReady flag once all custom NPCs have been spawned and finalized
+                FinalizedCustomNpcTypes.Add(GetType());
                 CheckAndSetCustomNpcsReady();
             }
             catch (Exception ex)
@@ -4182,24 +4187,18 @@ namespace S1API.Entities
 
             try
             {
-                // Check if all custom NPC types have been instantiated
-                var allCustomNpcs = All.Where(n => n.IsCustomNPC).ToList();
-
-                // If there are no custom NPCs, nothing to wait for
-                if (allCustomNpcs.Count == 0)
-                    return;
-
                 // Get all custom NPC types that should exist
                 var customNpcTypes = Internal.Utils.ReflectionUtils.GetDerivedClasses<NPC>()
                     .Where(t => t != null && !t.IsAbstract && t.Assembly != typeof(NPC).Assembly)
                     .ToList();
 
-                // Check if all custom NPC types have at least one instance
-                bool allTypesInstantiated = customNpcTypes.All(type =>
-                    allCustomNpcs.Any(npc => npc.GetType() == type)
-                );
+                if (customNpcTypes.Count == 0)
+                    return;
 
-                if (allTypesInstantiated)
+                bool allTypesFinalized = customNpcTypes.All(
+                    type => FinalizedCustomNpcTypes.Contains(type));
+
+                if (allTypesFinalized)
                     CustomNpcsReady = true;
             }
             catch (Exception ex)
@@ -4321,7 +4320,31 @@ namespace S1API.Entities
         /// <summary>
         /// Coroutine to send visibility RPC after a delay to ensure the NPC is fully spawned.
         /// </summary>
-        private IEnumerator DelayedVisibilityRPC(bool isPhysical)
+        internal bool ShouldBeVisibleAfterSpawn()
+        {
+            bool isSupplier = IsCustomNPC && IsSupplierType(GetType());
+            bool isSupplierMeeting = false;
+            if (isSupplier)
+            {
+                S1Economy.Supplier? supplier =
+                    gameObject.GetComponent<S1Economy.Supplier>();
+                isSupplierMeeting =
+                    supplier?.Status == S1Economy.Supplier.ESupplierStatus.Meeting;
+            }
+
+            return ResolveSpawnVisibility(
+                IsPhysical,
+                isSupplier,
+                isSupplierMeeting);
+        }
+
+        internal static bool ResolveSpawnVisibility(
+            bool isPhysical,
+            bool isSupplier,
+            bool isSupplierMeeting) =>
+            isPhysical && (!isSupplier || isSupplierMeeting);
+
+        private IEnumerator DelayedVisibilityRPC()
         {
             // Wait a frame to ensure the NPC is fully initialized and spawned
             yield return null;
@@ -4334,7 +4357,9 @@ namespace S1API.Entities
                 if (S1NPC != null && S1NPC.gameObject != null)
                 {
                     // Broadcast visibility to clients via RPC
-                    S1NPC.SetVisible(isPhysical, networked: true);
+                    S1NPC.SetVisible(
+                        ShouldBeVisibleAfterSpawn(),
+                        networked: true);
                 }
             }
             catch (Exception ex)

--- a/S1API/Entities/Supplier/SupplierDataBuilder.cs
+++ b/S1API/Entities/Supplier/SupplierDataBuilder.cs
@@ -23,10 +23,51 @@ namespace S1API.Entities.Supplier
             public float MaximumDeaddropOrderLimit { get; set; } = 500f;
             public List<S1ItemFramework.StorableItemDefinition> DeliveryItems { get; } =
                 new List<S1ItemFramework.StorableItemDefinition>();
+            public List<string> DeliveryItemIds { get; } =
+                new List<string>();
             public string SupplierRecommendMessage { get; set; } =
                 "My friend <NAME> can hook you up with <PRODUCT>. I've passed your number on to them.";
             public string SupplierUnlockHint { get; set; } =
                 "You can now order <PRODUCT> from <NAME>. <PRODUCT> can be used to <PURPOSE>.";
+
+            internal IReadOnlyList<S1ItemFramework.StorableItemDefinition>
+                ResolveDeliveryItems()
+            {
+                for (int idIndex = 0;
+                     idIndex < DeliveryItemIds.Count;
+                     idIndex++)
+                {
+                    ItemDefinition? item =
+                        ItemManager.GetDefinition(DeliveryItemIds[idIndex]);
+                    if (item == null ||
+                        !CrossType.Is(
+                            item.S1ItemDefinition,
+                            out S1ItemFramework.StorableItemDefinition storableItem))
+                    {
+                        continue;
+                    }
+
+                    bool alreadyResolved = false;
+                    for (int itemIndex = 0;
+                         itemIndex < DeliveryItems.Count;
+                         itemIndex++)
+                    {
+                        if (string.Equals(
+                                DeliveryItems[itemIndex]?.ID,
+                                storableItem.ID,
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            alreadyResolved = true;
+                            break;
+                        }
+                    }
+
+                    if (!alreadyResolved)
+                        DeliveryItems.Add(storableItem);
+                }
+
+                return DeliveryItems;
+            }
         }
 
         private readonly SupplierConfigData data = new SupplierConfigData();
@@ -90,6 +131,7 @@ namespace S1API.Entities.Supplier
             }
 
             data.DeliveryItems.Add(storableItem);
+            AddDeliveryItemId(storableItem.ID);
             return this;
         }
 
@@ -102,21 +144,21 @@ namespace S1API.Entities.Supplier
             WithDeliveryItem((ItemDefinition)item);
 
         /// <summary>
-        /// Resolves and adds a registered item by ID.
+        /// Declares an item ID for this supplier.
         /// </summary>
-        /// <param name="itemId">The registered item ID.</param>
+        /// <param name="itemId">
+        /// The stable item ID. The item may be registered after NPC prefab discovery;
+        /// S1API resolves it when supplier runtime data is materialized.
+        /// </param>
         /// <returns>The current builder for chaining.</returns>
-        /// <exception cref="ArgumentException">Thrown when the ID is empty, missing, or resolves to a non-storable item.</exception>
+        /// <exception cref="ArgumentException">Thrown when the ID is empty.</exception>
         public SupplierDataBuilder WithDeliveryItem(string itemId)
         {
             if (string.IsNullOrWhiteSpace(itemId))
                 throw new ArgumentException("The item ID cannot be empty.", nameof(itemId));
 
-            ItemDefinition? item = ItemManager.GetDefinition(itemId);
-            if (item == null)
-                throw new ArgumentException($"No registered item has ID '{itemId}'.", nameof(itemId));
-
-            return WithDeliveryItem(item);
+            AddDeliveryItemId(itemId.Trim());
+            return this;
         }
 
         /// <summary>
@@ -158,5 +200,23 @@ namespace S1API.Entities.Supplier
         }
 
         internal SupplierConfigData BuildInternal() => data;
+
+        private void AddDeliveryItemId(string itemId)
+        {
+            for (int index = 0;
+                 index < data.DeliveryItemIds.Count;
+                 index++)
+            {
+                if (string.Equals(
+                        data.DeliveryItemIds[index],
+                        itemId,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+
+            data.DeliveryItemIds.Add(itemId);
+        }
     }
 }

--- a/S1API/Internal/Entities/NPCDataAccess.cs
+++ b/S1API/Internal/Entities/NPCDataAccess.cs
@@ -14,6 +14,7 @@ using S1AvatarFramework = ScheduleOne.AvatarFramework;
 using S1DevUtilities = ScheduleOne.DevUtilities;
 using S1Dialogue = ScheduleOne.Dialogue;
 using S1Economy = ScheduleOne.Economy;
+using S1ItemFramework = ScheduleOne.ItemFramework;
 using S1Messaging = ScheduleOne.Messaging;
 using S1NPCFramework = ScheduleOne.NPCs.Framework;
 using S1NPCs = ScheduleOne.NPCs;
@@ -269,13 +270,17 @@ namespace S1API.Internal.Entities
             supplierData.SupplierUnlockHint = data.SupplierUnlockHint;
 
 #if IL2CPPMELON
-            var listings = new Il2CppReferenceArray<Il2CppScheduleOne.UI.Phone.PhoneShopInterface.Listing>(data.DeliveryItems.Count);
-            for (int i = 0; i < data.DeliveryItems.Count; i++)
-                listings[i] = new Il2CppScheduleOne.UI.Phone.PhoneShopInterface.Listing(data.DeliveryItems[i]);
+            IReadOnlyList<S1ItemFramework.StorableItemDefinition> deliveryItems =
+                data.ResolveDeliveryItems();
+            var listings = new Il2CppReferenceArray<Il2CppScheduleOne.UI.Phone.PhoneShopInterface.Listing>(deliveryItems.Count);
+            for (int i = 0; i < deliveryItems.Count; i++)
+                listings[i] = new Il2CppScheduleOne.UI.Phone.PhoneShopInterface.Listing(deliveryItems[i]);
 #else
-            var listings = new ScheduleOne.UI.Phone.PhoneShopInterface.Listing[data.DeliveryItems.Count];
-            for (int i = 0; i < data.DeliveryItems.Count; i++)
-                listings[i] = new ScheduleOne.UI.Phone.PhoneShopInterface.Listing(data.DeliveryItems[i]);
+            IReadOnlyList<S1ItemFramework.StorableItemDefinition> deliveryItems =
+                data.ResolveDeliveryItems();
+            var listings = new ScheduleOne.UI.Phone.PhoneShopInterface.Listing[deliveryItems.Count];
+            for (int i = 0; i < deliveryItems.Count; i++)
+                listings[i] = new ScheduleOne.UI.Phone.PhoneShopInterface.Listing(deliveryItems[i]);
 #endif
             supplierData.DeliveryShopListings = listings;
         }

--- a/S1API/Internal/Entities/NPCNetworkBootstrap.cs
+++ b/S1API/Internal/Entities/NPCNetworkBootstrap.cs
@@ -379,8 +379,28 @@ namespace S1API.Internal.Entities
                 }
 
                 var go = netObject.gameObject;
-                if (go == null || netObject.IsSpawned)
+                if (go == null)
                 {
+                    PendingSpawns.RemoveAt(i);
+                    continue;
+                }
+
+                // FishNet can spawn the object through its normal host path before this
+                // deferred queue observes it. The NPC still needs S1API's one-time
+                // post-spawn hydration; dropping the entry here leaves relationship,
+                // supplier visibility, and other prefab defaults unfinished.
+                if (netObject.IsSpawned)
+                {
+                    try
+                    {
+                        owner?.FinalizeNetworkSpawn();
+                    }
+                    catch (Exception finalizeEx)
+                    {
+                        Logger.Warning(
+                            $"[NPCNetworkBootstrap] FinalizeNetworkSpawn threw for already-spawned NPC '{ownerId}': {finalizeEx.Message}");
+                    }
+
                     PendingSpawns.RemoveAt(i);
                     continue;
                 }

--- a/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
+++ b/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
@@ -81,12 +81,15 @@ namespace S1API.Internal.Entities
                 S1Shop.ShopInterface shop = SupplierShopRuntime.Ensure(supplier, stableId, config);
                 bool vehicleReady = SupplierDeliveryVehicleRuntime.Ensure(supplier, shop, stableId);
                 bool meetingReady = SupplierMeetingRuntime.EnsureSelected(supplier);
+                bool meetingDialogueReady =
+                    SupplierMeetingRuntime.PrepareNativeStartDialogue(supplier);
                 SupplierStashRuntime.SchedulePlacement(supplier);
 
                 return shop != null
                        && vehicleReady
                        && supplier.Stash?.Storage != null
-                       && meetingReady;
+                       && meetingReady
+                       && meetingDialogueReady;
             }
             catch (Exception ex)
             {
@@ -144,6 +147,24 @@ namespace S1API.Internal.Entities
             catch (Exception ex)
             {
                 Logger.Warning($"Failed to restore delivery availability for supplier '{supplier.ID}': {ex.Message}");
+            }
+        }
+
+        internal static void ReconcileMeetingDialogue(
+            S1Economy.Supplier supplier,
+            bool visible)
+        {
+            if (supplier == null)
+                return;
+
+            bool active = SupplierMeetingDialoguePolicy.ShouldActivate(
+                visible,
+                supplier.Status == S1Economy.Supplier.ESupplierStatus.Meeting);
+            if (!SupplierMeetingRuntime.SetDialogueActive(supplier, active)
+                && active)
+            {
+                Logger.Warning(
+                    $"Supplier '{supplier.ID}' entered a meeting without a bound shop dialogue choice.");
             }
         }
 

--- a/S1API/Internal/Entities/Suppliers/SupplierMeetingDialoguePolicy.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierMeetingDialoguePolicy.cs
@@ -1,0 +1,39 @@
+namespace S1API.Internal.Entities.Suppliers
+{
+    /// <summary>
+    /// Computes the dialogue indexes that the native Supplier.Start method appends.
+    /// </summary>
+    internal static class SupplierMeetingDialoguePolicy
+    {
+        internal static SupplierMeetingDialogueBindings ForNativeStart(
+            int existingGreetingCount,
+            int existingChoiceCount)
+        {
+            return new SupplierMeetingDialogueBindings(
+                existingGreetingCount,
+                existingChoiceCount);
+        }
+
+        internal static bool ShouldActivate(
+            bool visible,
+            bool isMeeting)
+        {
+            return visible && isMeeting;
+        }
+    }
+
+    internal readonly struct SupplierMeetingDialogueBindings
+    {
+        internal SupplierMeetingDialogueBindings(
+            int greetingOverrideIndex,
+            int choiceIndex)
+        {
+            GreetingOverrideIndex = greetingOverrideIndex;
+            ChoiceIndex = choiceIndex;
+        }
+
+        internal int GreetingOverrideIndex { get; }
+
+        internal int ChoiceIndex { get; }
+    }
+}

--- a/S1API/Internal/Entities/Suppliers/SupplierMeetingRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierMeetingRuntime.cs
@@ -1,8 +1,10 @@
 #if IL2CPPMELON
+using S1Dialogue = Il2CppScheduleOne.Dialogue;
 using S1Economy = Il2CppScheduleOne.Economy;
 using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1Schedules = Il2CppScheduleOne.NPCs.Schedules;
 #elif MONOMELON
+using S1Dialogue = ScheduleOne.Dialogue;
 using S1Economy = ScheduleOne.Economy;
 using S1NPCs = ScheduleOne.NPCs;
 using S1Schedules = ScheduleOne.NPCs.Schedules;
@@ -120,6 +122,84 @@ namespace S1API.Internal.Entities.Suppliers
             }
 
             return false;
+        }
+
+        internal static bool PrepareNativeStartDialogue(S1Economy.Supplier supplier)
+        {
+            S1Schedules.NPCEvent_LocationDialogue? reserved =
+                FindReservedAction(supplier);
+            S1Dialogue.DialogueController? controller =
+                supplier.DialogueHandler
+                    ?.GetComponent<S1Dialogue.DialogueController>();
+            if (reserved == null
+                || controller?.GreetingOverrides == null
+                || controller.Choices == null)
+            {
+                return false;
+            }
+
+            SupplierMeetingDialogueBindings bindings =
+                SupplierMeetingDialoguePolicy.ForNativeStart(
+                    controller.GreetingOverrides.Count,
+                    controller.Choices.Count);
+
+            // Content prefabs such as BaseEmployee can contribute active dialogue
+            // entries before they are converted to suppliers. Native Supplier.Start
+            // appends its meeting entries, so preserve the inherited data but leave it
+            // inactive while the supplier meeting action owns the interaction.
+            for (int i = 0; i < controller.GreetingOverrides.Count; i++)
+                controller.GreetingOverrides[i].ShouldShow = false;
+
+            for (int i = 0; i < controller.Choices.Count; i++)
+                controller.Choices[i].Enabled = false;
+
+            reserved.GreetingOverrideToEnable =
+                bindings.GreetingOverrideIndex;
+            reserved.ChoiceToEnable = bindings.ChoiceIndex;
+            return true;
+        }
+
+        internal static bool SetDialogueActive(
+            S1Economy.Supplier supplier,
+            bool active)
+        {
+            S1Schedules.NPCEvent_LocationDialogue? reserved =
+                FindReservedAction(supplier);
+            S1Dialogue.DialogueController? controller =
+                supplier.DialogueHandler
+                    ?.GetComponent<S1Dialogue.DialogueController>();
+            if (reserved == null
+                || controller?.GreetingOverrides == null
+                || controller.Choices == null
+                || reserved.GreetingOverrideToEnable < 0
+                || reserved.GreetingOverrideToEnable
+                    >= controller.GreetingOverrides.Count
+                || reserved.ChoiceToEnable < 0
+                || reserved.ChoiceToEnable >= controller.Choices.Count)
+            {
+                return false;
+            }
+
+            controller.GreetingOverrides[
+                reserved.GreetingOverrideToEnable].ShouldShow = active;
+            controller.Choices[
+                reserved.ChoiceToEnable].Enabled = active;
+            return true;
+        }
+
+        private static S1Schedules.NPCEvent_LocationDialogue?
+            FindReservedAction(S1Economy.Supplier supplier)
+        {
+            S1NPCs.NPCScheduleManager? manager =
+                supplier.Behaviour?.ScheduleManager
+                ?? supplier.GetComponentInChildren<S1NPCs.NPCScheduleManager>(
+                    true);
+            return manager
+                ?.GetComponentsInChildren<S1Schedules.NPCEvent_LocationDialogue>(
+                    true)
+                .FirstOrDefault(
+                    action => action != null
+                              && action.gameObject.name == MeetingActionName);
         }
     }
 }

--- a/S1API/Internal/Entities/Suppliers/SupplierShopRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierShopRuntime.cs
@@ -125,8 +125,10 @@ namespace S1API.Internal.Entities.Suppliers
             var listings = new ShopListingList();
             if (config != null)
             {
-                for (int i = 0; i < config.DeliveryItems.Count; i++)
-                    listings.Add(CreateListing(config.DeliveryItems[i]));
+                IReadOnlyList<S1Items.StorableItemDefinition> deliveryItems =
+                    config.ResolveDeliveryItems();
+                for (int i = 0; i < deliveryItems.Count; i++)
+                    listings.Add(CreateListing(deliveryItems[i]));
                 return listings;
             }
 

--- a/S1API/Internal/Lifecycle/SceneStateCleaner.cs
+++ b/S1API/Internal/Lifecycle/SceneStateCleaner.cs
@@ -71,6 +71,7 @@ namespace S1API.Internal.Lifecycle
                         }
                     }
                     NPC.All.Clear();
+                    NPC.FinalizedCustomNpcTypes.Clear();
                     NPCPatches.CustomNpcsReady = false; // Reset flag for next scene load
                     
                     QuestManager.Quests.Clear();

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -580,7 +580,6 @@ namespace S1API.Internal.Patches
 
             // We instantiated all custom NPCs up front; clear pending list to avoid duplicate fallback instantiation.
             _pendingCustomNpcTypes.Clear();
-            CustomNpcsReady = true;
         }
 
         /// <summary>
@@ -934,7 +933,8 @@ namespace S1API.Internal.Patches
                 // We use a coroutine to delay until after the NPC is fully spawned/initialized
                 if (!InstanceFinder.IsServer)
                 {
-                    MelonCoroutines.Start(SetClientVisibilityDelayed(__instance, apiNpc.IsPhysical));
+                    MelonCoroutines.Start(
+                        SetClientVisibilityDelayed(__instance, apiNpc));
                 }
             }
 
@@ -967,7 +967,9 @@ namespace S1API.Internal.Patches
         /// <summary>
         /// Coroutine to set NPC visibility on clients after a delay to ensure the NPC is fully spawned/initialized.
         /// </summary>
-        private static IEnumerator SetClientVisibilityDelayed(S1NPCs.NPC npc, bool isPhysical)
+        private static IEnumerator SetClientVisibilityDelayed(
+            S1NPCs.NPC npc,
+            NPC apiNpc)
         {
             // Wait a frame to ensure the NPC is fully initialized and spawned
             yield return null;
@@ -980,7 +982,9 @@ namespace S1API.Internal.Patches
                 if (npc != null && npc.gameObject != null)
                 {
                     // Set visibility directly on clients (not networked since we're a client)
-                    npc.SetVisible(isPhysical, networked: false);
+                    npc.SetVisible(
+                        apiNpc.ShouldBeVisibleAfterSpawn(),
+                        networked: false);
                 }
             }
             catch (Exception ex)
@@ -1341,6 +1345,14 @@ namespace S1API.Internal.Patches
                             Logger.Warning($"[S1API] NPCLoader_Load_Prefix: RelationData is null when trying to apply defaults for '{baseData.ID}'");
                         }
                     }
+
+                    // NPC.Load restores the prefab's saved visibility. Native suppliers do
+                    // not use that value as an idle-world presence: they remain hidden
+                    // until MeetAtLocation transitions them into Meeting. Reconcile after
+                    // hydration so custom suppliers follow the same lifecycle.
+                    s1BaseNpc.SetVisible(
+                        wrap.ShouldBeVisibleAfterSpawn(),
+                        networked: false);
                 }
                 else
                 {
@@ -1855,7 +1867,6 @@ namespace S1API.Internal.Patches
                 Logger.Warning($"[S1API] NPCLoader_Load_Postfix: Exception marking NPC '{baseData.ID}' as loaded: {ex.Message}");
             }
 
-            CustomNpcsReady = true;
         }
 
         /// <summary>

--- a/S1API/Internal/Patches/SupplierRuntimePatches.cs
+++ b/S1API/Internal/Patches/SupplierRuntimePatches.cs
@@ -123,6 +123,28 @@ namespace S1API.Internal.Patches
             return !SupplierRuntimeCoordinator.TryInitializeGeneratedStash(__instance);
         }
 
+        [HarmonyPatch(
+            typeof(S1NPCs.NPC),
+            nameof(S1NPCs.NPC.SetVisible),
+            new[] { typeof(bool), typeof(bool) })]
+        [HarmonyPostfix]
+        private static void NpcSetVisiblePostfix(
+            S1NPCs.NPC __instance,
+            bool __0)
+        {
+            if (!NPCPatches.IsS1ApiCustomNpcComponent(__instance)
+                || !CrossType.Is(
+                    __instance,
+                    out S1Economy.Supplier supplier))
+            {
+                return;
+            }
+
+            SupplierRuntimeCoordinator.ReconcileMeetingDialogue(
+                supplier,
+                __0);
+        }
+
         [HarmonyPatch(typeof(S1Loaders.NPCLoader), nameof(S1Loaders.NPCLoader.Load))]
         [HarmonyPostfix]
         private static void NpcLoaderLoadPostfix(S1Datas.DynamicSaveData saveData)

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -9,7 +9,7 @@ using S1API.Internal.Products;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.7", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.8", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.0-beta.7</Version>
+        <Version>3.1.0-beta.8</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">

--- a/S1API/Stations/ChemistryStationRecipe.cs
+++ b/S1API/Stations/ChemistryStationRecipe.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 namespace S1API.Stations
 {
     /// <summary>
-    /// Read-only wrapper for a Chemistry Station recipe (<c>StationRecipe</c>).
+    /// Wrapper for a Chemistry Station recipe (<c>StationRecipe</c>).
     /// </summary>
     public sealed class ChemistryStationRecipe
     {
@@ -85,6 +85,31 @@ namespace S1API.Stations
         /// Calculation method used when determining resulting product's quality.
         /// </summary>
         public QualityCalculationMethod QualityCalculationMethod { get; }
+
+        /// <summary>
+        /// Whether the recipe is currently discovered and visible to the player.
+        /// </summary>
+        public bool IsDiscovered => S1StationRecipe.IsDiscovered;
+
+        /// <summary>
+        /// Whether the recipe is currently unlocked for use.
+        /// </summary>
+        public bool IsUnlocked => S1StationRecipe.Unlocked;
+
+        /// <summary>
+        /// Changes the local recipe discovery and unlock state.
+        /// </summary>
+        /// <param name="isDiscovered">Whether the recipe is visible to the player.</param>
+        /// <param name="isUnlocked">Whether the recipe can be selected and started.</param>
+        /// <remarks>
+        /// Custom recipes are registered independently on every peer. Mods should apply
+        /// progression-driven availability on each peer after its saved state has loaded.
+        /// </remarks>
+        public void SetAvailability(bool isDiscovered, bool isUnlocked)
+        {
+            S1StationRecipe.IsDiscovered = isDiscovered;
+            S1StationRecipe.Unlocked = isUnlocked;
+        }
 
         /// <summary>
         /// Returns the native product item definition.

--- a/S1API/Stations/ChemistryStationRecipeBuilder.cs
+++ b/S1API/Stations/ChemistryStationRecipeBuilder.cs
@@ -27,6 +27,8 @@ namespace S1API.Stations
         private float _cookTemperature = 250f;
         private float _cookTemperatureTolerance = 25f;
         private Color _finalLiquidColor = Color.white;
+        private bool _initiallyDiscovered = true;
+        private bool _initiallyUnlocked = true;
 
         private string? _productItemId;
         private int _productQuantity = 1;
@@ -81,6 +83,26 @@ namespace S1API.Stations
         public ChemistryStationRecipeBuilder WithFinalLiquidColor(Color color)
         {
             _finalLiquidColor = color;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether the recipe is discovered and unlocked when it is first registered.
+        /// </summary>
+        /// <param name="isDiscovered">Whether the recipe is visible to the player.</param>
+        /// <param name="isUnlocked">Whether the recipe can be selected and started.</param>
+        /// <returns>This builder for method chaining.</returns>
+        /// <remarks>
+        /// Both values default to <see langword="true"/> to preserve the behavior of
+        /// recipes created before availability control was added. Use
+        /// <see cref="ChemistryStationRecipe.SetAvailability"/> to change the state later.
+        /// </remarks>
+        public ChemistryStationRecipeBuilder WithInitialAvailability(
+            bool isDiscovered,
+            bool isUnlocked)
+        {
+            _initiallyDiscovered = isDiscovered;
+            _initiallyUnlocked = isUnlocked;
             return this;
         }
 
@@ -218,8 +240,8 @@ namespace S1API.Stations
                 throw new InvalidOperationException("WithProduct(...) must be called before BuildInternal().");
 
             var recipe = ScriptableObject.CreateInstance<S1StationFramework.StationRecipe>();
-            recipe.IsDiscovered = true;
-            recipe.Unlocked = true;
+            recipe.IsDiscovered = _initiallyDiscovered;
+            recipe.Unlocked = _initiallyUnlocked;
             recipe.RecipeTitle = string.IsNullOrWhiteSpace(_title) ? _productItemId! : _title!;
             recipe.CookTime_Mins = _cookTimeMinutes;
             recipe.CookTemperature = _cookTemperature;

--- a/S1API/docs/stations.md
+++ b/S1API/docs/stations.md
@@ -12,6 +12,10 @@ Important notes:
 - If `WithRecipeId(...)` is omitted, the existing `"{qty}x{productId}"` ID is preserved exactly.
 - Recipe IDs are matched case-insensitively. If another recipe with the same ID is already registered, S1API will **warn + skip** (first registration wins).
 - Ingredient items must exist and have a valid `StationItem` (the builder throws if not).
+- Recipes are discovered and unlocked by default for compatibility. Use
+  `WithInitialAvailability(false, false)` for progression-controlled recipes,
+  then call `SetAvailability(...)` on the returned recipe after loading the
+  mod's progression state on each peer.
 - Recommended timing: register recipes during `GameLifecycle.OnPreLoad` (late registration is supported; it will appear the next time the Chemistry Station UI is opened).
 
 ### Example (recommended timing)
@@ -48,6 +52,32 @@ public class MyMod : MelonMod
     }
 }
 ```
+
+### Progression-controlled recipes
+
+Keep the returned wrapper when a recipe should appear after a rank, quest, or
+other saved milestone:
+
+```csharp
+ChemistryStationRecipe recipe =
+    ChemistryStationRecipes.CreateAndRegister(b => b
+        .WithRecipeId("my-mod:late-game-reaction")
+        .WithInitialAvailability(
+            isDiscovered: false,
+            isUnlocked: false)
+        .WithTitle("Late-game Reaction")
+        .WithProduct("mymod_output", quantity: 1)
+        .WithIngredient("mymod_precursor", quantity: 1));
+
+// Reapply this on every peer after the relevant progression state loads.
+recipe.SetAvailability(
+    isDiscovered: progression.ReactionKnown,
+    isUnlocked: progression.ReactionKnown);
+```
+
+`IsDiscovered` and `IsUnlocked` report the live local state. S1API does not
+invent persistence or networking for a mod's progression rule; the owning mod
+reapplies its saved decision on each peer.
 
 ### Alternate recipes for the same product
 

--- a/S1API/docs/supplier-system.md
+++ b/S1API/docs/supplier-system.md
@@ -36,11 +36,19 @@ public sealed class WarehouseSupplier : NPC
 
 `WithSupplierDefaults(...)` calls `EnsureSupplier()` for you. Call `EnsureSupplier()` directly only when you want the supplier role with default data.
 
-The item ID passed to `WithDeliveryItem(...)` must already resolve to a registered, storable item when prefab configuration runs. You can also pass an `ItemDefinition`, a `StorableItemDefinition`, or multiple item wrappers with `WithDeliveryItems(...)`.
+The string overload of `WithDeliveryItem(...)` is declaration-order safe: S1API
+stores the stable ID during NPC prefab discovery and resolves it when supplier
+runtime data is materialized. This lets an NPC assembly be discovered before its
+mod registers custom items during pre-load. The resolved item must still be
+storable to appear in the supplier shop. You can also pass an already registered
+`ItemDefinition`, a `StorableItemDefinition`, or multiple item wrappers with
+`WithDeliveryItems(...)`.
 
 ## Configuration Rules
 
-- A supplier must return `true` from `IsPhysical`. Supplier infrastructure needs a world position, schedule, stash, shop, and delivery vehicle.
+- A supplier must return `true` from `IsPhysical`. Supplier infrastructure needs
+  a world position, its reserved meeting action, stash, shop, and delivery
+  vehicle.
 - A custom NPC cannot be both a supplier and a dealer. Choose one native root role per NPC type.
 - `WithOrderLimits(minimum, maximum)` requires finite values, `minimum >= 0`, `maximum > 0`, and `maximum >= minimum`.
 - Every delivery listing must reference a storable item. Register custom items before S1API configures the NPC prefab.
@@ -48,6 +56,11 @@ The item ID passed to `WithDeliveryItem(...)` must already resolve to a register
 - Configure supplier defaults in `ConfigurePrefab`, not in `OnCreated`. This keeps host, client, and saved-game prefab data consistent.
 
 S1API creates the native meeting action and supplier-owned stash, shop, and delivery vehicle behind the public API. Do not copy or assign native supplier scene objects yourself.
+
+Do not add an ordinary roaming schedule merely to make a supplier physical.
+Native suppliers remain hidden while idle. When the player requests a meeting,
+the game activates the reserved location-dialogue action, warps the supplier to
+the selected supplier stand point, and makes them visible until the meeting ends.
 
 ## Runtime Access
 


### PR DESCRIPTION
## Summary

- add opt-in Chemistry Station recipe discovery and unlock controls
- complete custom supplier lifecycle, visibility, deferred item resolution, and meeting dialogue behavior
- bump S1API to 3.1.0-beta.8

## Compatibility

- existing recipes remain discovered and unlocked by default
- existing public signatures, stable IDs, save formats, and network payloads remain unchanged
- supplier item IDs can now be declared before item registration

## Validation

- 323 Mono tests passed
- 16 focused IL2CPP recipe and supplier tests passed
- Mono and IL2CPP builds completed with zero warnings and errors
- public API documentation coverage: 81.54% (minimum 80%)