### PR TITLE
fix(beta): restore supplier roles and live presentation previews

### DIFF
--- a/S1API.Tests/Entities/ContactsAppRoleTests.cs
+++ b/S1API.Tests/Entities/ContactsAppRoleTests.cs
@@ -18,6 +18,24 @@ public sealed class ContactsAppRoleTests
         Assert.False(ContactsAppPatches.IsContactRole(typeof(NonContact)));
     }
 
+    [Fact]
+    public void GetRoleIndicators_DistinguishesDealerSupplierAndCustomer()
+    {
+        NPC.RegisterCustomerType(typeof(CustomerIndicatorContact));
+        NPC.RegisterDealerType(typeof(DealerIndicatorContact));
+        NPC.RegisterSupplierType(typeof(SupplierIndicatorContact));
+
+        Assert.Equal(
+            (IsDealer: false, IsSupplier: false),
+            ContactsAppPatches.GetRoleIndicators(typeof(CustomerIndicatorContact)));
+        Assert.Equal(
+            (IsDealer: true, IsSupplier: false),
+            ContactsAppPatches.GetRoleIndicators(typeof(DealerIndicatorContact)));
+        Assert.Equal(
+            (IsDealer: false, IsSupplier: true),
+            ContactsAppPatches.GetRoleIndicators(typeof(SupplierIndicatorContact)));
+    }
+
     private sealed class CustomerContact;
 
     private sealed class DealerContact;
@@ -25,4 +43,10 @@ public sealed class ContactsAppRoleTests
     private sealed class SupplierContact;
 
     private sealed class NonContact;
+
+    private sealed class CustomerIndicatorContact;
+
+    private sealed class DealerIndicatorContact;
+
+    private sealed class SupplierIndicatorContact;
 }

--- a/S1API.Tests/Entities/ContactsAppRoleTests.cs
+++ b/S1API.Tests/Entities/ContactsAppRoleTests.cs
@@ -36,17 +36,83 @@ public sealed class ContactsAppRoleTests
             ContactsAppPatches.GetRoleIndicators(typeof(SupplierIndicatorContact)));
     }
 
-    private sealed class CustomerContact;
+    [Fact]
+    public void ApplyRoleIndicators_ActivatesExpectedNamedIndicators()
+    {
+        NPC.RegisterCustomerType(typeof(CustomerActivationContact));
+        NPC.RegisterDealerType(typeof(DealerActivationContact));
+        NPC.RegisterSupplierType(typeof(SupplierActivationContact));
 
-    private sealed class DealerContact;
+        Assert.Equal(
+            new[]
+            {
+                ("DealerIndicator", false),
+                ("SupplierIndicator", false),
+            },
+            CaptureIndicatorStates(typeof(CustomerActivationContact)));
+        Assert.Equal(
+            new[]
+            {
+                ("DealerIndicator", true),
+                ("SupplierIndicator", false),
+            },
+            CaptureIndicatorStates(typeof(DealerActivationContact)));
+        Assert.Equal(
+            new[]
+            {
+                ("DealerIndicator", false),
+                ("SupplierIndicator", true),
+            },
+            CaptureIndicatorStates(typeof(SupplierActivationContact)));
+    }
 
-    private sealed class SupplierContact;
+    private static (string Name, bool IsActive)[] CaptureIndicatorStates(
+        Type npcType)
+    {
+        var states = new List<(string Name, bool IsActive)>();
+        ContactsAppPatches.ApplyRoleIndicators(
+            npcType,
+            (name, isActive) => states.Add((name, isActive)));
+        return states.ToArray();
+    }
 
-    private sealed class NonContact;
+    private sealed class CustomerContact
+    {
+    }
 
-    private sealed class CustomerIndicatorContact;
+    private sealed class DealerContact
+    {
+    }
 
-    private sealed class DealerIndicatorContact;
+    private sealed class SupplierContact
+    {
+    }
 
