### PR TITLE
feat: support native supplier stashes and custom chemistry recipes

### DIFF
--- a/S1API.Tests/Entities/SupplierDataBuilderDeferredItemTests.cs
+++ b/S1API.Tests/Entities/SupplierDataBuilderDeferredItemTests.cs
@@ -1,4 +1,6 @@
 using S1API.Entities.Supplier;
+using S1API.DeadDrops;
+using S1API.DeadDrops.Native;
 
 namespace S1API.Tests.Entities;
 
@@ -25,5 +27,29 @@ public sealed class SupplierDataBuilderDeferredItemTests
         var data = builder.BuildInternal();
 
         Assert.Single(data.DeliveryItemIds);
+    }
+
+    [Fact]
+    public void WithStashDeadDrop_StoresTypedGuidWithoutSceneResolution()
+    {
+        var builder = new SupplierDataBuilder()
+            .WithStashDeadDrop<BehindBank>();
+
+        var data = builder.BuildInternal();
+
+        Assert.Equal(
+            "e5399b56-22a5-4a2c-a254-cc81e3ab2f75",
+            data.StashDeadDropGuid);
+    }
+
+    [Fact]
+    public void GetGuid_RejectsUnannotatedIdentifiers()
+    {
+        Assert.Throws<InvalidOperationException>(
+            DeadDropManager.GetGuid<MissingGuid>);
+    }
+
+    private sealed class MissingGuid : IDeadDropIdentifier
+    {
     }
 }

--- a/S1API/DeadDrops/DeadDropGuidAttribute.cs
+++ b/S1API/DeadDrops/DeadDropGuidAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace S1API.DeadDrops
+{
+    /// <summary>
+    /// Associates a typed dead-drop identifier with a native scene GUID.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class DeadDropGuidAttribute : Attribute
+    {
+        public DeadDropGuidAttribute(string guid)
+        {
+            if (!System.Guid.TryParse(guid, out System.Guid parsed))
+                throw new ArgumentException("The dead-drop GUID is invalid.", nameof(guid));
+
+            Guid = parsed.ToString("D");
+        }
+
+        public string Guid { get; }
+    }
+}

--- a/S1API/DeadDrops/DeadDropManager.cs
+++ b/S1API/DeadDrops/DeadDropManager.cs
@@ -6,6 +6,7 @@ using S1Economy = ScheduleOne.Economy;
 
 using System;
 using System.Linq;
+using System.Reflection;
 using UnityEngine;
 
 namespace S1API.DeadDrops
