### PR TITLE
fix(beta): refine supplier messaging and diagnostics

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -550,7 +550,7 @@ namespace S1API.Entities
                 return;
 
             _loggedBaseEmployeeNormalization = true;
-            Logger.Msg($"[S1API] Normalized {BaseEmployeePrefabName} source prefab for beta NPC fallback.");
+            Logger.Debug($"[S1API] Normalized {BaseEmployeePrefabName} source prefab for beta NPC fallback.");
         }
 
         private static void LogBetaNpcPrefabDiagnostic(string message)
@@ -814,7 +814,7 @@ namespace S1API.Entities
                 }
 
                 if (removed > 0)
-                    Logger.Msg($"[S1API] Removed {removed} Employee component(s) from {BaseEmployeePrefabName} NPC fallback prefab.");
+                    Logger.Debug($"[S1API] Removed {removed} Employee component(s) from {BaseEmployeePrefabName} NPC fallback prefab.");
             }
             catch (Exception ex)
             {

--- a/S1API/Internal/Entities/NPCDataAccess.cs
+++ b/S1API/Internal/Entities/NPCDataAccess.cs
@@ -64,6 +64,12 @@ namespace S1API.Internal.Entities
             dataObject.Initialize();
             S1NPCFramework.NPCData data = dataObject.GetOriginalData();
             PrepareData(data);
+            if (rootRole == NpcRootRole.Supplier)
+            {
+                // Native supplier messaging presets do not allow their persistent
+                // order conversations to be hidden from the Messages app.
+                data.Messaging.ConversationCanBeHidden = false;
+            }
             EnsureDialogueDatabase(data, sourceNpc);
             if (rootRole == NpcRootRole.Supplier)
                 EnsureSupplierDialogueDatabase(data, required: false);

--- a/S1API/Internal/Patches/ConsolePatches.cs
+++ b/S1API/Internal/Patches/ConsolePatches.cs
@@ -70,7 +70,7 @@ namespace S1API.Internal.Patches
             var commandTypes = ReflectionUtils.GetDerivedClasses<BaseConsoleCommand>();
             foreach (var type in commandTypes)
             {
-                Logger.Msg($"Found console command: {type.FullName}");
+                Logger.Debug($"Found console command: {type.FullName}");
 
                 if (type.GetConstructor(Type.EmptyTypes) == null)
                     continue;

--- a/S1API/Internal/Patches/HomeScreen.Start.cs
+++ b/S1API/Internal/Patches/HomeScreen.Start.cs
@@ -45,7 +45,7 @@ namespace S1API.Internal.Patches
             var phoneApps = ReflectionUtils.GetDerivedClasses<PhoneApp.PhoneApp>();
             foreach (var type in phoneApps)
             {
-                Logger.Msg($"Found phone app: {type.FullName}");
+                Logger.Debug($"Found phone app: {type.FullName}");
 
                 if (type.GetConstructor(Type.EmptyTypes) == null)
                     continue;

--- a/S1API/Internal/S1APIPreferences.cs
+++ b/S1API/Internal/S1APIPreferences.cs
@@ -9,6 +9,7 @@ namespace S1API.Internal
     {
         internal static MelonPreferences_Entry<bool>? EnableMugshotLoadingScreen { get; private set; }
         internal static MelonPreferences_Entry<bool>? EnableUnityNullReferenceTraceLogging { get; private set; }
+        internal static MelonPreferences_Entry<bool>? EnableVerboseLogging { get; private set; }
 
         /// <summary>
         /// Initializes the S1API preferences category and entries. Call from OnInitializeMelon.
@@ -25,6 +26,11 @@ namespace S1API.Internal
                 "EnableUnityNullReferenceTraceLogging",
                 false,
                 "When true, S1API subscribes to Unity's threaded log callback and emits stack traces for NullReferenceException logs to help diagnose runtime issues.");
+
+            EnableVerboseLogging = category.CreateEntry<bool>(
+                "EnableVerboseLogging",
+                false,
+                "When true, S1API emits internal implementation diagnostics for rendering, resource registration, and runtime fallback behavior.");
         }
     }
 }

