### PR TITLE
feat(products): support complete Brick Press visuals

### DIFF
--- a/S1API.Tests/Products/ProductPackagingContentApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentApiCompatibilityTests.cs
@@ -25,6 +25,24 @@ public sealed class ProductPackagingContentApiCompatibilityTests
             typeof(ProductPackagingContentProfileBuilder).GetMethod(
                 nameof(ProductPackagingContentProfileBuilder.AddPlacements),
                 new[] { typeof(ProductPresentationTransform[]) })!;
+        System.Reflection.MethodInfo withCompleteFilledVisual =
+            typeof(ProductPackagingContentProfileBuilder).GetMethod(
+                nameof(ProductPackagingContentProfileBuilder.WithCompleteFilledVisual),
+                new[]
+                {
+                    typeof(Func<GameObject>),
+                    typeof(ProductPresentationTransform)
+                })!;
+        System.Reflection.MethodInfo withNativeFilledVisualScaffold =
+            typeof(ProductPackagingContentProfileBuilder).GetMethod(
+                nameof(ProductPackagingContentProfileBuilder
+                    .WithNativeFilledVisualScaffold),
+                new[]
+                {
+                    typeof(ProductPackagingVisualTemplate),
+                    typeof(Action<GameObject>),
+                    typeof(ProductPresentationTransform)
+                })!;
         System.Reflection.MethodInfo register =
             typeof(ProductPackagingContentProfileRegistry).GetMethod(
                 nameof(ProductPackagingContentProfileRegistry.Register),
@@ -39,10 +57,28 @@ public sealed class ProductPackagingContentApiCompatibilityTests
         Assert.NotNull(withContent);
         Assert.NotNull(addPlacement);
         Assert.NotNull(addPlacements);
+        Assert.NotNull(withCompleteFilledVisual);
+        Assert.NotNull(withNativeFilledVisualScaffold);
         Assert.NotNull(register);
         Assert.Equal(typeof(ProductPackagingContentProfileBuilder), withContent.ReturnType);
         Assert.Equal(typeof(ProductPackagingContentProfileBuilder), addPlacement.ReturnType);
         Assert.Equal(typeof(ProductPackagingContentProfileBuilder), addPlacements.ReturnType);
+        Assert.Equal(
+            typeof(ProductPackagingContentProfileBuilder),
+            withCompleteFilledVisual.ReturnType);
+        Assert.Equal(
+            typeof(ProductPackagingContentProfileBuilder),
+            withNativeFilledVisualScaffold.ReturnType);
         Assert.Equal(typeof(ProductPackagingContentProfile), register.ReturnType);
+
+        Assert.Equal(
+            new[]
+            {
+                ProductPackagingVisualTemplate.Marijuana,
+                ProductPackagingVisualTemplate.Methamphetamine,
+                ProductPackagingVisualTemplate.Cocaine,
+                ProductPackagingVisualTemplate.Shrooms
+            },
+            Enum.GetValues<ProductPackagingVisualTemplate>());
     }
 }

--- a/S1API.Tests/Products/ProductPackagingContentApiCompileFixture.cs
+++ b/S1API.Tests/Products/ProductPackagingContentApiCompileFixture.cs
@@ -23,4 +23,31 @@ internal static class ProductPackagingContentApiCompileFixture
             packagingId: "baggie",
             profile: profile);
     }
+
+    internal static ProductPackagingContentProfile CompileCompleteFilledVisualCaller(
+        GameObject completeVisualPrefab,
+        ProductPresentationTransform transform)
+    {
+        return new ProductPackagingContentProfileBuilder()
+            .WithCompleteFilledVisual(
+                provider: () => completeVisualPrefab,
+                transform: transform)
+            .Build();
+    }
+
+    internal static ProductPackagingContentProfile CompileNativeScaffoldCaller(
+        Material modOwnedMaterial)
+    {
+        return new ProductPackagingContentProfileBuilder()
+            .WithNativeFilledVisualScaffold(
+                template: ProductPackagingVisualTemplate.Marijuana,
+                customize: clone =>
+                {
+                    Renderer[] renderers =
+                        clone.GetComponentsInChildren<Renderer>(true);
+                    for (int i = 0; i < renderers.Length; i++)
+                        renderers[i].sharedMaterial = modOwnedMaterial;
+                })
+            .Build();
+    }
 }

