### PR TITLE
ci: enforce public API compatibility

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- Explain the modder-facing outcome and the native/runtime seam used. -->
+
+## Compatibility
+
+<!--
+Inventory changed public/protected symbols and durable IDs.
+State the source, binary, behavioral, save, and network compatibility impact.
+If nothing changes, say so explicitly.
+-->
+
+- Public/protected API:
+- Existing defaults and behavior:
+- Stable IDs, saves, and network payloads:
+
+## Validation
+
+### Mono
+
+<!-- Build, tests, and any in-game scenario exercised. -->
+
+### IL2CPP
+
+<!-- Build, tests, and any in-game scenario exercised. -->
+
+### Runtime evidence
+
+<!--
+Required when behavior depends on Unity lifecycle, save/load, networking, UI,
+rendering, or native interaction. Keep smoke mods and generated evidence local.
+-->
+
+## Documentation
+
+<!-- List XML, DocFX, sample, or migration documentation changed. -->

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
 
       # Determine which assembly branch to use (beta or main) - MUST run before cache
       - name: Determine Assembly Branch
@@ -254,6 +256,15 @@ jobs:
       - name: Build S1API
         run: dotnet build S1API/S1API.csproj --no-restore -c MonoMelon -v normal
 
+      - name: Run Mono contract and compatibility tests
+        run: >-
+          dotnet test
+          S1API.Tests/S1API.Tests.csproj
+          --no-restore
+          --configuration MonoMelon
+          --verbosity normal
+          --property:AutomateLocalDeployment=false
+
       - name: Upload S1API Mono Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -276,6 +287,44 @@ jobs:
           --
           --api-directory S1API/api
           --minimum 80
+
+      - name: Preserve pull request API assembly
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p "$RUNNER_TEMP/s1api-api-compat"
+          cp \
+            S1API/bin/MonoMelon/netstandard2.1/S1API.dll \
+            "$RUNNER_TEMP/s1api-api-compat/current.dll"
+
+      - name: Build target branch API baseline
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git checkout --detach --force "$BASE_SHA"
+          dotnet restore S1API/S1API.csproj -p:Configuration=MonoMelon
+          dotnet build \
+            S1API/S1API.csproj \
+            --no-restore \
+            --configuration MonoMelon \
+            --verbosity minimal \
+            --property:AutomateLocalDeployment=false
+          cp \
+            S1API/bin/MonoMelon/netstandard2.1/S1API.dll \
+            "$RUNNER_TEMP/s1api-api-compat/baseline.dll"
+
+      - name: Check public API compatibility
+        if: github.event_name == 'pull_request'
+        run: |
+          dotnet tool install \
+            Microsoft.DotNet.ApiCompat.Tool \
+            --tool-path "$RUNNER_TEMP/apicompat" \
+            --version 8.0.423
+          "$RUNNER_TEMP/apicompat/apicompat" \
+            --left "$RUNNER_TEMP/s1api-api-compat/baseline.dll" \
+            --right "$RUNNER_TEMP/s1api-api-compat/current.dll" \
+            --enable-rule-cannot-change-parameter-name \
+            --enable-rule-attributes-must-match
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -323,14 +323,28 @@ jobs:
           cp \
             S1API/bin/MonoMelon/netstandard2.1/S1API.dll \
             "$RUNNER_TEMP/s1api-api-compat/baseline.dll"
+          git checkout --detach --force "$GITHUB_SHA"
+
+      - name: Restore ApiCompat tool cache
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/apicompat
+          key: apicompat-${{ runner.os }}-${{ runner.arch }}-10.0.302
+
+      - name: Install ApiCompat
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ ! -x "$RUNNER_TEMP/apicompat/apicompat" ]; then
+            dotnet tool install \
+              Microsoft.DotNet.ApiCompat.Tool \
+              --tool-path "$RUNNER_TEMP/apicompat" \
+              --version 10.0.302
+          fi
 
       - name: Check public API compatibility
         if: github.event_name == 'pull_request'
         run: |
-          dotnet tool install \
-            Microsoft.DotNet.ApiCompat.Tool \
-            --tool-path "$RUNNER_TEMP/apicompat" \
-            --version 10.0.302
           "$RUNNER_TEMP/apicompat/apicompat" \
             --left "$RUNNER_TEMP/s1api-api-compat/baseline.dll" \
             --right "$RUNNER_TEMP/s1api-api-compat/current.dll" \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,8 @@ jobs:
 
       # Try to restore assemblies from cache first (for external PRs)
       # Cache key includes assembly branch to separate beta from main
-      # v3 suffix allows cache invalidation by bumping version
+      # v4 includes Unity.Burst.dll, which the Mono test host needs while
+      # reflecting native test data.
       # Only use cache for PR events to avoid stale assemblies after merges
       - name: Restore Game Assemblies from Cache
         id: cache-assemblies
@@ -83,9 +84,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: S1API/ScheduleOneAssemblies
-          key: game-assemblies-v3-${{ steps.assembly-branch.outputs.branch }}-${{ hashFiles('S1API/S1API.csproj') }}
+          key: game-assemblies-v4-${{ steps.assembly-branch.outputs.branch }}-${{ hashFiles('S1API/S1API.csproj') }}
           restore-keys: |
-            game-assemblies-v3-${{ steps.assembly-branch.outputs.branch }}-
+            game-assemblies-v4-${{ steps.assembly-branch.outputs.branch }}-
 
       # Only checkout game assemblies if cache miss AND we have access to secrets
       - name: Checkout Game Assemblies