--- a/S1API/Items/AvatarEquippableRegistry.cs
+++ b/S1API/Items/AvatarEquippableRegistry.cs
@@ -58,7 +58,7 @@ namespace S1API.Items
             bool success = RuntimeResourceRegistry.RegisterGameObject(assetPath, prefab);
             if (success)
             {
-                _logger.Msg($"Registered AvatarEquippable prefab: {assetPath}");
+                _logger.Debug($"Registered AvatarEquippable prefab: {assetPath}");
             }
             return success;
         }

--- a/S1API/Logging/Log.cs
+++ b/S1API/Logging/Log.cs
@@ -1,4 +1,5 @@
 using MelonLoader;
+using S1API.Internal;
 
 namespace S1API.Logging
 {
@@ -25,6 +26,16 @@ namespace S1API.Logging
         public void Msg(string message)
         {
             _loggerInstance.Msg(message);
+        }
+
+        /// <summary>
+        /// Logs an internal diagnostic message when verbose S1API logging is enabled.
+        /// </summary>
+        /// <param name="message">Diagnostic message to log.</param>
+        internal void Debug(string message)
+        {
+            if (S1APIPreferences.EnableVerboseLogging?.Value == true)
+                _loggerInstance.Msg(message);
         }
 
         /// <summary>

--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -380,7 +380,7 @@ namespace S1API.PhoneApp
                 // Set app state to open using the same pattern as native apps
                 SetAppOpen(true);
 
-                Logger.Msg($"Opened phone app: {AppName}");
+                Logger.Debug($"Opened phone app: {AppName}");
             }
             catch (Exception e)
             {
@@ -401,7 +401,7 @@ namespace S1API.PhoneApp
                     SetAppOpen(false);
                 }
 
-                Logger.Msg($"Closed phone app: {AppName}");
+                Logger.Debug($"Closed phone app: {AppName}");
             }
             catch (Exception e)
             {

--- a/S1API/Rendering/IconFactory.cs
+++ b/S1API/Rendering/IconFactory.cs
@@ -175,7 +175,7 @@ namespace S1API.Rendering
                         iconLayer);
                 }
 