--- a/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
@@ -1,4 +1,11 @@
+#if IL2CPPMELON
+using NativeProductDefinition = Il2CppScheduleOne.Product.ProductDefinition;
+#elif MONOMELON
+using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
+#endif
+
 using System;
+using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using S1API.Products;
 using Xunit;
@@ -8,7 +15,19 @@ namespace S1API.Tests.Products;
 [Collection(CustomProductRegistryCollection.Name)]
 public sealed class ProductPackagingContentFallbackTests : IDisposable
 {
-    public void Dispose() => ProductPackagingContentProfileRegistry.ResetForTesting();
+    private readonly FakeProductRuntime _runtime = new();
+
+    public ProductPackagingContentFallbackTests()
+    {
+        ProductPackagingContentProfileRegistry.ResetForTesting();
+        CustomProductDefinitionRegistry.ResetForTesting(_runtime);
+    }
+
+    public void Dispose()
+    {
+        ProductPackagingContentProfileRegistry.ResetForTesting();
+        CustomProductDefinitionRegistry.RestoreRuntimeAdapterForTesting();
+    }
 
     [Fact]
     public void LogicalKindFallbackResolvesForDynamicallyAllocatedGeneratedMixes()
@@ -24,5 +43,66 @@ public sealed class ProductPackagingContentFallbackTests : IDisposable
         Assert.True(ProductPackagingContentProfileRegistry.TryResolveForProductKind(
             kindId, "baggie", out ProductPackagingContentProfileRegistration? resolved));
         Assert.Same(profile, resolved!.Profile);
+    }
+
+    [Fact]
+    public void ProductSpecificBrickProfilePrecedesLogicalKindFallback()
+    {
+        string productId = "s1api-tests:brick-" + Guid.NewGuid().ToString("N");
+        ProductKind kind =
+            new ProductKindBuilder(
+                    "s1api-tests:brick-kind-" + Guid.NewGuid().ToString("N"))
+                .WithCompatibilityDrugType(DrugType.MDMA)
+                .Build();
+        ProductPackagingContentProfile kindProfile =
+            new ProductPackagingContentProfileBuilder()
+                .WithCompleteFilledVisual(() => null)
+                .Build();
+        ProductPackagingContentProfile productProfile =
+            new ProductPackagingContentProfileBuilder()
+                .WithNativeFilledVisualScaffold(
+                    ProductPackagingVisualTemplate.Marijuana)
+                .Build();
+
+        CustomProductDefinitionRegistry.Register(
+            "s1api-tests",
+            productId,
+            "Brick Product",
+            10f,
+            CreateDefinition(),
+            new CustomProductDefinitionMetadata(kind, Quality.Standard));
+        ProductPackagingContentProfileRegistry.RegisterForProductKind(
+            "s1api-tests",
+            kind.Id,
+            "brick",
+            kindProfile);
+        ProductPackagingContentProfileRegistry.Register(
+            "s1api-tests",
+            productId,
+            "brick",
+            productProfile);
+
+        Assert.True(
+            ProductPackagingContentProfileRegistry.TryResolve(
+                productId,
+                "brick",
+                out ProductPackagingContentProfileRegistration? resolved));
+        Assert.Same(productProfile, resolved!.Profile);
+    }
+
+    private static NativeProductDefinition CreateDefinition()
+    {
+        var definition =
+            (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
+                typeof(NativeProductDefinition));
+        GC.SuppressFinalize(definition);
+        return definition;
+    }
+
+    private sealed class FakeProductRuntime :
+        ICustomProductDefinitionRuntimeAdapter
+    {
+        public bool Apply(CustomProductDefinitionRegistration registration) =>
+            true;
     }
 }

--- a/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
@@ -37,6 +37,122 @@ public sealed class ProductPackagingContentProfileTests
 
         Assert.Same(provider, profile.ContentProvider);
         Assert.Empty(profile.Placements);