@@ -36,6 +37,30 @@ namespace S1API.DeadDrops
         /// <returns>The dead drop instance if found; otherwise null.</returns>
         public static DeadDropInstance? GetByGUID(string guid) =>
             All.FirstOrDefault(d => string.Equals(d.GUID, guid, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Gets a dead drop through a type annotated with <see cref="DeadDropGuidAttribute"/>.
+        /// </summary>
+        public static DeadDropInstance? Get<T>() where T : IDeadDropIdentifier
+        {
+            return GetByGUID(GetGuid<T>());
+        }
+
+        /// <summary>
+        /// Gets the stable native GUID declared by a typed dead-drop identifier.
+        /// </summary>
+        public static string GetGuid<T>() where T : IDeadDropIdentifier
+        {
+            DeadDropGuidAttribute? identifier =
+                typeof(T).GetCustomAttribute<DeadDropGuidAttribute>();
+            if (identifier == null)
+            {
+                throw new InvalidOperationException(
+                    $"Dead-drop identifier '{typeof(T).FullName}' has no {nameof(DeadDropGuidAttribute)}.");
+            }
+
+            return identifier.Guid;
+        }
 
         /// <summary>
         /// Gets the closest dead drop to a world position.

--- a/S1API/DeadDrops/IDeadDropIdentifier.cs
+++ b/S1API/DeadDrops/IDeadDropIdentifier.cs
@@ -1,0 +1,9 @@
+namespace S1API.DeadDrops
+{
+    /// <summary>
+    /// Marker interface for types used with <see cref="DeadDropManager.Get{T}"/>.
+    /// </summary>
+    public interface IDeadDropIdentifier
+    {
+    }
+}

--- a/S1API/DeadDrops/NativeDeadDrops.cs
+++ b/S1API/DeadDrops/NativeDeadDrops.cs
@@ -1,0 +1,28 @@
+namespace S1API.DeadDrops.Native
+{
+    [DeadDropGuid("fe1782b0-64e5-4ae6-a3f9-56af509af104")] public sealed class BehindSupermarket : IDeadDropIdentifier { }
+    [DeadDropGuid("d66b3fd6-7b7f-4e98-b000-6d5a197f7437")] public sealed class BehindMotelOffice : IDeadDropIdentifier { }
+    [DeadDropGuid("eda8c6a4-07be-4d8f-97f4-ddd6dfca19df")] public sealed class SkatePark : IDeadDropIdentifier { }
+    [DeadDropGuid("64d10032-64a9-4cd9-8750-8048d71c5029")] public sealed class BehindGasMart : IDeadDropIdentifier { }
+    [DeadDropGuid("0fd91cf3-ac6a-41ce-968f-1f356f996a83")] public sealed class UnderWestBridge : IDeadDropIdentifier { }
+    [DeadDropGuid("f5614c42-2c74-42d5-bee2-025e84718792")] public sealed class BehindCasino : IDeadDropIdentifier { }
+    [DeadDropGuid("79200bb6-7d39-44d9-ab22-c63f136d8cdf")] public sealed class TacoTicklersExteriorWall : IDeadDropIdentifier { }
+    [DeadDropGuid("d28c727e-5175-4989-8c33-2a36c159c817")] public sealed class TownHallFountain : IDeadDropIdentifier { }
+    [DeadDropGuid("fde97bca-d21a-476c-bf03-b00768a45030")] public sealed class PawnShopWestWall : IDeadDropIdentifier { }
+    [DeadDropGuid("58ec86b5-647e-456d-9266-4cd77413e9c3")] public sealed class BehindSlopShop : IDeadDropIdentifier { }
+    [DeadDropGuid("94eef741-d688-4380-ac64-cf190e812b10")] public sealed class Gazebo : IDeadDropIdentifier { }
+    [DeadDropGuid("baf08ceb-a0e7-4e4a-baa8-6b4cc992cb15")] public sealed class BehindRandysBaitAndTackle : IDeadDropIdentifier { }
+    [DeadDropGuid("e5399b56-22a5-4a2c-a254-cc81e3ab2f75")] public sealed class BehindBank : IDeadDropIdentifier { }
+    [DeadDropGuid("51e8f8ec-adcb-4800-8020-55cc24f9ba40")] public sealed class BehindCrimsonCanary : IDeadDropIdentifier { }
+    [DeadDropGuid("766389cd-b2e3-44ec-84fe-9c59eccfcdd7")] public sealed class BehindThompsonConstruction : IDeadDropIdentifier { }
+    [DeadDropGuid("4ac50ff1-ad3c-415b-aa77-c80249dfa473")] public sealed class CentralCanal : IDeadDropIdentifier { }
+    [DeadDropGuid("dd3d22f1-da56-4673-9203-640eeaf915fc")] public sealed class NorthArcadeWall : IDeadDropIdentifier { }
+    [DeadDropGuid("b77ed1a0-c729-41d5-b8a2-81b480ca971f")] public sealed class BrownApartmentBlock : IDeadDropIdentifier { }
+    [DeadDropGuid("683fa5b9-c55d-4b3f-8026-6f29857d09d1")] public sealed class BehindMedicalPractice : IDeadDropIdentifier { }
+    [DeadDropGuid("555e565d-2f65-4882-9edb-7167168b2e00")] public sealed class BehindLaundromat : IDeadDropIdentifier { }
+    [DeadDropGuid("aaea12a7-ee38-47ba-aeb8-fb0d45a03957")] public sealed class BehindAutoShop : IDeadDropIdentifier { }
+    [DeadDropGuid("eff8fff2-0f89-4936-aef5-c4d383ea4f50")] public sealed class GreyDocksBuilding : IDeadDropIdentifier { }
+    [DeadDropGuid("5aeef10c-955d-4fdb-9061-38f4ad7a6289")] public sealed class BehindGroceryStore : IDeadDropIdentifier { }
+    [DeadDropGuid("86835825-f5f8-454d-9c74-c31e257f9cc2")] public sealed class BehindFireStation : IDeadDropIdentifier { }
+    [DeadDropGuid("3ed706ba-458d-44b5-95cd-d65e4a699043")] public sealed class BehindTopTattoo : IDeadDropIdentifier { }
+}

--- a/S1API/Entities/Supplier/SupplierDataBuilder.cs
+++ b/S1API/Entities/Supplier/SupplierDataBuilder.cs
@@ -6,6 +6,7 @@ using S1ItemFramework = ScheduleOne.ItemFramework;
 
 using System;
 using System.Collections.Generic;
+using S1API.DeadDrops;
 using S1API.Internal.Utils;
 using S1API.Items;
 using StorableItemDefinition = S1API.Items.Storable.StorableItemDefinition;
@@ -29,6 +30,7 @@ namespace S1API.Entities.Supplier
                 "My friend <NAME> can hook you up with <PRODUCT>. I've passed your number on to them.";
             public string SupplierUnlockHint { get; set; } =
                 "You can now order <PRODUCT> from <NAME>. <PRODUCT> can be used to <PURPOSE>.";
+            public string? StashDeadDropGuid { get; set; }
 
             internal IReadOnlyList<S1ItemFramework.StorableItemDefinition>
                 ResolveDeliveryItems()
@@ -196,6 +198,50 @@ namespace S1API.Entities.Supplier
         public SupplierDataBuilder WithUnlockHint(string? hint)
         {
             data.SupplierUnlockHint = hint ?? string.Empty;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses an existing scene dead drop as this supplier's debt-payment stash.
+        /// </summary>
+        /// <remarks>
+        /// The selected dead drop is reserved from normal supplier delivery selection.
+        /// Omitting this option preserves the generated stash beside the supplier spawn.
+        /// </remarks>
+        /// <param name="deadDrop">The dead drop to use as the supplier stash.</param>
+        /// <returns>The current builder for chaining.</returns>
+        public SupplierDataBuilder WithStashDeadDrop(DeadDropInstance deadDrop)
+        {
+            if (deadDrop == null)
+                throw new ArgumentNullException(nameof(deadDrop));
+
+            return WithStashDeadDrop(deadDrop.GUID);
+        }
+
+        /// <summary>
+        /// Uses the native dead drop represented by <typeparamref name="T"/> as
+        /// this supplier's debt-payment stash.
+        /// </summary>
+        public SupplierDataBuilder WithStashDeadDrop<T>()
+            where T : IDeadDropIdentifier =>
+            WithStashDeadDrop(DeadDropManager.GetGuid<T>());
+
+        /// <summary>
+        /// Uses the scene dead drop with the specified GUID as this supplier's
+        /// debt-payment stash.
+        /// </summary>
+        /// <param name="deadDropGuid">The stable GUID exposed by <see cref="DeadDropInstance.GUID"/>.</param>
+        /// <returns>The current builder for chaining.</returns>
+        public SupplierDataBuilder WithStashDeadDrop(string deadDropGuid)
+        {
+            if (!Guid.TryParse(deadDropGuid, out Guid parsed))
+            {
+                throw new ArgumentException(
+                    "The stash dead-drop GUID must be a valid GUID.",
+                    nameof(deadDropGuid));
+            }
+
+            data.StashDeadDropGuid = parsed.ToString("D");
             return this;
         }
 

--- a/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
+++ b/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
@@ -77,13 +77,18 @@ namespace S1API.Internal.Entities
             try
             {
                 string stableId = SupplierRuntimeIds.ResolveStableId(supplier.gameObject, supplierId);
-                SupplierStashRuntime.Bind(supplier, stableId);
+                SupplierStashRuntime.Bind(
+                    supplier,
+                    stableId,
+                    config?.StashDeadDropGuid);
                 S1Shop.ShopInterface shop = SupplierShopRuntime.Ensure(supplier, stableId, config);
                 bool vehicleReady = SupplierDeliveryVehicleRuntime.Ensure(supplier, shop, stableId);
                 bool meetingReady = SupplierMeetingRuntime.EnsureSelected(supplier);
                 bool meetingDialogueReady =
                     SupplierMeetingRuntime.PrepareNativeStartDialogue(supplier);
-                SupplierStashRuntime.SchedulePlacement(supplier);
+                SupplierStashRuntime.SchedulePlacement(
+                    supplier,
+                    config?.StashDeadDropGuid);
 
                 return shop != null
                        && vehicleReady

--- a/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
@@ -19,7 +19,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using HarmonyLib;
 using MelonLoader;
+using S1API.DeadDrops;
 using S1API.Internal.Utils;
 using S1API.Logging;
 using UnityEngine;
@@ -39,6 +41,9 @@ namespace S1API.Internal.Entities.Suppliers
         private static readonly Dictionary<int, GameObject> OwnedStashes = new Dictionary<int, GameObject>();
         private static readonly HashSet<int> InitializedStashes = new HashSet<int>();
         private static readonly HashSet<int> ScheduledPlacements = new HashSet<int>();
+        private static readonly HashSet<int> ConfiguredStashes = new HashSet<int>();
+        private static readonly Dictionary<int, string> ConfiguredStashGuids =
+            new Dictionary<int, string>();
 
         internal static void EnsurePrefab(GameObject prefabRoot)
         {
@@ -103,8 +108,17 @@ namespace S1API.Internal.Entities.Suppliers
             }
         }
 
-        internal static void Bind(S1Economy.Supplier supplier, string stableId)
+        internal static void Bind(
+            S1Economy.Supplier supplier,
+            string stableId,
+            string? stashDeadDropGuid)
         {
+            if (!string.IsNullOrWhiteSpace(stashDeadDropGuid))
+            {
+                BindDeadDrop(supplier, stashDeadDropGuid);
+                return;
+            }
+
             S1Economy.SupplierStash stash = BindPrefab(supplier);
 
             if (stash.Storage != null
@@ -134,7 +148,11 @@ namespace S1API.Internal.Entities.Suppliers
 
         internal static bool TryInitialize(S1Economy.SupplierStash stash)
         {
-            if (stash == null || stash.gameObject == null || stash.gameObject.name != StashObjectName)
+            if (stash == null || stash.gameObject == null)
+                return false;
+
+            bool configuredStash = ConfiguredStashes.Contains(stash.GetInstanceID());
+            if (!configuredStash && stash.gameObject.name != StashObjectName)
                 return false;
 
             int instanceId = stash.GetInstanceID();
@@ -147,7 +165,8 @@ namespace S1API.Internal.Entities.Suppliers
                 return true;
             }
 
-            if (CrossType.Is(stash.Storage, out S1Storage.WorldStorageEntity worldStorage))
+            if (!configuredStash &&
+                CrossType.Is(stash.Storage, out S1Storage.WorldStorageEntity worldStorage))
             {
                 string stableId = SupplierRuntimeIds.ResolveStableId(
                     stash.Supplier.gameObject,
@@ -159,9 +178,14 @@ namespace S1API.Internal.Entities.Suppliers
             stash.IntObj.enabled = stash.Supplier.RelationData.Unlocked;
             stash.IntObj.onInteractStart.AddListener((UnityAction)(() => UpdateSubtitle(stash)));
             stash.Storage.StorageEntityName = $"{stash.Supplier.FullName}'s Stash";
+            if (stash.StashPoI != null)
+            {
+                stash.StashPoI.enabled = stash.Supplier.RelationData.Unlocked;
+                stash.StashPoI.SetMainText($"{stash.Supplier.FullName}'s Stash");
+            }
 #if IL2CPPMELON
             var onUnlocked = DelegateSupport.ConvertDelegate<Il2CppSystem.Action<S1Relation.NPCRelationData.EUnlockType, bool>>(
-                new Action<S1Relation.NPCRelationData.EUnlockType, bool>((_, _) => stash.IntObj.enabled = true));
+                new Action<S1Relation.NPCRelationData.EUnlockType, bool>((_, _) => EnableUnlockedStash(stash)));
             stash.Supplier.RelationData.OnUnlocked = Il2CppSystem.Delegate
                 .Combine(stash.Supplier.RelationData.OnUnlocked, onUnlocked)
                 .Cast<Il2CppSystem.Action<S1Relation.NPCRelationData.EUnlockType, bool>>();
@@ -172,15 +196,27 @@ namespace S1API.Internal.Entities.Suppliers
                 .Combine(stash.Storage.onContentsChanged, onContentsChanged)
                 .Cast<Il2CppSystem.Action>();
 #else
-            stash.Supplier.RelationData.OnUnlocked += (_, _) => stash.IntObj.enabled = true;
+            stash.Supplier.RelationData.OnUnlocked += (_, _) => EnableUnlockedStash(stash);
             stash.Storage.onContentsChanged += () => Recalculate(stash);
 #endif
             Recalculate(stash);
             return true;
         }
 
-        internal static void SchedulePlacement(S1Economy.Supplier supplier)
+        private static void EnableUnlockedStash(S1Economy.SupplierStash stash)
         {
+            stash.IntObj.enabled = true;
+            if (stash.StashPoI != null)
+                stash.StashPoI.enabled = true;
+        }
+
+        internal static void SchedulePlacement(
+            S1Economy.Supplier supplier,
+            string? stashDeadDropGuid)
+        {
+            if (!string.IsNullOrWhiteSpace(stashDeadDropGuid))
+                return;
+
             int supplierKey = supplier.GetInstanceID();
             if (!ScheduledPlacements.Add(supplierKey))
                 return;
@@ -190,7 +226,9 @@ namespace S1API.Internal.Entities.Suppliers
 
         internal static S1Economy.SupplierStash? Find(S1Economy.Supplier supplier)
         {
-            if (supplier.Stash != null && supplier.Stash.gameObject.name == StashObjectName)
+            if (supplier.Stash != null &&
+                (supplier.Stash.gameObject.name == StashObjectName ||
+                 ConfiguredStashes.Contains(supplier.Stash.GetInstanceID())))
                 return supplier.Stash;
 
             if (OwnedStashes.TryGetValue(supplier.GetInstanceID(), out GameObject? ownedStash)
@@ -208,6 +246,11 @@ namespace S1API.Internal.Entities.Suppliers
                 return;
 
             int supplierKey = supplier.GetInstanceID();
+            if (ConfiguredStashGuids.Remove(supplierKey, out string? configuredGuid) &&
+                supplier.Stash != null)
+            {
+                ConfiguredStashes.Remove(supplier.Stash.GetInstanceID());
+            }
             if (OwnedStashes.TryGetValue(supplierKey, out GameObject? stashObject))
             {
                 Destroy(stashObject);
@@ -225,6 +268,8 @@ namespace S1API.Internal.Entities.Suppliers
             OwnedStashes.Clear();
             InitializedStashes.Clear();
             ScheduledPlacements.Clear();
+            ConfiguredStashes.Clear();
+            ConfiguredStashGuids.Clear();
         }
 
         private static IEnumerator PlaceAfterSpawn(S1Economy.Supplier supplier, int supplierKey)
@@ -273,6 +318,64 @@ namespace S1API.Internal.Entities.Suppliers
                 .GetComponentsInChildren<S1Economy.SupplierStash>(true)
                 .FirstOrDefault(candidate => candidate != null && candidate.gameObject.name == StashObjectName);
         }
+
+        private static void BindDeadDrop(
+            S1Economy.Supplier supplier,
+            string deadDropGuid)
+        {
+            DeadDropInstance deadDrop =
+                DeadDropManager.GetByGUID(deadDropGuid) ??
+                throw new InvalidOperationException(
+                    $"Supplier stash dead drop '{deadDropGuid}' is not present in the scene.");
+            S1Economy.DeadDrop nativeDeadDrop = deadDrop.S1DeadDrop;
+            int supplierKey = supplier.GetInstanceID();
+
+            foreach (KeyValuePair<int, string> reservation in ConfiguredStashGuids)
+            {
+                if (reservation.Key != supplierKey &&
+                    string.Equals(
+                        reservation.Value,
+                        deadDrop.GUID,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Dead drop '{deadDrop.Name}' is already assigned to another supplier stash.");
+                }
+            }
+
+            S1Economy.SupplierStash stash =
+                nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
+                nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
+            S1Storage.StorageEntityInteractable interactable =
+                nativeDeadDrop.Storage.GetComponent<S1Storage.StorageEntityInteractable>() ??
+                nativeDeadDrop.Storage.GetComponentInChildren<S1Storage.StorageEntityInteractable>(true) ??
+                throw new InvalidOperationException(
+                    $"Dead drop '{deadDrop.Name}' has no storage interaction component.");
+
+            stash.Supplier = supplier;
+            stash.Storage = nativeDeadDrop.Storage;
+            stash.IntObj = interactable;
+            stash.Light = nativeDeadDrop.Light;
+            stash.StashPoI = nativeDeadDrop.PoI;
+            stash.locationDescription = nativeDeadDrop.DeadDropDescription;
+            supplier.Stash = stash;
+
+            ConfiguredStashes.Add(stash.GetInstanceID());
+            ConfiguredStashGuids[supplierKey] = deadDrop.GUID;
+        }
+
+        internal static bool IsReservedDeadDrop(S1Economy.DeadDrop deadDrop)
+        {
+            if (deadDrop == null)
+                return false;
+
+            string guid = deadDrop.GUID.ToString("D");
+            return ConfiguredStashGuids.Values.Any(value =>
+                string.Equals(value, guid, StringComparison.OrdinalIgnoreCase));
+        }
+
+        internal static bool HasReservedDeadDrops =>
+            ConfiguredStashGuids.Count > 0;
 
         private static void ConfigureIdentity(S1Storage.WorldStorageEntity storage, string stableId)
         {

--- a/S1API/Internal/Patches/ChemistryStationPatches.cs
+++ b/S1API/Internal/Patches/ChemistryStationPatches.cs
@@ -40,7 +40,6 @@ namespace S1API.Internal.Patches
                 "SetSelectedRecipe");
 
         private static bool _loggedRecipeEntriesMissing;
-        private static bool _loggedChemistryStationUiMissing;
         private static bool _loggedSetSelectedRecipeMissing;
 
         private sealed class CanvasInjectionState
@@ -55,32 +54,8 @@ namespace S1API.Internal.Patches
             return CanvasStateTable.GetValue(canvas, _ => new CanvasInjectionState());
         }
 
-        private static Type? ResolveChemistryStationUiType()
-        {
-            return typeof(S1UIStations.ChemistryStationInterface);
-        }
-
-        private static IEnumerable<MethodBase> ResolveChemistryStationUiMethods(string methodName)
-        {
-            var type = ResolveChemistryStationUiType();
-            if (type == null)
-            {
-                if (!_loggedChemistryStationUiMissing)
-                {
-                    _loggedChemistryStationUiMissing = true;
-                    Logger.Warning("[S1API] Chemistry station UI type could not be resolved. Recipe UI injection will be skipped.");
-                }
-
-                yield break;
-            }
-
-            var method = AccessTools.Method(type, methodName);
-            if (method != null)
-                yield return method;
-        }
-
         private static bool TryGetRecipeEntriesList(
-            object canvas,
+            S1UIStations.ChemistryStationInterface canvas,
 #if IL2CPPMELON
             out Il2CppSystem.Collections.Generic.List<S1UIStations.StationRecipeEntry>? entries
 #else
@@ -94,12 +69,12 @@ namespace S1API.Internal.Patches
 
             try
             {
-                var value = ReflectionUtils.TryGetFieldOrProperty(canvas, "recipeEntries");
                 entries =
 #if IL2CPPMELON
-                    value as Il2CppSystem.Collections.Generic.List<S1UIStations.StationRecipeEntry>;
+                    canvas.recipeEntries;
 #else
-                    value as List<S1UIStations.StationRecipeEntry>;
+                    ReflectionUtils.TryGetFieldOrProperty(canvas, "recipeEntries")
+                        as List<S1UIStations.StationRecipeEntry>;
 #endif
             }
             catch
@@ -110,39 +85,24 @@ namespace S1API.Internal.Patches
             return entries != null;
         }
 
-        [HarmonyPatch]
-        private static class ChemistryStationAwakePatch
+        [HarmonyPatch(typeof(S1UIStations.ChemistryStationInterface), "Awake")]
+        [HarmonyPrefix]
+        private static void ChemistryStationAwakePrefix(
+            S1UIStations.ChemistryStationInterface __instance)
         {
-            [HarmonyTargetMethods]
-            private static IEnumerable<MethodBase> TargetMethods()
-            {
-                return ResolveChemistryStationUiMethods("Awake");
-            }
-
-            [HarmonyPrefix]
-            private static void Prefix(object __instance)
-            {
-                AwakePrefix(__instance);
-            }
+            AwakePrefix(__instance);
         }
 
-        [HarmonyPatch]
-        private static class ChemistryStationOpenPatch
+        [HarmonyPatch(typeof(S1UIStations.ChemistryStationInterface), "Open")]
+        [HarmonyPrefix]
+        private static void ChemistryStationOpenPrefix(
+            S1UIStations.ChemistryStationInterface __instance,
+            S1ObjectScripts.ChemistryStation __0)
         {
-            [HarmonyTargetMethods]
-            private static IEnumerable<MethodBase> TargetMethods()
-            {
-                return ResolveChemistryStationUiMethods("Open");
-            }
-
-            [HarmonyPrefix]
-            private static void Prefix(object __instance, S1ObjectScripts.ChemistryStation __0)
-            {
-                OpenPrefix(__instance, __0);
-            }
+            OpenPrefix(__instance, __0);
         }
 
-        private static void AwakePrefix(object __instance)
+        private static void AwakePrefix(S1UIStations.ChemistryStationInterface __instance)
         {
             try
             {
@@ -154,7 +114,9 @@ namespace S1API.Internal.Patches
             }
         }
 
-        private static void OpenPrefix(object __instance, S1ObjectScripts.ChemistryStation __0)
+        private static void OpenPrefix(
+            S1UIStations.ChemistryStationInterface __instance,
+            S1ObjectScripts.ChemistryStation __0)
         {
             try
             {
@@ -168,7 +130,8 @@ namespace S1API.Internal.Patches
             }
         }
 
-        private static void InjectRegisteredRecipes(object canvas)
+        private static void InjectRegisteredRecipes(
+            S1UIStations.ChemistryStationInterface canvas)
         {
             if (canvas == null)
                 return;
@@ -177,12 +140,7 @@ namespace S1API.Internal.Patches
             if (registered.Count == 0)
                 return;
 
-            var recipes =
-#if IL2CPPMELON
-                ReflectionUtils.TryGetFieldOrProperty(canvas, "Recipes") as Il2CppSystem.Collections.Generic.List<S1StationFramework.StationRecipe>;
-#else
-                ReflectionUtils.TryGetFieldOrProperty(canvas, "Recipes") as List<S1StationFramework.StationRecipe>;
-#endif
+            var recipes = canvas.Recipes;
             if (recipes == null)
                 return;
 
@@ -212,7 +170,8 @@ namespace S1API.Internal.Patches
             }
         }
 
-        private static void EnsureRecipeEntries(object canvas)
+        private static void EnsureRecipeEntries(
+            S1UIStations.ChemistryStationInterface canvas)
         {
             if (canvas == null)
                 return;
@@ -254,8 +213,8 @@ namespace S1API.Internal.Patches
 
                 try
                 {
-                    var recipeEntryPrefab = ReflectionUtils.TryGetFieldOrProperty(canvas, "RecipeEntryPrefab") as S1UIStations.StationRecipeEntry;
-                    var recipeContainer = ReflectionUtils.TryGetFieldOrProperty(canvas, "RecipeContainer") as Transform;
+                    var recipeEntryPrefab = canvas.RecipeEntryPrefab;
+                    var recipeContainer = canvas.RecipeContainer;
                     if (recipeEntryPrefab == null || recipeContainer == null)
                         return;
 

--- a/S1API/Internal/Patches/SupplierRuntimePatches.cs
+++ b/S1API/Internal/Patches/SupplierRuntimePatches.cs
@@ -11,10 +11,13 @@ using S1NPCs = ScheduleOne.NPCs;
 #endif
 
 using System;
+using System.Linq;
 using HarmonyLib;
 using S1API.Entities;
 using S1API.Internal.Entities;
+using S1API.Internal.Entities.Suppliers;
 using S1API.Internal.Utils;
+using UnityEngine;
 
 namespace S1API.Internal.Patches
 {
@@ -121,6 +124,42 @@ namespace S1API.Internal.Patches
         private static bool SupplierStashStartPrefix(S1Economy.SupplierStash __instance)
         {
             return !SupplierRuntimeCoordinator.TryInitializeGeneratedStash(__instance);
+        }
+
+        [HarmonyPatch(
+            typeof(S1Economy.DeadDrop),
+            nameof(S1Economy.DeadDrop.GetRandomEmptyDrop))]
+        [HarmonyPrefix]
+        private static bool ExcludeSupplierStashesFromDeadDropSelection(
+            Vector3 origin,
+            ref S1Economy.DeadDrop __result)
+        {
+            if (!SupplierStashRuntime.HasReservedDeadDrops)
+                return true;
+
+            var candidates = S1Economy.DeadDrop.DeadDrops
+                .ToArray()
+                .Where(drop =>
+                    drop != null &&
+                    drop.Storage.ItemCount == 0 &&
+                    !SupplierStashRuntime.IsReservedDeadDrop(drop))
+                .OrderBy(drop => Vector3.Distance(drop.transform.position, origin))
+                .ToList();
+
+            if (candidates.Count > 1)
+                candidates.RemoveAt(0);
+            if (candidates.Count > 1)
+            {
+                int removeStart = candidates.Count / 2;
+                candidates.RemoveRange(
+                    removeStart,
+                    candidates.Count - removeStart);
+            }
+
+            __result = candidates.Count == 0
+                ? null!
+                : candidates[UnityEngine.Random.Range(0, candidates.Count)];
+            return false;
         }
 
         [HarmonyPatch(

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -163,13 +163,13 @@
 
     <!-- Automated local deployment -->
     <Target Name="PostBuildIl2CppMelon" AfterTargets="Build" Condition="'$(AutomateLocalDeployment)' == 'true' and '$(Configuration)' == 'Il2CppMelon'">
-        <Message Text="[IL2CPP/MelonLoader] Deploying S1API to local Il2Cpp plugins folder" Importance="high" />
-        <Copy SourceFiles=".\bin\Il2CppMelon\net6.0\S1API.dll" DestinationFiles="$(LocalIl2CppDeploymentPath)\Plugins\S1API\S1API.Il2Cpp.MelonLoader.dll" />
+        <Message Text="[IL2CPP/MelonLoader] Deploying S1API to local Il2Cpp mods folder" Importance="high" />
+        <Copy SourceFiles=".\bin\Il2CppMelon\net6.0\S1API.dll" DestinationFiles="$(LocalIl2CppDeploymentPath)\Mods\S1API.Il2Cpp.MelonLoader.dll" />
     </Target>
 
     <Target Name="PostBuildMonoMelon" AfterTargets="Build" Condition="'$(AutomateLocalDeployment)' == 'true' and '$(Configuration)' == 'MonoMelon'">
-        <Message Text="[Mono/MelonLoader] Deploying S1API to local Mono plugins folder" Importance="high" />
-        <Copy SourceFiles=".\bin\MonoMelon\netstandard2.1\S1API.dll" DestinationFiles="$(LocalMonoDeploymentPath)\Plugins\S1API\S1API.Mono.MelonLoader.dll" />
+        <Message Text="[Mono/MelonLoader] Deploying S1API to local Mono mods folder" Importance="high" />
+        <Copy SourceFiles=".\bin\MonoMelon\netstandard2.1\S1API.dll" DestinationFiles="$(LocalMonoDeploymentPath)\Mods\S1API.Mono.MelonLoader.dll" />
     </Target>
 
 </Project>

--- a/S1API/Stations/ChemistryStationRecipeBuilder.cs
+++ b/S1API/Stations/ChemistryStationRecipeBuilder.cs
@@ -240,6 +240,7 @@ namespace S1API.Stations
                 throw new InvalidOperationException("WithProduct(...) must be called before BuildInternal().");
 
             var recipe = ScriptableObject.CreateInstance<S1StationFramework.StationRecipe>();
+            recipe.hideFlags = HideFlags.DontUnloadUnusedAsset;
             recipe.IsDiscovered = _initiallyDiscovered;
             recipe.Unlocked = _initiallyUnlocked;
             recipe.RecipeTitle = string.IsNullOrWhiteSpace(_title) ? _productItemId! : _title!;


### PR DESCRIPTION
## Summary

- restore custom Chemistry Station recipes in Mono and IL2CPP UI lifecycle paths
- retain runtime-created station recipes across Unity asset cleanup
- add typed native dead-drop lookup and supplier stash selection
- bind custom suppliers to the selected native dead drop while excluding reserved stashes from random native deliveries
- correct local dual-runtime S1API deployment paths

## Root cause

The IL2CPP Chemistry Station UI hook targeted a lifecycle seam that did not populate the active interface, and runtime recipes could be unloaded. Supplier stashes were generated independently instead of binding the configured native dead-drop storage and interaction.

## Compatibility

- Source compatibility: unchanged; all public API changes are additive.
- Binary compatibility: unchanged for existing members; new types and overloads only.
- Behavioral compatibility: existing suppliers without a configured native dead drop retain the generated-stash fallback.
- Save/network compatibility: existing identifiers and payloads are unchanged; the selected stash is runtime configuration.
- Runtime parity: validated separately on Mono and IL2CPP.

## Validation

- MonoMelon build: passed with 0 warnings/errors
- Il2CppMelon build: passed with 0 warnings/errors
- focused chemistry and supplier tests: 20/20 on each runtime
- full Mono suite: 388/388
- full IL2CPP assertions: 274 passed before the native wrapper host finalized against unavailable GameAssembly; test discovery passes
- IL2CPP slot 2 chemistry/stash smoke: custom recipe visible, BehindBank native storage bound, custom liquids transferred, task advanced to Stir
- Mono slot 3 chemistry/stash smoke: custom liquids transferred and task advanced to Stir