-    private sealed class SupplierIndicatorContact;
+    private sealed class NonContact
+    {
+    }
+
+    private sealed class CustomerIndicatorContact
+    {
+    }
+
+    private sealed class DealerIndicatorContact
+    {
+    }
+
+    private sealed class SupplierIndicatorContact
+    {
+    }
+
+    private sealed class CustomerActivationContact
+    {
+    }
+
+    private sealed class DealerActivationContact
+    {
+    }
+
+    private sealed class SupplierActivationContact
+    {
+    }
 }

--- a/S1API.Tests/Entities/NPCRelationshipEventTests.cs
+++ b/S1API.Tests/Entities/NPCRelationshipEventTests.cs
@@ -1,4 +1,5 @@
 using S1API.Entities;
+using System.Reflection;
 
 namespace S1API.Tests.Entities;
 
@@ -16,5 +17,41 @@ public sealed class NPCRelationshipEventTests
 
         Assert.NotNull(member);
         Assert.Equal(canonicalName, member.Name);
+    }
+
+    [Fact]
+    public void CanonicalPropertyTakesPrecedenceOverLegacyField()
+    {
+        MemberInfo? member = NPCRelationship.ResolveNativeEventMember(
+            typeof(CanonicalPropertyAndLegacyFieldFixture),
+            "OnUnlocked",
+            "onUnlocked");
+
+        PropertyInfo property = Assert.IsAssignableFrom<PropertyInfo>(member);
+        Assert.Equal("OnUnlocked", property.Name);
+    }
+
+    [Fact]
+    public void LegacyFieldIsUsedWhenCanonicalMemberDoesNotExist()
+    {
+        MemberInfo? member = NPCRelationship.ResolveNativeEventMember(
+            typeof(LegacyFieldOnlyFixture),
+            "OnUnlocked",
+            "onUnlocked");
+
+        FieldInfo field = Assert.IsAssignableFrom<FieldInfo>(member);
+        Assert.Equal("onUnlocked", field.Name);
+    }
+
+    private sealed class CanonicalPropertyAndLegacyFieldFixture
+    {
+        public Action? onUnlocked = null;
+
+        public Action? OnUnlocked { get; set; }
+    }
+
+    private sealed class LegacyFieldOnlyFixture
+    {
+        public Action? onUnlocked = null;
     }
 }

--- a/S1API.Tests/Entities/NPCRelationshipEventTests.cs
+++ b/S1API.Tests/Entities/NPCRelationshipEventTests.cs
@@ -1,0 +1,20 @@
+using S1API.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NPCRelationshipEventTests
+{
+    [Theory]
+    [InlineData("OnUnlocked", "onUnlocked")]
+    [InlineData("OnRelationshipChange", "onRelationshipChange")]
+    public void ResolvesCanonicalNativeRelationshipEventMembers(
+        string canonicalName,
+        string legacyName)
+    {
+        var member =
+            NPCRelationship.ResolveNativeEventMember(canonicalName, legacyName);
+
+        Assert.NotNull(member);
+        Assert.Equal(canonicalName, member.Name);
+    }
+}

--- a/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
+++ b/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
@@ -60,6 +60,32 @@ public sealed class PresentationWorkbenchTests
         Assert.NotEqual(first, second);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("+")]
+    [InlineData("-")]
+    [InlineData(".")]
+    [InlineData("+.")]
+    [InlineData("-.")]
+    [InlineData("1e")]
+    [InlineData("1E+")]
+    [InlineData("1e-")]
+    public void IncompleteNumericInputIsTreatedAsTransient(string value)
+    {
+        Assert.True(PresentationWorkbenchView.IsIncompleteNumericInput(value));
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("--1")]
+    [InlineData("1.5")]
+    [InlineData("1e2")]
+    public void CompleteOrInvalidNumericInputIsNotTransient(string value)
+    {
+        Assert.False(PresentationWorkbenchView.IsIncompleteNumericInput(value));
+    }
+
 #if MONOMELON
     [Fact]
     public void ExportUsesExistingApisAndInvariantCulture()

--- a/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
+++ b/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
@@ -47,6 +47,19 @@ public sealed class PresentationWorkbenchTests
                 StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void InputBindingsUseDistinctDelegatesForSharedCallbacks()