+        Assert.Equal(
+            ProductPackagingContentSource.RepeatedContent,
+            profile.Source);
+        Assert.Null(profile.CompleteVisualTransform);
+        Assert.Null(profile.NativeVisualTemplate);
+        Assert.Null(profile.NativeVisualCustomizer);
+    }
+
+    [Fact]
+    public void CompleteFilledVisualSnapshotsItsProviderAndTransform()
+    {
+        Func<GameObject?> provider = () => null;
+        ProductPresentationTransform transform =
+            CreatePlacementWithoutUnityRuntime();
+
+        ProductPackagingContentProfile profile =
+            new ProductPackagingContentProfileBuilder()
+                .WithCompleteFilledVisual(provider, transform)
+                .Build();
+
+        Assert.Equal(
+            ProductPackagingContentSource.CompleteFilledVisual,
+            profile.Source);
+        Assert.Same(provider, profile.ContentProvider);
+        Assert.Same(transform, profile.CompleteVisualTransform);
+        Assert.Empty(profile.Placements);
+        Assert.Null(profile.NativeVisualTemplate);
+        Assert.Null(profile.NativeVisualCustomizer);
+    }
+
+    [Fact]
+    public void NullCompleteFilledVisualProviderIsRejected()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .WithCompleteFilledVisual(null!));
+    }
+
+    [Fact]
+    public void NativeFilledVisualScaffoldSnapshotsTemplateCustomizerAndTransform()
+    {
+        Action<GameObject> customize = _ => { };
+        ProductPresentationTransform transform =
+            CreatePlacementWithoutUnityRuntime();
+
+        ProductPackagingContentProfile profile =
+            new ProductPackagingContentProfileBuilder()
+                .WithNativeFilledVisualScaffold(
+                    ProductPackagingVisualTemplate.Marijuana,
+                    customize,
+                    transform)
+                .Build();
+
+        Assert.Equal(
+            ProductPackagingContentSource.NativeFilledVisualScaffold,
+            profile.Source);
+        Assert.Null(profile.ContentProvider);
+        Assert.Same(transform, profile.CompleteVisualTransform);
+        Assert.Equal(
+            ProductPackagingVisualTemplate.Marijuana,
+            profile.NativeVisualTemplate);
+        Assert.Same(customize, profile.NativeVisualCustomizer);
+        Assert.Empty(profile.Placements);
+    }
+
+    [Fact]
+    public void UndefinedNativeFilledVisualTemplateIsRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () =>
+                new ProductPackagingContentProfileBuilder()
+                    .WithNativeFilledVisualScaffold(
+                        (ProductPackagingVisualTemplate)int.MaxValue));
+    }
+
+    [Fact]
+    public void CompleteFilledVisualCannotRepeatContentPlacements()
+    {
+        ProductPackagingContentProfileBuilder builder =
+            new ProductPackagingContentProfileBuilder()
+                .WithCompleteFilledVisual(() => null)
+                .AddPlacement(CreatePlacementWithoutUnityRuntime());
+
+        InvalidOperationException exception =
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.Contains("placements", exception.Message);
+        Assert.Contains("complete filled visual", exception.Message);
+    }
+
+    [Fact]
+    public void BuilderCanReturnToLegacyRepeatedContentAfterSelectingScaffold()
+    {
+        Func<GameObject?> provider = () => null;
+        ProductPresentationTransform placement =
+            CreatePlacementWithoutUnityRuntime();
+        ProductPackagingContentProfileBuilder builder =
+            new ProductPackagingContentProfileBuilder()
+                .AddPlacement(placement)
+                .WithNativeFilledVisualScaffold(
+                    ProductPackagingVisualTemplate.Cocaine);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        ProductPackagingContentProfile legacy =
+            builder.WithContent(provider).Build();
+
+        Assert.Equal(
+            ProductPackagingContentSource.RepeatedContent,
+            legacy.Source);
+        Assert.Same(provider, legacy.ContentProvider);
+        Assert.Equal(new[] { placement }, legacy.Placements);
+        Assert.Null(legacy.CompleteVisualTransform);
+        Assert.Null(legacy.NativeVisualTemplate);
+        Assert.Null(legacy.NativeVisualCustomizer);
     }
 
     [Fact]

