### PR TITLE
fix(beta): restore custom contact and avatar behavior

### DIFF
--- a/S1API.Tests/Entities/ContactsAppRoleTests.cs
+++ b/S1API.Tests/Entities/ContactsAppRoleTests.cs
@@ -1,0 +1,28 @@
+using S1API.Entities;
+using S1API.Internal.Patches;
+
+namespace S1API.Tests.Entities;
+
+public sealed class ContactsAppRoleTests
+{
+    [Fact]
+    public void IsContactRole_IncludesCustomersDealersAndSuppliers()
+    {
+        NPC.RegisterCustomerType(typeof(CustomerContact));
+        NPC.RegisterDealerType(typeof(DealerContact));
+        NPC.RegisterSupplierType(typeof(SupplierContact));
+
+        Assert.True(ContactsAppPatches.IsContactRole(typeof(CustomerContact)));
+        Assert.True(ContactsAppPatches.IsContactRole(typeof(DealerContact)));
+        Assert.True(ContactsAppPatches.IsContactRole(typeof(SupplierContact)));
+        Assert.False(ContactsAppPatches.IsContactRole(typeof(NonContact)));
+    }
+
+    private sealed class CustomerContact;
+
+    private sealed class DealerContact;
+
+    private sealed class SupplierContact;
+
+    private sealed class NonContact;
+}

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -180,8 +180,7 @@ namespace S1API.Internal.Patches
         private static void AddRelationCircles(S1ContactsApp.ContactsApp contactsApp)
         {
             var customNPCs = NPC.All
-                .Where(n => n.IsCustomNPC &&
-                            (NPC.IsCustomerType(n.GetType()) || NPC.IsDealerType(n.GetType())))
+                .Where(n => n.IsCustomNPC && IsContactRole(n.GetType()))
                 .ToList();
 
             var regionUIs = contactsApp.RegionUIs.ToDictionary(r => r.Region, r => r);
@@ -377,6 +376,13 @@ namespace S1API.Internal.Patches
 
             // Create connection lines for custom NPCs
             CreateConnectionLines(contactsApp, customNPCs, regionUIs);
+        }
+
+        internal static bool IsContactRole(System.Type npcType)
+        {
+            return NPC.IsCustomerType(npcType)
+                   || NPC.IsDealerType(npcType)
+                   || NPC.IsSupplierType(npcType);
         }
 
         /// <summary>

--- a/S1API/Internal/Patches/EquippableAvatarPatches.cs
+++ b/S1API/Internal/Patches/EquippableAvatarPatches.cs
@@ -1,0 +1,67 @@
+#if IL2CPPMELON
+using S1AvatarEquipping = Il2CppScheduleOne.AvatarFramework.Equipping;
+using S1Equipping = Il2CppScheduleOne.Equipping;
+using S1Player = Il2CppScheduleOne.PlayerScripts.Player;
+#elif MONOMELON
+using S1AvatarEquipping = ScheduleOne.AvatarFramework.Equipping;
+using S1Equipping = ScheduleOne.Equipping;
+using S1Player = ScheduleOne.PlayerScripts.Player;
+#endif
+
+using HarmonyLib;
+using S1API.Internal.Utils;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// Activates avatar presentation configured through EquippableBuilder for
+    /// non-viewmodel equippables, including native buildable-item equippables.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class EquippableAvatarPatches
+    {
+        [HarmonyPatch(
+            typeof(S1Equipping.Equippable),
+            nameof(S1Equipping.Equippable.Equip))]
+        [HarmonyPostfix]
+        private static void Equip_Postfix(S1Equipping.Equippable __instance)
+        {
+            if (!TryGetNonViewmodelAvatar(__instance, out var avatar))
+                return;
+
+            S1Player.Local?.SendEquippable_Networked(avatar.AssetPath);
+        }
+
+        [HarmonyPatch(
+            typeof(S1Equipping.Equippable),
+            nameof(S1Equipping.Equippable.Unequip))]
+        [HarmonyPrefix]
+        private static void Unequip_Prefix(S1Equipping.Equippable __instance)
+        {
+            if (!TryGetNonViewmodelAvatar(__instance, out _))
+                return;
+
+            S1Player.Local?.SendEquippable_Networked(string.Empty);
+        }
+
+        private static bool TryGetNonViewmodelAvatar(
+            S1Equipping.Equippable equippable,
+            out S1AvatarEquipping.AvatarEquippable avatar)
+        {
+            avatar = null!;
+            if (equippable == null ||
+                CrossType.Is(
+                    equippable,
+                    out S1Equipping.Equippable_Viewmodel _))
+            {
+                return false;
+            }
+
+            avatar =
+                equippable.GetComponentInChildren<
+                    S1AvatarEquipping.AvatarEquippable>(true);
+            return avatar != null &&
+                   !string.IsNullOrWhiteSpace(avatar.AssetPath);
+        }
+    }
+}

--- a/S1API/Internal/Utils/RuntimePrefabCache.cs
+++ b/S1API/Internal/Utils/RuntimePrefabCache.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace S1API.Internal.Utils
+{
+    /// <summary>
+    /// Keeps runtime-created prefab templates alive without allowing their
+    /// behaviours to tick in the scene.
+    /// </summary>
+    internal static class RuntimePrefabCache
+    {
+        private static GameObject? _root;
+
+        internal static void Store(GameObject prefab)
+        {
+            GameObject root = GetOrCreateRoot();
+            prefab.hideFlags = HideFlags.HideAndDontSave;
+            prefab.transform.SetParent(root.transform, false);
+            prefab.transform.localPosition = Vector3.zero;
+            prefab.transform.localRotation = Quaternion.identity;
+
+            // Native consumers instantiate the template without explicitly
+            // activating the clone. Keep activeSelf true while the inactive
+            // cache parent prevents the template's behaviours from ticking.
+            prefab.SetActive(true);
+        }
+
+        private static GameObject GetOrCreateRoot()
+        {
+            if (_root != null)
+                return _root;
+
+            _root = new GameObject("S1API_RuntimePrefabCache")
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _root.SetActive(false);
+            Object.DontDestroyOnLoad(_root);
+            return _root;
+        }
+    }
+}

