### PR TITLE
chore(release): bump version to 3.1.0-beta.9

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.8", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0-beta.9", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.0-beta.8</Version>
+        <Version>3.1.0-beta.9</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- bump the S1API assembly and package version from `3.1.0-beta.8` to `3.1.0-beta.9`
- prepare the next GitHub-only beta prerelease

## Validation

- MonoMelon solution build: 0 warnings, 0 errors
- Il2CppMelon solution build: 0 warnings, 0 errors
- version metadata agrees between `S1API.csproj` and `MelonInfo`
- `git diff --check` passes