--- a/S1API/Internal/Products/ProductPackagingContentRuntime.cs
+++ b/S1API/Internal/Products/ProductPackagingContentRuntime.cs
@@ -902,7 +902,9 @@ namespace S1API.Internal.Products
                 LogFailureOnce(
                     registration,
                     "native visual scaffold",
-                    "the selected template is unavailable in this packaging context");
+                    $"the selected template " +
+                    $"'{registration.Profile.NativeVisualTemplate!.Value}' is " +
+                    "unavailable in this packaging context");
                 DestroyOwnedRoot(generatedRoot);
                 return false;
             }

--- a/S1API/Internal/Products/ProductPackagingContentRuntime.cs
+++ b/S1API/Internal/Products/ProductPackagingContentRuntime.cs
@@ -102,7 +102,7 @@ namespace S1API.Internal.Products
             }
 
             if (!TryCreateContentRoot(
-                    setter.transform,
+                    setter,
                     registration,
                     expectedRootName,
                     out GameObject? generatedRoot))
@@ -373,7 +373,7 @@ namespace S1API.Internal.Products
                 }
 
                 if (!TryCreateContentRoot(
-                        setter.transform,
+                        setter,
                         registration,
                         GetGeneratedRootName(registration.Key),
                         out GameObject? generatedRoot))
@@ -790,19 +790,35 @@ namespace S1API.Internal.Products
         }
 
         private static bool TryCreateContentRoot(
-            Transform parent,
+            S1Product.MultiTypeVisualsSetter setter,
             ProductPackagingContentProfileRegistration registration,
             string rootName,
             out GameObject? generatedRoot)
         {
+            Transform parent = setter.transform;
             generatedRoot = new GameObject(rootName);
             generatedRoot.transform.SetParent(parent, false);
             generatedRoot.SetActive(false);
 
+            if (registration.Profile.Source ==
+                ProductPackagingContentSource.NativeFilledVisualScaffold)
+            {
+                if (TryCreateNativeScaffold(
+                    setter,
+                    registration,
+                    generatedRoot))
+                {
+                    return true;
+                }
+
+                generatedRoot = null;
+                return false;
+            }
+
             GameObject? source;
             try
             {
-                source = registration.Profile.ContentProvider();
+                source = registration.Profile.ContentProvider!();
             }
             catch (Exception exception)
             {
@@ -828,9 +844,24 @@ namespace S1API.Internal.Products
 
             try
             {
+                if (registration.Profile.Source ==
+                    ProductPackagingContentSource.CompleteFilledVisual)
+                {
+                    AddContentClone(
+                        source,
+                        generatedRoot.transform,
+                        registration.Profile.CompleteVisualTransform,
+                        null);
+                    return true;
+                }
+
                 if (registration.Profile.Placements.Count == 0)
                 {
-                    AddContentClone(source, generatedRoot.transform, null);
+                    AddContentClone(
+                        source,
+                        generatedRoot.transform,
+                        null,
+                        null);
                     return true;
                 }
 
@@ -839,7 +870,8 @@ namespace S1API.Internal.Products
                     AddContentClone(
                         source,
                         generatedRoot.transform,
-                        registration.Profile.Placements[i]);
+                        registration.Profile.Placements[i],
+                        null);
                 }
 
                 return true;
@@ -856,10 +888,76 @@ namespace S1API.Internal.Products
             }
         }
 
