### PR TITLE
fix(suppliers): finish beta supplier lifecycle support

### DIFF
--- a/S1API.Tests/Logging/UnityExceptionTraceHookTests.cs
+++ b/S1API.Tests/Logging/UnityExceptionTraceHookTests.cs
@@ -1,0 +1,29 @@
+using S1API.Internal.Diagnostics;
+
+namespace S1API.Tests.Logging;
+
+public sealed class UnityExceptionTraceHookTests
+{
+    [Theory]
+    [InlineData("ScheduleOne.Weather.EnvironmentManager.GetWeatherProfileFromPosition (UnityEngine.Vector3 position)")]
+    [InlineData("ScheduleOne.NPCs.NPCMovement+<FaceDirection_Process>d__170.MoveNext ()")]
+    [InlineData("ScheduleOne.Configuration.ConfigurationServiceNetworker.OnDestroy ()")]
+    [InlineData("ScheduleOne.UI.PauseMenu.OnDestroy ()")]
+    public void KnownNativeStackFramesReturnBaseGameAdvisory(string stackTrace)
+    {
+        string? advisory = UnityExceptionTraceHook.GetKnownBaseGameNullReferenceAdvisory(stackTrace);
+
+        Assert.NotNull(advisory);
+        Assert.Contains("native/base game", advisory, StringComparison.Ordinal);
+        Assert.Contains("not caused by a mod", advisory, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OtherStackFramesDoNotReturnBaseGameAdvisory()
+    {
+        string? advisory = UnityExceptionTraceHook.GetKnownBaseGameNullReferenceAdvisory(
+            "ExampleMod.Widget.Update ()");
+
+        Assert.Null(advisory);
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -3915,6 +3915,13 @@ namespace S1API.Entities
         {
             try
             {
+                if (!TryValidateNativeAwakeReferences(out string diagnostic))
+                {
+                    Logger.Error(
+                        $"[NPC] Refusing to spawn custom NPC '{GetSafeNpcId()}' because its native Awake reference graph is invalid: {diagnostic}");
+                    return false;
+                }
+
                 NPCDataAccess.PrepareForRuntime(S1NPC);
 
                 var customer = gameObject.GetComponent<S1Economy.Customer>();
@@ -3931,13 +3938,6 @@ namespace S1API.Entities
                         TryApplySupplierDefaults(supplier, defaults);
 
                     SupplierRuntimeCoordinator.EnsureReady(supplier, ID, defaults);
-                }
-
-                if (!TryValidateNativeAwakeReferences(out string diagnostic))
-                {
-                    Logger.Error(
-                        $"[NPC] Refusing to spawn custom NPC '{GetSafeNpcId()}' because its native Awake reference graph is invalid: {diagnostic}");
-                    return false;
                 }
 
                 return true;

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -2334,7 +2334,9 @@ namespace S1API.Entities
             SetConversationCategories(categories);
         }
 
-        internal void SetConversationCategory(S1Messaging.EConversationCategory category)
+        internal void SetConversationCategory(
+            S1Messaging.EConversationCategory category,
+            bool ensureUi = true)
         {
             var categories = new ConversationCategoryList();
             categories.Add(category);
@@ -2344,7 +2346,8 @@ namespace S1API.Entities
                 return;
 
             S1NPC.MSGConversation.SetCategories(categories);
-            S1NPC.MSGConversation.EnsureUIExists();
+            if (ensureUi)
+                S1NPC.MSGConversation.EnsureUIExists();
         }
 
         private bool ShouldUseDealerCategory()

--- a/S1API/Entities/NPCSupplier.cs
+++ b/S1API/Entities/NPCSupplier.cs
@@ -150,7 +150,11 @@ namespace S1API.Entities
                 return;
             }
 
-            npc.SetConversationCategory(S1Messaging.EConversationCategory.Supplier);
+            // Native suppliers keep a conversation object for persistence and
+            // networking, but do not add it to Messages until SupplierUnlocked.
+            npc.SetConversationCategory(
+                S1Messaging.EConversationCategory.Supplier,
+                ensureUi: false);
             npc.EnsureMessageConversationReady(resetDefaults: false);
             EnsureDeadDropReadyDispatcher();
         }

--- a/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
+++ b/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
@@ -251,6 +251,14 @@ namespace S1API.Entities.Relation
                     var targetList = relationData.Connections;
                     if (targetList != null)
                     {
+                        foreach (var previousConnection in targetList)
+                        {
+                            var reverseConnections =
+                                previousConnection?.RelationData?.Connections;
+                            if (reverseConnections != null)
+                                reverseConnections.Remove(owner);
+                        }
+
                         int previousCount = targetList.Count;
                         targetList.Clear();
                         int foundCount = 0;
@@ -281,6 +289,14 @@ namespace S1API.Entities.Relation
                                 else
                                 {
                                     foundCount++;
+                                }
+
+                                var reverseConnections =
+                                    other.RelationData?.Connections;
+                                if (reverseConnections != null &&
+                                    !reverseConnections.Contains(owner))
+                                {
+                                    reverseConnections.Add(owner);
                                 }
                             }
                             else

--- a/S1API/Internal/Logging/UnityExceptionTraceHook.cs
+++ b/S1API/Internal/Logging/UnityExceptionTraceHook.cs
@@ -12,6 +12,9 @@ namespace S1API.Internal.Diagnostics
     /// </summary>
     internal static class UnityExceptionTraceHook
     {
+        private const string KnownBaseGameNullReferenceAdvisory =
+            "[Unity] Note: this NullReferenceException is commonly observed in the native/base game and is usually not caused by a mod. The original stack trace is retained for diagnosis.";
+
         private static readonly Log Logger = new Log("S1API.UnityExceptionTrace");
         private static readonly object Sync = new object();
 #if IL2CPPMELON
@@ -82,6 +85,11 @@ namespace S1API.Internal.Diagnostics
 
             Logger.Error($"[Unity] {condition}");
 
+            if (GetKnownBaseGameNullReferenceAdvisory(stackTrace) is not null)
+            {
+                Logger.Warning(KnownBaseGameNullReferenceAdvisory);
+            }
+
             if (!string.IsNullOrWhiteSpace(stackTrace))
             {
                 Logger.Error($"[Unity] stack trace:\n{stackTrace}");
@@ -92,6 +100,21 @@ namespace S1API.Internal.Diagnostics
         {
             string haystack = string.Concat(condition ?? string.Empty, "\n", stackTrace ?? string.Empty);
             return haystack.Contains("NullReferenceException", StringComparison.Ordinal);
+        }
+
+        internal static string? GetKnownBaseGameNullReferenceAdvisory(string? stackTrace)
+        {
+            if (string.IsNullOrWhiteSpace(stackTrace))
+            {
+                return null;
+            }
+
+            return stackTrace.Contains("ScheduleOne.Weather.EnvironmentManager.GetWeatherProfileFromPosition", StringComparison.Ordinal)
+                || stackTrace.Contains("ScheduleOne.NPCs.NPCMovement+<FaceDirection_Process>", StringComparison.Ordinal)
+                || stackTrace.Contains("ScheduleOne.Configuration.ConfigurationServiceNetworker.OnDestroy", StringComparison.Ordinal)
+                || stackTrace.Contains("ScheduleOne.UI.PauseMenu.OnDestroy", StringComparison.Ordinal)
+                ? KnownBaseGameNullReferenceAdvisory
+                : null;
         }
 
         private static bool ShouldSuppressDuplicate(string signature)


### PR DESCRIPTION
## Summary
- integrate the local supplier spawn and shop lifecycle fixes
- annotate known native null-reference traces
- make custom NPC relationship connections mutual for native recommendations
- keep locked supplier conversations out of Messages until native unlock

## Validation
- MonoMelon full S1API.Tests: 339 passed
- Il2CppMelon solution build: succeeded with 0 warnings and 0 errors
- Il2CppMelon supplier-focused tests: 21 passed

## Compatibility
- Public and protected API surface is unchanged
- Existing dealer conversation behavior is preserved
- Supplier conversation visibility now follows the native lazy-unlock lifecycle
- Save and network identities are unchanged