### PR TITLE
fix(suppliers): preserve spawn and shop lifecycle

### DIFF
--- a/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
+++ b/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
@@ -24,4 +24,16 @@ public sealed class NpcVisibilityPolicyTests
                 isSupplier,
                 isSupplierMeeting));
     }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void LoadedVisibilityIsDeferredForSuppliersUntilAfterSpawn(
+        bool isSupplier,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPC.ShouldApplyLoadedVisibilityBeforeSpawn(isSupplier));
+    }
 }

--- a/S1API.Tests/Entities/SupplierShopUiPolicyTests.cs
+++ b/S1API.Tests/Entities/SupplierShopUiPolicyTests.cs
@@ -1,0 +1,23 @@
+using S1API.Internal.Entities.Suppliers;
+
+namespace S1API.Tests.Entities;
+
+public sealed class SupplierShopUiPolicyTests
+{
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    [InlineData(true, true, false)]
+    public void CleanupRemovesOnlyListingRows(
+        bool isListingUi,
+        bool isAmountSelector,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            SupplierShopRuntime.ShouldRemoveClonedUiChild(
+                isListingUi,
+                isAmountSelector));
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -3915,6 +3915,13 @@ namespace S1API.Entities
         {
             try
             {
+                if (!TryValidateNativeAwakeReferences(out string diagnostic))
+                {
+                    Logger.Error(
+                        $"[NPC] Refusing to spawn custom NPC '{GetSafeNpcId()}' because its native Awake reference graph is invalid: {diagnostic}");
+                    return false;
+                }
+
                 NPCDataAccess.PrepareForRuntime(S1NPC);
 
                 var customer = gameObject.GetComponent<S1Economy.Customer>();
@@ -3931,13 +3938,6 @@ namespace S1API.Entities
                         TryApplySupplierDefaults(supplier, defaults);
 
                     SupplierRuntimeCoordinator.EnsureReady(supplier, ID, defaults);
-                }
-
-                if (!TryValidateNativeAwakeReferences(out string diagnostic))
-                {
-                    Logger.Error(
-                        $"[NPC] Refusing to spawn custom NPC '{GetSafeNpcId()}' because its native Awake reference graph is invalid: {diagnostic}");
-                    return false;
                 }
 
                 return true;

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -2,6 +2,7 @@
 using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
 using S1AvatarEquipping = Il2CppScheduleOne.AvatarFramework.Equipping;
 using S1Dialogue = Il2CppScheduleOne.Dialogue;
+using S1Equipping = Il2CppScheduleOne.Equipping.Framework;
 using S1Interaction = Il2CppScheduleOne.Interaction;
 using S1Messaging = Il2CppScheduleOne.Messaging;
 using S1Noise = Il2CppScheduleOne.Noise;
@@ -15,6 +16,7 @@ using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
 using S1Behaviour = Il2CppScheduleOne.NPCs.Behaviour;
 using S1Vehicles = Il2CppScheduleOne.Vehicles;
 using S1Vision = Il2CppScheduleOne.Vision;
+using S1VoiceOver = Il2CppScheduleOne.VoiceOver;
 using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1Employees = Il2CppScheduleOne.Employees;
 using S1Combat = Il2CppScheduleOne.Combat;
@@ -29,6 +31,7 @@ using ConversationCategoryList = Il2CppSystem.Collections.Generic.List<Il2CppSch
 using S1DevUtilities = ScheduleOne.DevUtilities;
 using S1AvatarEquipping = ScheduleOne.AvatarFramework.Equipping;
 using S1Dialogue = ScheduleOne.Dialogue;
+using S1Equipping = ScheduleOne.Equipping.Framework;
 using S1Interaction = ScheduleOne.Interaction;
 using S1Messaging = ScheduleOne.Messaging;
 using S1Noise = ScheduleOne.Noise;
@@ -42,6 +45,7 @@ using S1AvatarFramework = ScheduleOne.AvatarFramework;
 using S1Behaviour = ScheduleOne.NPCs.Behaviour;
 using S1Vehicles = ScheduleOne.Vehicles;
 using S1Vision = ScheduleOne.Vision;
+using S1VoiceOver = ScheduleOne.VoiceOver;
 using S1NPCs = ScheduleOne.NPCs;
 using S1Employees = ScheduleOne.Employees;
 using S1Combat = ScheduleOne.Combat;
@@ -3907,7 +3911,7 @@ namespace S1API.Entities
             }
         }
 