+        private static bool TryCreateNativeScaffold(
+            S1Product.MultiTypeVisualsSetter setter,
+            ProductPackagingContentProfileRegistration registration,
+            GameObject generatedRoot)
+        {
+            GameObject? source =
+                GetNativeScaffoldSource(
+                    setter,
+                    registration.Profile.NativeVisualTemplate!.Value);
+            if (source == null)
+            {
+                LogFailureOnce(
+                    registration,
+                    "native visual scaffold",
+                    "the selected template is unavailable in this packaging context");
+                DestroyOwnedRoot(generatedRoot);
+                return false;
+            }
+
+            try
+            {
+                AddContentClone(
+                    source,
+                    generatedRoot.transform,
+                    registration.Profile.CompleteVisualTransform,
+                    registration.Profile.NativeVisualCustomizer);
+                return true;
+            }
+            catch (Exception exception)
+            {
+                LogFailureOnce(
+                    registration,
+                    "native visual scaffold",
+                    exception.Message);
+                DestroyOwnedRoot(generatedRoot);
+                return false;
+            }
+        }
+
+        private static GameObject? GetNativeScaffoldSource(
+            S1Product.MultiTypeVisualsSetter setter,
+            ProductPackagingVisualTemplate template)
+        {
+            Transform? container;
+            switch (template)
+            {
+                case ProductPackagingVisualTemplate.Marijuana:
+                    container = setter.WeedVisuals?.VisualsContainer;
+                    break;
+                case ProductPackagingVisualTemplate.Methamphetamine:
+                    container = setter.MethVisuals?.VisualsContainer;
+                    break;
+                case ProductPackagingVisualTemplate.Cocaine:
+                    container = setter.CocaineVisuals?.VisualsContainer;
+                    break;
+                case ProductPackagingVisualTemplate.Shrooms:
+                    container = setter.ShroomVisuals?.VisualsContainer;
+                    break;
+                default:
+                    return null;
+            }
+
+            return container?.gameObject;
+        }
+
         private static void AddContentClone(
             GameObject source,
             Transform parent,
-            ProductPresentationTransform? placement)
+            ProductPresentationTransform? placement,
+            Action<GameObject>? customize)
         {
             Vector3 authoredPosition = source.transform.localPosition;
             Quaternion authoredRotation = source.transform.localRotation;
@@ -877,6 +975,7 @@ namespace S1API.Internal.Products
                 content.transform.localScale = authoredScale;
             }
 
+            customize?.Invoke(content);
             content.SetActive(true);
         }
 

--- a/S1API/Products/ProductPackagingContentProfile.cs
+++ b/S1API/Products/ProductPackagingContentProfile.cs
@@ -5,24 +5,49 @@ using UnityEngine;
 namespace S1API.Products
 {
     /// <summary>
-    /// Describes mod-owned product content rendered inside one packaging type.
+    /// Describes product content or a complete filled visual rendered for one packaging type.
     /// </summary>
     /// <remarks>
-    /// S1API clones the provider's object for every configured placement. The game-owned
-    /// packaging shell remains unchanged and assets are not transmitted to other peers.
+    /// Repeated-content profiles clone the provider's object for every configured placement.
+    /// Complete-filled profiles clone one mod-owned object or one runtime-resolved game-owned
+    /// visual template. Shared game-owned prefabs remain unchanged and assets are not
+    /// transmitted to other peers.
     /// </remarks>
     public sealed class ProductPackagingContentProfile
     {
         internal ProductPackagingContentProfile(
-            Func<GameObject?> contentProvider,
-            IReadOnlyList<ProductPresentationTransform> placements)
+            ProductPackagingContentSource source,
+            Func<GameObject?>? contentProvider,
+            IReadOnlyList<ProductPresentationTransform> placements,
+            ProductPresentationTransform? completeVisualTransform,
+            ProductPackagingVisualTemplate? nativeVisualTemplate,
+            Action<GameObject>? nativeVisualCustomizer)
         {
+            Source = source;
             ContentProvider = contentProvider;
             Placements = placements;
+            CompleteVisualTransform = completeVisualTransform;
+            NativeVisualTemplate = nativeVisualTemplate;
+            NativeVisualCustomizer = nativeVisualCustomizer;
         }
 
-        internal Func<GameObject?> ContentProvider { get; }
+        internal ProductPackagingContentSource Source { get; }
+
+        internal Func<GameObject?>? ContentProvider { get; }
 
         internal IReadOnlyList<ProductPresentationTransform> Placements { get; }
+
+        internal ProductPresentationTransform? CompleteVisualTransform { get; }
+
+        internal ProductPackagingVisualTemplate? NativeVisualTemplate { get; }
+
+        internal Action<GameObject>? NativeVisualCustomizer { get; }
+    }
+
+    internal enum ProductPackagingContentSource
+    {
+        RepeatedContent = 0,
+        CompleteFilledVisual = 1,
+        NativeFilledVisualScaffold = 2
     }
 }