+    {
+        Action<string> callback = _ => { };
+
+        Action<string> first =
+            PresentationWorkbenchView.CreateInputBindingAction(callback);
+        Action<string> second =
+            PresentationWorkbenchView.CreateInputBindingAction(callback);
+
+        Assert.NotEqual(first, second);
+    }
+
 #if MONOMELON
     [Fact]
     public void ExportUsesExistingApisAndInvariantCulture()

--- a/S1API/Entities/NPCRelationship.cs
+++ b/S1API/Entities/NPCRelationship.cs
@@ -325,15 +325,25 @@ namespace S1API.Entities
             string canonicalName,
             string legacyName)
         {
+            return ResolveNativeEventMember(
+                typeof(S1Relation.NPCRelationData),
+                canonicalName,
+                legacyName);
+        }
+
+        internal static MemberInfo? ResolveNativeEventMember(
+            Type relationType,
+            string canonicalName,
+            string legacyName)
+        {
             const BindingFlags flags =
                 BindingFlags.Public |
                 BindingFlags.NonPublic |
                 BindingFlags.Instance;
-            Type relationType = typeof(S1Relation.NPCRelationData);
-            return relationType.GetField(canonicalName, flags) ??
-                   relationType.GetField(legacyName, flags) ??
+            return (MemberInfo?)relationType.GetField(canonicalName, flags) ??
                    (MemberInfo?)relationType.GetProperty(canonicalName, flags) ??
-                   relationType.GetProperty(legacyName, flags);
+                   (MemberInfo?)relationType.GetField(legacyName, flags) ??
+                   (MemberInfo?)relationType.GetProperty(legacyName, flags);
         }
 
         private static object? GetNativeEventValue(

--- a/S1API/Entities/NPCRelationship.cs
+++ b/S1API/Entities/NPCRelationship.cs
@@ -44,6 +44,10 @@ namespace S1API.Entities
         internal readonly NPC NPC;
         private readonly Dictionary<Action<float>, Delegate> _relationshipChangedHandlers = new Dictionary<Action<float>, Delegate>();
         private readonly Dictionary<Action<UnlockType, bool>, Delegate> _relationshipUnlockedHandlers = new Dictionary<Action<UnlockType, bool>, Delegate>();
+        private static readonly MemberInfo? RelationshipChangedMember =
+            ResolveNativeEventMember("OnRelationshipChange", "onRelationshipChange");
+        private static readonly MemberInfo? RelationshipUnlockedMember =
+            ResolveNativeEventMember("OnUnlocked", "onUnlocked");
 
         internal NPCRelationship(NPC npc)
         {
@@ -178,20 +182,20 @@ namespace S1API.Entities
 
                 try
                 {
-                    FieldInfo? field = typeof(S1Relation.NPCRelationData).GetField("onRelationshipChange", BindingFlags.Public | BindingFlags.Instance);
-                    if (field == null)
+                    MemberInfo? member = RelationshipChangedMember;
+                    if (member == null)
                         return;
 
-                    object? existing = field.GetValue(Component);
+                    object? existing = GetNativeEventValue(member, Component);
 #if IL2CPPMELON
                     System.Action<float> wrapped = new System.Action<float>(d => { try { value(d); } catch { } });
                     var combined = (Il2CppSystem.Delegate)Il2CppSystem.Delegate.Combine(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped);
-                    field.SetValue(Component, combined);
+                    SetNativeEventValue(member, Component, combined);
                     _relationshipChangedHandlers[value] = wrapped;
 #else
                     Action<float> wrapped = d => { try { value(d); } catch { } };
                     var combined = Delegate.Combine(existing as Delegate, wrapped);
-                    field.SetValue(Component, combined);
+                    SetNativeEventValue(member, Component, combined);
                     _relationshipChangedHandlers[value] = wrapped;
 #endif
                 }
@@ -208,22 +212,22 @@ namespace S1API.Entities
                 _relationshipChangedHandlers.Remove(value);
                 try
                 {
-                    FieldInfo? field = typeof(S1Relation.NPCRelationData).GetField("onRelationshipChange", BindingFlags.Public | BindingFlags.Instance);
-                    if (field == null)
+                    MemberInfo? member = RelationshipChangedMember;
+                    if (member == null)
                         return;
 
 #if IL2CPPMELON
-                    var existing = field.GetValue(Component);
+                    var existing = GetNativeEventValue(member, Component);
                     var remaining = existing != null
                         ? Il2CppSystem.Delegate.Remove(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped)
                         : null;
-                    field.SetValue(Component, remaining);
+                    SetNativeEventValue(member, Component, remaining);
 #else
-                    var existing = field.GetValue(Component);
+                    var existing = GetNativeEventValue(member, Component);
                     var remaining = existing != null
                         ? Delegate.Remove(existing as Delegate, (Delegate)wrapped)
                         : null;
-                    field.SetValue(Component, remaining);
+                    SetNativeEventValue(member, Component, remaining);
 #endif
                 }
                 catch { }
@@ -246,18 +250,18 @@ namespace S1API.Entities
 
                 try
                 {
-                    FieldInfo? field = typeof(S1Relation.NPCRelationData).GetField("onUnlocked", BindingFlags.Public | BindingFlags.Instance);
-                    if (field == null)
+                    MemberInfo? member = RelationshipUnlockedMember;
+                    if (member == null)
                         return;
 
-                    object? existing = field.GetValue(Component);
+                    object? existing = GetNativeEventValue(member, Component);
 #if IL2CPPMELON
                     System.Action<S1Relation.NPCRelationData.EUnlockType, bool> wrapped = new System.Action<S1Relation.NPCRelationData.EUnlockType, bool>((t, notify) =>
                     {
                         try { value(FromS1(t), notify); } catch { }
                     });
                     var combined = (Il2CppSystem.Delegate)Il2CppSystem.Delegate.Combine(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped);
-                    field.SetValue(Component, combined);
+                    SetNativeEventValue(member, Component, combined);
                     _relationshipUnlockedHandlers[value] = wrapped;
 #else
                     Action<S1Relation.NPCRelationData.EUnlockType, bool> wrapped = (t, notify) =>
@@ -265,7 +269,7 @@ namespace S1API.Entities
                         try { value(FromS1(t), notify); } catch { }
                     };
                     var combined = Delegate.Combine(existing as Delegate, wrapped);
-                    field.SetValue(Component, combined);
+                    SetNativeEventValue(member, Component, combined);
                     _relationshipUnlockedHandlers[value] = wrapped;
 #endif
                 }
@@ -282,22 +286,22 @@ namespace S1API.Entities
                 _relationshipUnlockedHandlers.Remove(value);
                 try
                 {
-                    FieldInfo? field = typeof(S1Relation.NPCRelationData).GetField("onUnlocked", BindingFlags.Public | BindingFlags.Instance);
-                    if (field == null)
+                    MemberInfo? member = RelationshipUnlockedMember;
+                    if (member == null)
                         return;
 
 #if IL2CPPMELON
-                    var existing = field.GetValue(Component);
+                    var existing = GetNativeEventValue(member, Component);
                     var remaining = existing != null
                         ? Il2CppSystem.Delegate.Remove(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped)
                         : null;
-                    field.SetValue(Component, remaining);
+                    SetNativeEventValue(member, Component, remaining);
 #else
-                    var existing = field.GetValue(Component);
+                    var existing = GetNativeEventValue(member, Component);
                     var remaining = existing != null
                         ? Delegate.Remove(existing as Delegate, (Delegate)wrapped)
                         : null;
-                    field.SetValue(Component, remaining);
+                    SetNativeEventValue(member, Component, remaining);
 #endif
                 }
                 catch { }
@@ -316,6 +320,39 @@ namespace S1API.Entities
         #endregion
 
         #region Private Helpers
+
+        internal static MemberInfo? ResolveNativeEventMember(
+            string canonicalName,
+            string legacyName)
+        {
+            const BindingFlags flags =
+                BindingFlags.Public |
+                BindingFlags.NonPublic |
+                BindingFlags.Instance;
+            Type relationType = typeof(S1Relation.NPCRelationData);
+            return relationType.GetField(canonicalName, flags) ??
+                   relationType.GetField(legacyName, flags) ??
+                   (MemberInfo?)relationType.GetProperty(canonicalName, flags) ??
+                   relationType.GetProperty(legacyName, flags);
+        }
+
+        private static object? GetNativeEventValue(
+            MemberInfo member,
+            object target) =>
+            member is FieldInfo field
+                ? field.GetValue(target)
+                : ((PropertyInfo)member).GetValue(target);
+
+        private static void SetNativeEventValue(
+            MemberInfo member,
+            object target,
+            object? value)
+        {
+            if (member is FieldInfo field)
+                field.SetValue(target, value);
+            else
+                ((PropertyInfo)member).SetValue(target, value);
+        }
 
         private static UnlockType FromS1(S1Relation.NPCRelationData.EUnlockType t) =>
             t == S1Relation.NPCRelationData.EUnlockType.Recommendation ? UnlockType.Recommendation : UnlockType.DirectApproach;

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -249,7 +249,7 @@ namespace S1API.Internal.Patches
                     contactsApp.SelectionIndicator.position = cachedCircle.Rect.position;
                 };
 