-                Logger.Msg(
+                Logger.Debug(
                     $"Icon generation for '{model.name}': world pos={model.position}, " +
                     $"layer={model.gameObject.layer} " +
                     $"({LayerMask.LayerToName(model.gameObject.layer)}), " +
@@ -185,7 +185,7 @@ namespace S1API.Rendering
                 if (bakeSkinnedMeshes)
                 {
                     bakedRenderers = BakeSkinnedMeshRenderers(model.gameObject);
-                    Logger.Msg($"Baked {bakedRenderers.Count} SkinnedMeshRenderer(s)");
+                    Logger.Debug($"Baked {bakedRenderers.Count} SkinnedMeshRenderer(s)");
                 }
 
                 // Center the model in the container to ensure it's in view of the camera
@@ -205,7 +205,7 @@ namespace S1API.Rendering
                 generator.ModifyLighting = true;
 
                 texture = generator.GetTexture(model);
-                Logger.Msg($"Generated texture: {(texture != null ? $"{texture.width}x{texture.height}" : "null")}");
+                Logger.Debug($"Generated texture: {(texture != null ? $"{texture.width}x{texture.height}" : "null")}");
                 if (texture != null && !HasVisibleContent(texture))
                 {
                     Logger.Warning(
@@ -553,7 +553,7 @@ namespace S1API.Rendering
                 // Moving the model position shifts the bounds center to the container position.
                 model.position += centerOffset;
 
-                Logger.Msg($"Recentered model '{model.name}'. Old Bounds Center: {bounds.center}, New Center: {container.position}, Offset: {centerOffset}");
+                Logger.Debug($"Recentered model '{model.name}'. Old Bounds Center: {bounds.center}, New Center: {container.position}, Offset: {centerOffset}");
             }
             else
             {
@@ -591,7 +591,7 @@ namespace S1API.Rendering
 
             float scaleFactor = targetDimension / largestDimension;
             model.localScale *= scaleFactor;
-            Logger.Msg(
+            Logger.Debug(
                 $"Fit model '{model.name}' to native icon camera. " +
                 $"Bounds={bounds.size}, target={targetDimension:F3}, scale={scaleFactor:F3}");
         }
@@ -758,7 +758,7 @@ namespace S1API.Rendering
                         {
                             generatedMugshot.Apply();
                             capturedTexture = generatedMugshot;
-                            Logger.Msg($"Generated accessory icon for '{next.AccessoryPath}': {generatedMugshot.width}x{generatedMugshot.height}");
+                            Logger.Debug($"Generated accessory icon for '{next.AccessoryPath}': {generatedMugshot.width}x{generatedMugshot.height}");
                         }
                         else
                         {
@@ -809,7 +809,7 @@ namespace S1API.Rendering
             if (playerSettings != null)
             {
                 settings = playerSettings.ToAvatarSettings().S1AvatarSettings;
-                Logger.Msg("Using local player's avatar settings for accessory icon");
+                Logger.Debug("Using local player's avatar settings for accessory icon");
             }
             else
             {
@@ -832,7 +832,7 @@ namespace S1API.Rendering
         /// </summary>
         private static S1AvatarFramework.AvatarSettings CreateFallbackAvatarSettings()
         {
-            Logger.Msg("Local player not available, using fallback avatar settings for accessory icon");
+            Logger.Debug("Local player not available, using fallback avatar settings for accessory icon");
             var settings = ScriptableObject.CreateInstance<S1AvatarFramework.AvatarSettings>();
 
             // Set minimal defaults

--- a/S1API/Rendering/RuntimeResourceRegistry.cs
+++ b/S1API/Rendering/RuntimeResourceRegistry.cs
@@ -66,7 +66,7 @@ namespace S1API.Rendering
             string typedKey = GetTypedKey(resourcePath, asset.GetType());
             _typedAssets[typedKey] = asset;
 
-            Logger.Msg($"Registered '{resourcePath}' as type '{asset.GetType().Name}'");
+            Logger.Debug($"Registered '{resourcePath}' as type '{asset.GetType().Name}'");
             return true;
         }
 
@@ -103,7 +103,7 @@ namespace S1API.Rendering
             string typedKey = GetTypedKey(resourcePath, forType);
             _typedAssets[typedKey] = asset;
 
-            Logger.Msg($"Registered '{resourcePath}' for type '{NormalizeTypeName(forType.FullName)}'");
+            Logger.Debug($"Registered '{resourcePath}' for type '{NormalizeTypeName(forType.FullName)}'");
             return true;
         }
 
@@ -322,7 +322,7 @@ namespace S1API.Rendering
                 }
 
                 _isPatched = true;
-                Logger.Msg($"Patched Resources.Load methods (typed={loadWithTypeMethod != null}, string={loadStringMethod != null})");
+                Logger.Debug($"Patched Resources.Load methods (typed={loadWithTypeMethod != null}, string={loadStringMethod != null})");
             }
             catch (Exception ex)
             {

--- a/S1API/UI/CharacterCreatorManager.cs
+++ b/S1API/UI/CharacterCreatorManager.cs
@@ -437,7 +437,7 @@ namespace S1API.UI
                 var currentSettings = localPlayer.GetCurrentBasicAvatarSettings();
                 if (currentSettings == null)
                 {
-                    Logger.Msg("Player has no current avatar settings, using default");
+                    Logger.Debug("Player has no current avatar settings, using default");
                     return null;
                 }
 


### PR DESCRIPTION
## Summary
- Keep supplier order conversations visible in the Messages app.
- Gate high-volume internal diagnostics behind an opt-in verbose logging preference.

## Validation
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`

## Compatibility
No public or protected API signatures, durable IDs, save formats, or network payloads changed. The new preference and diagnostic helper are internal.