--- a/S1API/Products/ProductPackagingContentProfileBuilder.cs
+++ b/S1API/Products/ProductPackagingContentProfileBuilder.cs
@@ -155,7 +155,8 @@ namespace S1API.Products
             {
                 throw new InvalidOperationException(
                     "Explicit content placements cannot be combined with a complete " +
-                    "filled visual. Configure its optional transform instead.");
+                    "filled visual or a native filled visual scaffold. Configure the " +
+                    "optional transform instead.");
             }
 
             return new ProductPackagingContentProfile(

--- a/S1API/Products/ProductPackagingContentProfileBuilder.cs
+++ b/S1API/Products/ProductPackagingContentProfileBuilder.cs
@@ -11,7 +11,12 @@ namespace S1API.Products
     {
         private readonly List<ProductPresentationTransform> _placements =
             new List<ProductPresentationTransform>();
+        private ProductPackagingContentSource _source =
+            ProductPackagingContentSource.RepeatedContent;
         private Func<GameObject?>? _contentProvider;
+        private ProductPresentationTransform? _completeVisualTransform;
+        private ProductPackagingVisualTemplate? _nativeVisualTemplate;
+        private Action<GameObject>? _nativeVisualCustomizer;
 
         /// <summary>
         /// Sets the reusable mod-owned content prefab source.
@@ -23,6 +28,74 @@ namespace S1API.Products
         {
             _contentProvider =
                 provider ?? throw new ArgumentNullException(nameof(provider));
+            _source = ProductPackagingContentSource.RepeatedContent;
+            _completeVisualTransform = null;
+            _nativeVisualTemplate = null;
+            _nativeVisualCustomizer = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets one complete mod-owned visual for packaging whose filled form is the product.
+        /// </summary>
+        /// <param name="provider">A provider that returns a reusable complete visual source.</param>
+        /// <param name="transform">
+        /// An optional local transform applied to the cloned visual. When omitted, S1API
+        /// preserves the transform authored by the provider.
+        /// </param>
+        /// <returns>This builder.</returns>
+        /// <remarks>
+        /// Use this for packaging such as <c>brick</c>, where the native variants represent
+        /// the complete filled item instead of repeated contents inside a shared shell.
+        /// The same strategy is applied to stored, equipped, and composite-icon contexts.
+        /// </remarks>
+        public ProductPackagingContentProfileBuilder WithCompleteFilledVisual(
+            Func<GameObject?> provider,
+            ProductPresentationTransform? transform = null)
+        {
+            _contentProvider =
+                provider ?? throw new ArgumentNullException(nameof(provider));
+            _source = ProductPackagingContentSource.CompleteFilledVisual;
+            _completeVisualTransform = transform;
+            _nativeVisualTemplate = null;
+            _nativeVisualCustomizer = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Clones one game-owned filled visual template and optionally customizes the clone.
+        /// </summary>
+        /// <param name="template">The presentation-only game-owned visual template.</param>
+        /// <param name="customize">
+        /// An optional callback that receives each newly cloned visual before it is shown.
+        /// Only the clone is passed; shared game-owned prefabs are never exposed or mutated.
+        /// </param>
+        /// <param name="transform">
+        /// An optional local transform applied to the clone. When omitted, S1API preserves
+        /// the context-specific transform authored by the game-owned template.
+        /// </param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="template"/> is not a defined value.
+        /// </exception>
+        /// <remarks>
+        /// The template controls presentation only and does not alter the custom product's
+        /// logical kind or native execution strategy. The callback should assign only
+        /// mod-owned materials or other local presentation data.
+        /// </remarks>
+        public ProductPackagingContentProfileBuilder WithNativeFilledVisualScaffold(
+            ProductPackagingVisualTemplate template,
+            Action<GameObject>? customize = null,
+            ProductPresentationTransform? transform = null)
+        {
+            if (!Enum.IsDefined(typeof(ProductPackagingVisualTemplate), template))
+                throw new ArgumentOutOfRangeException(nameof(template));
+
+            _source = ProductPackagingContentSource.NativeFilledVisualScaffold;
+            _contentProvider = null;
+            _completeVisualTransform = transform;
+            _nativeVisualTemplate = template;
+            _nativeVisualCustomizer = customize;
             return this;
         }
 
@@ -65,19 +138,33 @@ namespace S1API.Products
         /// </summary>
         /// <returns>The packaging-content profile.</returns>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when no content provider is configured.
+        /// Thrown when no visual source is configured or placements are combined with a
+        /// complete-filled strategy.
         /// </exception>
         public ProductPackagingContentProfile Build()
         {
-            if (_contentProvider == null)
+            if (_source != ProductPackagingContentSource.NativeFilledVisualScaffold &&
+                _contentProvider == null)
             {
                 throw new InvalidOperationException(
                     "A packaging content provider must be configured before Build().");
             }
 
+            if (_source != ProductPackagingContentSource.RepeatedContent &&
+                _placements.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    "Explicit content placements cannot be combined with a complete " +
+                    "filled visual. Configure its optional transform instead.");
+            }
+
             return new ProductPackagingContentProfile(
+                _source,
                 _contentProvider,
-                new List<ProductPresentationTransform>(_placements).AsReadOnly());
+                new List<ProductPresentationTransform>(_placements).AsReadOnly(),
+                _completeVisualTransform,
+                _nativeVisualTemplate,
+                _nativeVisualCustomizer);
         }
     }
 }