-        internal void PrepareForNetworkSpawn()
+        internal bool PrepareForNetworkSpawn()
         {
             try
             {
@@ -3928,11 +3932,73 @@ namespace S1API.Entities
 
                     SupplierRuntimeCoordinator.EnsureReady(supplier, ID, defaults);
                 }
+
+                if (!TryValidateNativeAwakeReferences(out string diagnostic))
+                {
+                    Logger.Error(
+                        $"[NPC] Refusing to spawn custom NPC '{GetSafeNpcId()}' because its native Awake reference graph is invalid: {diagnostic}");
+                    return false;
+                }
+
+                return true;
             }
             catch (Exception ex)
             {
                 Logger.Warning($"[S1API] Failed to prepare NPC runtime data before spawn: {ex.Message}");
+                return false;
             }
+        }
+
+        private bool TryValidateNativeAwakeReferences(out string diagnostic)
+        {
+            var missing = new System.Collections.Generic.List<string>();
+
+            if (gameObject.GetComponent<S1NPCs.NPCInventory>() == null)
+                missing.Add(nameof(S1NPCs.NPCInventory));
+            if (gameObject.GetComponent<S1NPCs.NPCHealth>() == null)
+                missing.Add(nameof(S1NPCs.NPCHealth));
+            if (gameObject.GetComponent<S1Vision.EntityVisibility>() == null)
+                missing.Add(nameof(S1Vision.EntityVisibility));
+            if (gameObject.GetComponent<S1NPCs.NPCMovement>() == null)
+                missing.Add(nameof(S1NPCs.NPCMovement));
+            if (gameObject.GetComponent<S1Equipping.NetworkedEquipper>() == null)
+                missing.Add(nameof(S1Equipping.NetworkedEquipper));
+
+            var activeAvatar =
+                gameObject.GetComponentInChildren<S1AvatarFramework.Avatar>();
+            var anyAvatar =
+                gameObject.GetComponentInChildren<S1AvatarFramework.Avatar>(true);
+            if (activeAvatar == null)
+            {
+                missing.Add(
+                    anyAvatar == null
+                        ? "Avatar"
+                        : "Avatar(active)");
+            }
+            else if (activeAvatar.HeadBone == null)
+            {
+                missing.Add("Avatar.HeadBone");
+            }
+            else if (activeAvatar.HeadBone.GetComponentInChildren<S1VoiceOver.VOEmitter>() == null)
+            {
+                missing.Add(nameof(S1VoiceOver.VOEmitter));
+            }
+
+            if (gameObject.GetComponentInChildren<S1Dialogue.DialogueHandler>() == null)
+                missing.Add(nameof(S1Dialogue.DialogueHandler));
+            if (gameObject.GetComponentInChildren<S1NPCs.NPCAwareness>() == null)
+                missing.Add(nameof(S1NPCs.NPCAwareness));
+            if (gameObject.GetComponentInChildren<S1Responses.NPCResponses>() == null)
+                missing.Add(nameof(S1Responses.NPCResponses));
+            if (gameObject.GetComponentInChildren<S1NPCs.Actions.NPCActions>() == null)
+                missing.Add(nameof(S1NPCs.Actions.NPCActions));
+            if (gameObject.GetComponentInChildren<S1Behaviour.NPCBehaviour>() == null)
+                missing.Add(nameof(S1Behaviour.NPCBehaviour));
+
+            diagnostic = missing.Count == 0
+                ? string.Empty
+                : string.Join(", ", missing);
+            return missing.Count == 0;
         }
 
         internal void FinalizeNetworkSpawn()
@@ -4343,6 +4409,10 @@ namespace S1API.Entities
             bool isSupplier,
             bool isSupplierMeeting) =>
             isPhysical && (!isSupplier || isSupplierMeeting);