-                EnableDealerIndicator(circle, npc);
+                ApplyRoleIndicators(circle, npc.GetType());
             }
 
             var regionCircles =
@@ -1075,19 +1075,36 @@ namespace S1API.Internal.Patches
         }
 
         /// <summary>
-        /// Enables the dealer indicator for dealer NPCs if a matching child exists on the relation circle.
+        /// Applies the dealer and supplier indicators when matching children exist on the relation circle.
         /// </summary>
-        private static void EnableDealerIndicator(S1Relations.RelationCircle circle, NPC npc)
+        private static void ApplyRoleIndicators(S1Relations.RelationCircle circle, System.Type npcType)
         {
-            if (circle == null || npc == null)
+            if (circle == null || npcType == null)
                 return;
 
-            var indicator = circle.transform?.Find("DealerIndicator");
+            var indicators = GetRoleIndicators(npcType);
+            SetRoleIndicator(circle, "DealerIndicator", indicators.IsDealer);
+            SetRoleIndicator(circle, "SupplierIndicator", indicators.IsSupplier);
+        }
+
+        internal static (bool IsDealer, bool IsSupplier) GetRoleIndicators(System.Type npcType)
+        {
+            if (npcType == null)
+                return (false, false);
+
+            return (NPC.IsDealerType(npcType), NPC.IsSupplierType(npcType));
+        }
+
+        private static void SetRoleIndicator(
+            S1Relations.RelationCircle circle,
+            string indicatorName,
+            bool isActive)
+        {
+            var indicator = circle.transform?.Find(indicatorName);
             if (indicator == null)
                 return;
 
-            var isDealer = NPC.IsDealerType(npc.GetType());
-            indicator.gameObject.SetActive(isDealer);
+            indicator.gameObject.SetActive(isActive);
         }
 
     }

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -1082,9 +1082,22 @@ namespace S1API.Internal.Patches
             if (circle == null || npcType == null)
                 return;
 