--- a/S1API/Products/ProductPackagingVisualTemplate.cs
+++ b/S1API/Products/ProductPackagingVisualTemplate.cs
@@ -1,0 +1,33 @@
+namespace S1API.Products
+{
+    /// <summary>
+    /// Selects a game-owned filled-product visual template to clone at runtime.
+    /// </summary>
+    /// <remarks>
+    /// This value controls presentation only. It does not change a custom product's
+    /// logical kind, compatibility drug type, save data, or network representation.
+    /// The template is resolved independently for stored, equipped, and icon contexts.
+    /// </remarks>
+    public enum ProductPackagingVisualTemplate
+    {
+        /// <summary>
+        /// Uses the marijuana-family filled visual template.
+        /// </summary>
+        Marijuana = 0,
+
+        /// <summary>
+        /// Uses the methamphetamine-family filled visual template.
+        /// </summary>
+        Methamphetamine = 1,
+
+        /// <summary>
+        /// Uses the cocaine-family filled visual template.
+        /// </summary>
+        Cocaine = 2,
+
+        /// <summary>
+        /// Uses the shroom-family filled visual template.
+        /// </summary>
+        Shrooms = 3
+    }
+}

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -352,6 +352,85 @@ into their game-owned packaging objects, so this profile intentionally does not
 replace that interaction. Custom packaging definitions, packaging asset
 networking, and extra packaging save data remain outside this API.
 