@@ -177,6 +178,15 @@ jobs:
             fi
           fi
           echo ""
+          echo "=== Burst Assembly Check ==="
+          if [ -f S1API/ScheduleOneAssemblies/Managed/Unity.Burst.dll ]; then
+            echo "✓ Found Unity.Burst.dll"
+            ls -l S1API/ScheduleOneAssemblies/Managed/Unity.Burst.dll
+          else
+            echo "✗ Missing Unity.Burst.dll"
+            exit 1
+          fi
+          echo ""
           echo "=== MelonLoader Assembly Check ==="
           if [ -f S1API/ScheduleOneAssemblies/MelonLoader/0Harmony.dll ]; then
             echo "✓ Found 0Harmony.dll"
@@ -198,10 +208,10 @@ jobs:
       # Save only verified non-empty assembly caches.
       - name: Save Game Assemblies to Cache
         uses: actions/cache/save@v4
-        if: always() && steps.cache-assemblies.outputs.cache-hit != 'true' && hashFiles('S1API/ScheduleOneAssemblies/Managed/Assembly-CSharp.dll') != '' && hashFiles('S1API/ScheduleOneAssemblies/MelonLoader/0Harmony.dll') != '' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/npc-prefabs')))
+        if: always() && steps.cache-assemblies.outputs.cache-hit != 'true' && hashFiles('S1API/ScheduleOneAssemblies/Managed/Assembly-CSharp.dll') != '' && hashFiles('S1API/ScheduleOneAssemblies/Managed/Unity.Burst.dll') != '' && hashFiles('S1API/ScheduleOneAssemblies/MelonLoader/0Harmony.dll') != '' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/npc-prefabs')))
         with:
           path: S1API/ScheduleOneAssemblies
-          key: game-assemblies-v3-${{ steps.assembly-branch.outputs.branch }}-${{ hashFiles('S1API/S1API.csproj') }}
+          key: game-assemblies-v4-${{ steps.assembly-branch.outputs.branch }}-${{ hashFiles('S1API/S1API.csproj') }}
 
       - name: Create CI Build Properties
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       # Determine which assembly branch to use (beta or main) - MUST run before cache
       - name: Determine Assembly Branch
@@ -329,7 +330,7 @@ jobs:
           dotnet tool install \
             Microsoft.DotNet.ApiCompat.Tool \
             --tool-path "$RUNNER_TEMP/apicompat" \
-            --version 8.0.423
+            --version 10.0.302
           "$RUNNER_TEMP/apicompat/apicompat" \
             --left "$RUNNER_TEMP/s1api-api-compat/baseline.dll" \
             --right "$RUNNER_TEMP/s1api-api-compat/current.dll" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ Every public API PR must include a compatibility audit against the target branch
 
 Do not disguise API changes as refactors, cleanups, consistency fixes, or nullable improvements. Before changing a surprising legacy behavior, search existing tests, docs, samples, call sites, release history, and relevant native lifecycle behavior to determine whether mods may rely on it.
 
+The required `documentation` check enforces three repository-wide gates on pull
+requests: the full Mono contract suite, at least 80% public API documentation
+coverage, and Microsoft ApiCompat against the exact target-branch assembly.
+ApiCompat also checks public parameter names and attributes. Do not suppress,
+disable, or work around these checks for convenience. If an explicitly approved
+breaking release needs an exception, make that exception narrow and reviewable
+and document the migration impact in the PR.
+
 ## Testing Guidelines
 `S1API.Tests/` contains xUnit contract and compatibility tests. Before opening a PR, restore, build, and test both `MonoMelon` and `Il2CppMelon` with matching configurations. Exercise affected gameplay flows in both runtimes when behavior depends on native lifecycle, networking, save/load, or rendered state.
 


### PR DESCRIPTION
## Summary

- Run the full Mono contract suite inside the already-required documentation job.
- Build the exact pull-request target commit and compare its public assembly with the PR assembly using Microsoft ApiCompat 10.0.302.
- Treat removed or changed public API, public parameter-name changes, and attribute changes as blocking failures.
- Add a pull request template that makes compatibility, dual-runtime validation, runtime evidence, and documentation explicit.
- Record the enforced gates in AGENTS.md for future agents.

## Compatibility

- Public/protected API: unchanged; this PR only changes repository workflow and contributor guidance.
- Existing defaults and behavior: unchanged.
- Stable IDs, saves, and network payloads: unchanged.

The comparison uses the exact target-branch assembly rather than the latest release, so APIs merged between prereleases remain protected.

## Validation

### Mono

- Local workflow test command passed: 323/323 tests.
- Hosted workflow test command passed: 323/323 tests after adding the missing Unity.Burst.dll to the private Mono build-input repository and rotating its cache.
- Workflow YAML parsed successfully.

### IL2CPP

- No runtime code changed. The existing required IL2CPP build workflow remains unchanged and continues to run independently.

### Runtime evidence

- Not applicable; this PR does not change game runtime behavior.

- ApiCompat passed a beta.7-to-beta.8 comparison locally with parameter-name and attribute rules enabled.
- The existing documentation job remains the required status, so the new tests and compatibility comparison block PRs on every target branch where that rule applies.

## Documentation

- Added the repository pull request template.
- Updated AGENTS.md with the enforced compatibility gates.