+            ApplyRoleIndicators(
+                npcType,
+                (indicatorName, isActive) =>
+                    SetRoleIndicator(circle, indicatorName, isActive));
+        }
+
+        internal static void ApplyRoleIndicators(
+            System.Type npcType,
+            System.Action<string, bool> setRoleIndicator)
+        {
+            if (npcType == null || setRoleIndicator == null)
+                return;
+
             var indicators = GetRoleIndicators(npcType);
-            SetRoleIndicator(circle, "DealerIndicator", indicators.IsDealer);
-            SetRoleIndicator(circle, "SupplierIndicator", indicators.IsSupplier);
+            setRoleIndicator("DealerIndicator", indicators.IsDealer);
+            setRoleIndicator("SupplierIndicator", indicators.IsSupplier);
         }
 
         internal static (bool IsDealer, bool IsSupplier) GetRoleIndicators(System.Type npcType)

--- a/S1API/Internal/Rendering/PresentationWorkbenchView.cs
+++ b/S1API/Internal/Rendering/PresentationWorkbenchView.cs
@@ -191,7 +191,7 @@ namespace S1API.Internal.Rendering
                     {
                         updateCameraFill(parsed);
                     }
-                    else
+                    else if (!IsIncompleteNumericInput(value))
                     {
                         SetStatus("Camera fill must be a finite number.");
                     }