+### Complete filled visuals and Brick Press support
+
+Some packaging does not have a reusable shell with repeated contents. The
+native `brick` packaging is a complete filled product form. Register one
+complete mod-owned visual explicitly:
+
+```csharp
+var brick = ProductPopulator.GetPackaging("brick");
+if (brick == null)
+{
+    throw new InvalidOperationException(
+        "The native 'brick' packaging is unavailable during OnPreLoad.");
+}
+
+// Include brick when building the product:
+// .WithValidPackaging(baggie, brick)
+
+var pressedBrick =
+    new ProductPackagingContentProfileBuilder()
+        .WithCompleteFilledVisual(
+            provider: () => modOwnedBrickPrefab,
+            transform: new ProductPresentationTransform(
+                Vector3.zero,
+                Vector3.zero,
+                Vector3.one))
+        .Build();
+
+ProductPackagingContentProfileRegistry.Register(
+    ownerId: "example.mod",
+    productId: "example.mod:products/focus-tablet",
+    packagingId: "brick",
+    profile: pressedBrick);
+```
+
+`WithCompleteFilledVisual(...)` creates exactly one clone in each filled stored,
+equipped, and composite-icon context. The provider may return a mod-owned prefab,
+an object loaded from the mod's asset bundle, or another reusable local source.
+It must not return or modify the shared native packaging prefab.
+
+If a mod wants the native brick geometry and wrapping without extracting or
+redistributing them, it can instead select a presentation-only runtime scaffold:
+
+```csharp
+var pressedBrick =
+    new ProductPackagingContentProfileBuilder()
+        .WithNativeFilledVisualScaffold(
+            template: ProductPackagingVisualTemplate.Marijuana,
+            customize: clone =>
+            {
+                Renderer[] renderers =
+                    clone.GetComponentsInChildren<Renderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
+                    renderers[i].sharedMaterial = modOwnedBrickMaterial;
+            })
+        .Build();
+```
+
+S1API resolves and clones the selected game-owned visual independently from the
+active stored, equipped, or icon prefab, then invokes `customize` only with that
+clone. The template does not change `ProductKind`, compatibility metadata,
+native execution behavior, stable IDs, save data, or network data. Use only
+mod-owned materials or other local presentation data in the callback.
+
+The native Brick Press remains authoritative for conversion: it groups
+stack-compatible unpackaged inputs, consumes 20 units, copies one product
+instance, and applies packaging ID `brick`. S1API does not patch its batch size,
+eligibility, task flow, player path, or NPC/server path. Adding `brick` through
+`WithValidPackaging(...)` is the explicit product declaration and keeps ordinary
+packaged-instance APIs consistent; registering the `brick` presentation profile
+is the separate visual opt-in.
+
+The 20 loose objects poured into the mould still use the product's
+`ProductPresentationProfile` functional-product context. Presentation assets
+are local per peer and are never saved or transmitted. Every participating peer
+must register the same product/profile IDs and provide its own assets. If the
+complete provider, selected runtime scaffold, or customization callback fails,
+S1API removes the partial clone, logs the failure once for that pair and
+operation, and preserves the native fallback.
+
 ## Loose and packaged instances
 
 ```csharp


### PR DESCRIPTION
## Summary

- extend `ProductPackagingContentProfileBuilder` with an opt-in complete filled-visual strategy for mod-owned prefabs
- add a presentation-only native filled scaffold selector with clone-only customization for marijuana, methamphetamine, cocaine, and shroom templates
- reuse the existing stored/equipped/composite-icon runtime, registry precedence, cleanup, fallback, logging, render queue, and scene cache
- document custom-product Brick Press setup, native 20-to-1 behavior, local-assets semantics, and fallback behavior

## Compatibility

- preserves every existing public/protected API and the legacy repeated-content path by default
- keeps `ProductKind` and compatibility metadata independent from visual-template selection
- adds no Schedule One or IL2CPP types to the public API
- changes no stable IDs, save payloads, network payloads, Brick Press eligibility, batch size, player task flow, or NPC/server execution
- exact `origin/beta` ApiCompat comparison passed with parameter names and attributes enabled

## Testing

- MonoMelon restore/build: pass, 0 warnings / 0 errors
- Il2CppMelon restore/build: pass, 0 warnings / 0 errors
- focused packaging tests: 44/44 on each runtime
- MonoMelon full suite: 330/330
- Il2CppMelon full suite: 322/322 using a stable aggregate plus five isolated native-wrapper classes; the monolithic process passes assertions but aborts during testhost shutdown on a native-wrapper finalizer attempting to load `GameAssembly`
- DocFX: pass, 0 errors, 4 existing unresolved external-reference warnings
- documentation coverage: 81.63% (2,981/3,652; minimum 80%)
- isolated real-game create/save/reload smoke on MonoMelon and Il2CppMelon: pass
  - native `BrickPress.CompletePress` consumes 20 loose custom products and creates one `brick` output
  - stored, equipped, and composite-icon presentation render the mod-owned complete visual
  - saved custom product ID and `PackagingID=brick` restore correctly after scene/process reload
  - final runtime logs contain no error, exception, or fail markers

## Evidence boundaries

Native source and serialized prefab evidence came from the locally installed game and a local AssetRipper export. Real-game smoke used an isolated install and disposable copy of an existing save. No game assemblies, generated wrappers, extracted assets, saves, logs, screenshots, or smoke sources are committed.

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for complete filled visuals and native filled visual scaffolds in product packaging.
  * Added four visual template options: Marijuana, Methamphetamine, Cocaine, and Shrooms.
  * Added customization support for cloned native visual scaffolds.

* **Bug Fixes**
  * Improved fallback behavior when visual providers, templates, or customization fail.
  * Prevented invalid visual configurations and incompatible placement combinations.

* **Documentation**
  * Added guidance for configuring complete filled visuals and Brick Press packaging presentations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->