+
+        internal static bool ShouldApplyLoadedVisibilityBeforeSpawn(
+            bool isSupplier) =>
+            !isSupplier;
 
         private IEnumerator DelayedVisibilityRPC()
         {

--- a/S1API/Internal/Entities/NPCNetworkBootstrap.cs
+++ b/S1API/Internal/Entities/NPCNetworkBootstrap.cs
@@ -415,11 +415,19 @@ namespace S1API.Internal.Entities
 
                 try
                 {
-                    owner?.PrepareForNetworkSpawn();
+                    if (owner != null && !owner.PrepareForNetworkSpawn())
+                    {
+                        Logger.Warning(
+                            $"[NPCNetworkBootstrap] Dropping invalid pending spawn for '{ownerId}'.");
+                        PendingSpawns.RemoveAt(i);
+                        continue;
+                    }
                 }
                 catch (Exception prepEx)
                 {
                     Logger.Warning($"[NPCNetworkBootstrap] PrepareForNetworkSpawn threw for '{ownerId}': {prepEx.Message}");
+                    PendingSpawns.RemoveAt(i);
+                    continue;
                 }
 
                 try

--- a/S1API/Internal/Entities/Suppliers/SupplierShopRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierShopRuntime.cs
@@ -165,8 +165,18 @@ namespace S1API.Internal.Entities.Suppliers
                 for (int i = shop.ListingContainer.childCount - 1; i >= 0; i--)
                 {
                     Transform child = shop.ListingContainer.GetChild(i);
-                    if (shop.ListingUIPrefab != null && child.gameObject == shop.ListingUIPrefab.gameObject)
+                    bool isAmountSelector =
+                        shop.AmountSelector != null &&
+                        child == shop.AmountSelector.transform;
+                    bool isListingUi =
+                        child.GetComponent<S1Shop.ListingUI>() != null;
+                    if (!ShouldRemoveClonedUiChild(
+                            isListingUi,
+                            isAmountSelector))
+                    {
                         continue;
+                    }
+
                     Object.DestroyImmediate(child.gameObject);
                 }
             }
@@ -181,5 +191,10 @@ namespace S1API.Internal.Entities.Suppliers
                     | System.Reflection.BindingFlags.Instance)
                 ?.Invoke(listingPanel, null);
         }
+
+        internal static bool ShouldRemoveClonedUiChild(
+            bool isListingUi,
+            bool isAmountSelector) =>
+            isListingUi && !isAmountSelector;
     }
 }

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -1346,13 +1346,15 @@ namespace S1API.Internal.Patches
                         }
                     }
 
-                    // NPC.Load restores the prefab's saved visibility. Native suppliers do
-                    // not use that value as an idle-world presence: they remain hidden
-                    // until MeetAtLocation transitions them into Meeting. Reconcile after
-                    // hydration so custom suppliers follow the same lifecycle.
-                    s1BaseNpc.SetVisible(
-                        wrap.ShouldBeVisibleAfterSpawn(),
-                        networked: false);
+                    // SetVisible(false) deactivates the Avatar GameObject. Custom suppliers
+                    // must remain active through FishNet spawn so native NPC.Awake can find
+                    // the Avatar reference; FinalizeNetworkSpawn applies idle visibility.
+                    if (NPC.ShouldApplyLoadedVisibilityBeforeSpawn(wrap.IsSupplier))
+                    {
+                        s1BaseNpc.SetVisible(
+                            wrap.ShouldBeVisibleAfterSpawn(),
+                            networked: false);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

- defer idle custom-supplier visibility until after FishNet activates the NPC, so native `NPC.Awake` can resolve the active Avatar hierarchy
- fail fast and drop pending custom NPC spawns when the native Awake reference graph is invalid, preventing per-frame exception cascades
- preserve the native `ShopAmountSelector` and other required shop children while clearing only cloned listing rows

## Root causes

- `NPC.Load` reconciliation called native `SetVisible(false)` before spawn for idle suppliers; native visibility deactivates the Avatar GameObject, causing `NPC.GetAndValidateReferences` to fail during FishNet activation
- supplier shop cleanup destroyed every child under `ListingContainer`, including the serialized native `ShopAmountSelector.Container`, causing close/buy/exit failures

## Runtime evidence

- live FishNet registry diagnostics confirmed no game-owned supplier spawnable prefab is exposed; suppliers continue to use the existing `BaseEmployee` fallback without changing dealer or ordinary NPC selection
- AssetRipper native source confirmed `NPC.GetAndValidateReferences` requires an active Avatar and dereferences `Avatar.HeadBone`
- AssetRipper scene serialization confirmed the amount selector is a required child of the listing container

## Testing

- MonoMelon full suite: 336/336
- Il2CppMelon focused brick/supplier suite: 56/56
- MoreDrugs tests: 43/43
- MoreDrugs Mono and IL2CPP builds: pass, 0 warnings / 0 errors
- Mono real-game custom-NPC smoke with MoreDrugs loaded: pass; 6 physical custom NPCs, base/custom appearances, gameplay-menu recovery, and player input gates validated
- final smoke log: no `GetAndValidateReferences`, invalid-spawn, failed-finalization, `ShopAmountSelector`, error, exception, or fail markers