@@ -342,7 +342,9 @@ namespace S1API.Internal.Rendering
                 {
                     update(parsedPosition, parsedRotation, parsedScale);
                 }
-                else
+                else if (!HasIncompleteNumericInput(position) &&
+                         !HasIncompleteNumericInput(rotation) &&
+                         !HasIncompleteNumericInput(scale))
                 {
                     SetStatus("Enter finite numeric values for every axis.");
                 }
@@ -550,6 +552,51 @@ namespace S1API.Internal.Rendering
                 out result) &&
             !float.IsNaN(result) &&
             !float.IsInfinity(result);
+
+        internal static bool IsIncompleteNumericInput(string value)
+        {
+            string text = value?.Trim() ?? string.Empty;
+            if (text.Length == 0 ||
+                text == "+" ||
+                text == "-" ||
+                text == "." ||
+                text == "+." ||
+                text == "-.")
+            {
+                return true;
+            }
+
+            int exponentIndex = text.IndexOf('e');
+            if (exponentIndex < 0)
+            {
+                exponentIndex = text.IndexOf('E');
+            }
+
+            if (exponentIndex < 0)
+            {
+                return false;
+            }
+
+            int exponentLength = text.Length - exponentIndex - 1;
+            return exponentLength == 0 ||
+                   (exponentLength == 1 &&
+                    (text[text.Length - 1] == '+' ||
+                     text[text.Length - 1] == '-'));
+        }
+
+        private static bool HasIncompleteNumericInput(
+            IReadOnlyList<InputField> fields)
+        {
+            for (int index = 0; index < fields.Count; index++)
+            {
+                if (IsIncompleteNumericInput(fields[index].text))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static string Format(float value) =>
             value.ToString("0.######", CultureInfo.InvariantCulture);

--- a/S1API/Internal/Rendering/PresentationWorkbenchView.cs
+++ b/S1API/Internal/Rendering/PresentationWorkbenchView.cs
@@ -195,7 +195,8 @@ namespace S1API.Internal.Rendering
                     {
                         SetStatus("Camera fill must be a finite number.");
                     }
-                });
+                },
+                live: true);
 
             Button resetButton =
                 CreateButton("Reset", "Reset", controls.transform);
@@ -219,7 +220,7 @@ namespace S1API.Internal.Rendering
 
             _status = CreateText(
                 "Status",
-                "Edits are local and temporary.",
+                "Preview edits are temporary. Copy C# to persist them.",
                 controls.transform,
                 15,
                 TextAnchor.UpperLeft,
@@ -262,14 +263,14 @@ namespace S1API.Internal.Rendering
             _iconRow.SetActive(icon);
             _previewPanel.SetActive(mode != PresentationWorkbenchMode.FirstPerson);
             _fitLabel.text = fitToCamera ? "Fit: On" : "Fit: Off";
-            _cameraFillField.text = Format(cameraFill);
+            _cameraFillField.SetTextWithoutNotify(Format(cameraFill));
             SetVector(_positionFields, transform.LocalPosition);
             SetVector(_rotationFields, transform.LocalEulerAngles);
             SetVector(_scaleFields, transform.LocalScale);
             SetStatus(
                 mode == PresentationWorkbenchMode.Avatar
-                    ? "Drag the preview to orbit; use the mouse wheel to zoom."
-                    : "Edits are local and temporary.");
+                    ? "Drag to orbit and scroll to zoom. Preview edits are temporary."
+                    : "Preview edits update live. Copy C# to persist them.");
         }
 
         internal void SetPreview(Texture? texture)
@@ -296,7 +297,9 @@ namespace S1API.Internal.Rendering
             {
                 EventHelper.RemoveListener(
                     binding.Action,
-                    binding.Input.onEndEdit);
+                    binding.Live
+                        ? binding.Input.onValueChanged
+                        : binding.Input.onEndEdit);
             }
 
             _buttonBindings.Clear();