--- a/S1API/Items/EquippableBuilder.cs
+++ b/S1API/Items/EquippableBuilder.cs
@@ -110,7 +110,8 @@ namespace S1API.Items
 
         /// <summary>
         /// Configures the third-person avatar equippable animation.
-        /// Only applies to viewmodel equippables created with <see cref="CreateViewmodelEquippable"/>.
+        /// Viewmodel equippables use the native viewmodel lifecycle. Other
+        /// equippable types use S1API's shared avatar synchronization runtime.
         /// </summary>
         /// <param name="assetPath">Resources path to the AvatarEquippable prefab (e.g., "Equippables/MyItem").</param>
         /// <param name="hand">Which hand holds the item in third-person (Left or Right).</param>
@@ -204,39 +205,13 @@ namespace S1API.Items
                     viewmodelEquippable.localScale = _viewmodelScale.Value;
                 }
 
-                // Configure AvatarEquippable if provided
-                if (!string.IsNullOrEmpty(_avatarEquippableAssetPath))
-                {
-                    // Create a child GameObject for the AvatarEquippable
-                    var avatarEquippableGO = new GameObject("AvatarEquippable");
-                    avatarEquippableGO.transform.SetParent(_gameObject.transform);
-                    
-                    var avatarEquippable = avatarEquippableGO.AddComponent<S1AvatarEquipping.AvatarEquippable>();
-                    avatarEquippable.AssetPath = _avatarEquippableAssetPath;
-                    avatarEquippable.Hand = _avatarHand;
-                    avatarEquippable.AnimationTrigger = _avatarAnimationTrigger;
-                    
-                    // Create an alignment point if it doesn't exist
-                    if (avatarEquippable.AlignmentPoint == null)
-                    {
-                        var alignmentPoint = new GameObject("AlignmentPoint");
-                        alignmentPoint.transform.SetParent(avatarEquippableGO.transform);
-                        alignmentPoint.transform.localPosition = Vector3.zero;
-                        alignmentPoint.transform.localRotation = Quaternion.identity;
-                        avatarEquippable.AlignmentPoint = alignmentPoint.transform;
-                    }
-                    
-                    viewmodelEquippable.AvatarEquippable = avatarEquippable;
-                }
             }
+
+            ApplyAvatarPresentation();
 
             ApplyInteractionSettings(_equippable);
 
-            // Make it persistent across scene loads
-            Object.DontDestroyOnLoad(_gameObject);
-
-            // Set inactive (prefab-like state)
-            _gameObject.SetActive(false);
+            RuntimePrefabCache.Store(_gameObject);
 
             return new Equippable(_equippable);
         }
@@ -252,15 +227,51 @@ namespace S1API.Items
                 throw new System.InvalidOperationException("Cannot build equippable: No equippable component created. Call CreateEquippable<T>() or CreateBasicEquippable() first.");
             }
 
+            ApplyAvatarPresentation();
             ApplyInteractionSettings(_equippable);
 
-            // Make it persistent across scene loads
-            Object.DontDestroyOnLoad(_gameObject);
-
-            // Set inactive (prefab-like state)
-            _gameObject.SetActive(false);
+            RuntimePrefabCache.Store(_gameObject);
 
             return _equippable;
+        }
+
+        private void ApplyAvatarPresentation()
+        {
+            if (_gameObject == null ||
+                _equippable == null ||
+                string.IsNullOrEmpty(_avatarEquippableAssetPath))
+            {
+                return;
+            }
+
+            var avatarEquippable =
+                _gameObject.GetComponentInChildren<
+                    S1AvatarEquipping.AvatarEquippable>(true);
+            if (avatarEquippable == null)
+            {
+                var avatarEquippableObject =
+                    new GameObject("AvatarEquippable");
+                avatarEquippableObject.transform.SetParent(
+                    _gameObject.transform,
+                    false);
+                avatarEquippable =
+                    avatarEquippableObject
+                        .AddComponent<
+                            S1AvatarEquipping.AvatarEquippable>();
+
+                var alignmentPoint = new GameObject("AlignmentPoint");
+                alignmentPoint.transform.SetParent(
+                    avatarEquippableObject.transform,
+                    false);
+                avatarEquippable.AlignmentPoint =
+                    alignmentPoint.transform;
+            }
+
+            avatarEquippable.AssetPath = _avatarEquippableAssetPath;
+            avatarEquippable.Hand = _avatarHand;
+            avatarEquippable.AnimationTrigger = _avatarAnimationTrigger;
+            if (_equippable is S1Equipping.Equippable_Viewmodel viewmodel)
+                viewmodel.AvatarEquippable = avatarEquippable;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Include custom supplier NPCs in the Contacts app relationship display.
- Preserve avatar-equippable presentation for non-viewmodel equippables with a shared runtime prefab cache.

## Validation
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build --filter FullyQualifiedName~ContactsAppRoleTests`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build --filter FullyQualifiedName~ContactsAppRoleTests`

## Compatibility
No public or protected signatures, durable IDs, save formats, or network payload shapes changed. Existing viewmodel avatar behavior is preserved; non-viewmodel equippables now receive the configured avatar presentation.