@@ -347,9 +350,9 @@ namespace S1API.Internal.Rendering
 
             for (int i = 0; i < 3; i++)
             {
-                Bind(position[i], Apply);
-                Bind(rotation[i], Apply);
-                Bind(scale[i], Apply);
+                Bind(position[i], Apply, live: true);
+                Bind(rotation[i], Apply, live: true);
+                Bind(scale[i], Apply, live: true);
             }
         }
 
@@ -359,11 +362,21 @@ namespace S1API.Internal.Rendering
             _buttonBindings.Add(new ButtonBinding(button, action));
         }
 
-        private void Bind(InputField input, Action<string> action)
+        private void Bind(
+            InputField input,
+            Action<string> action,
+            bool live = false)
         {
-            EventHelper.AddListener(action, input.onEndEdit);
-            _inputBindings.Add(new InputBinding(input, action));
+            Action<string> bindingAction = CreateInputBindingAction(action);
+            EventHelper.AddListener(
+                bindingAction,
+                live ? input.onValueChanged : input.onEndEdit);
+            _inputBindings.Add(new InputBinding(input, bindingAction, live));
         }
+
+        internal static Action<string> CreateInputBindingAction(
+            Action<string> action) =>
+            value => action(value);
 
         private static GameObject CreateVectorRow(
             string label,
@@ -508,9 +521,9 @@ namespace S1API.Internal.Rendering
 
         private static void SetVector(InputField[] fields, Vector3 value)
         {
-            fields[0].text = Format(value.x);
-            fields[1].text = Format(value.y);
-            fields[2].text = Format(value.z);
+            fields[0].SetTextWithoutNotify(Format(value.x));
+            fields[1].SetTextWithoutNotify(Format(value.y));
+            fields[2].SetTextWithoutNotify(Format(value.z));
         }
 
         private static bool TryRead(
@@ -556,15 +569,21 @@ namespace S1API.Internal.Rendering
 
         private sealed class InputBinding
         {
-            internal InputBinding(InputField input, Action<string> action)
+            internal InputBinding(
+                InputField input,
+                Action<string> action,
+                bool live)
             {
                 Input = input;
                 Action = action;
+                Live = live;
             }
 
             internal InputField Input { get; }
 
             internal Action<string> Action { get; }
+
+            internal bool Live { get; }
         }
     }
 }


### PR DESCRIPTION
## Summary

- render custom supplier relationship circles with the native supplier indicator instead of the customer appearance
- bind `NPCRelationship` callbacks to the current canonical native relationship members while retaining legacy member-name fallback
- recapture presentation workbench previews as transform and camera-fill fields change, while preserving correct listener cleanup
- add focused regression coverage for supplier/dealer/customer roles, relationship event resolution, and workbench input bindings

## Root cause

The contacts patch only activated the dealer indicator, relationship event binding reflected stale lowercase member names, and workbench inputs shared callback identities on end-edit listeners. Together these left supplier circles styled as customers, made relationship unlock callbacks silently no-op on current game types, and prevented live icon recapture when transform fields changed.

## Impact

Custom suppliers now use the expected red supplier relationship styling, relationship unlock/change subscriptions resolve against current native types, and presentation rotation/scale/camera-fill edits update the preview without replacing runtime definitions.

## Validation

- Mono focused tests: 12/12 passed
- IL2CPP focused tests: 11/11 passed
- Mono full suite: 369/369 passed
- IL2CPP suite: 358 tests passed across isolated groups with zero assertion failures; the combined local process still hits the pre-existing `Il2CppObjectBase` finalizer crash when test-created wrappers outlive the process without `GameAssembly`
- `git diff --check` passed

No proprietary game assemblies, generated wrappers, prefabs, or exported assets are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relation circles now display both dealer and supplier indicators where applicable.
  * Camera fill and vector inputs update live while editing.
  * Preview status messages now explain how to copy C# code to preserve changes.

* **Bug Fixes**
  * Improved relationship event handling across supported game versions.
  * Updated input cleanup and value updates for more reliable editing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->