### PR TITLE
fix(ci): route coverage updates through pull requests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout S1API
         uses: actions/checkout@v4
@@ -220,76 +221,35 @@ jobs:
             echo "Covered Classes: $(jq -r '.classCoverage.covered' coverage-report.json) / $(jq -r '.classCoverage.total' coverage-report.json)"
           fi
 
-      - name: Update README Badge and Chart
+      - name: Generate README Badge and Chart Updates
+        id: coverage-files
         if: steps.verify-assemblies.outputs.has_assemblies == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stable')
         run: |
           COVERAGE_CHANGED="${{ steps.coverage.outputs.coverage_changed }}"
           echo "Coverage changed status: $COVERAGE_CHANGED"
-          
-          # Configure git early for potential commits
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           # Check if history was deduplicated (has changes)
           HISTORY_DEDUPLICATED=false
           if ! git diff --quiet tools/S1APICoverageAnalyzer/coverage-history.json; then
             echo "History file was deduplicated"
             HISTORY_DEDUPLICATED=true
           fi
-          
-          # If coverage hasn't changed, only commit history deduplication and chart update if needed
-          if [ "$COVERAGE_CHANGED" != "true" ]; then
-            echo "Coverage percentage unchanged - skipping badge update"
-            
-            if [ "$HISTORY_DEDUPLICATED" = true ]; then
-              echo "Updating chart with deduplicated history..."
-              
-              # Update coverage chart in README if chart file exists
-              if [ -f coverage-chart.md ]; then
-                echo "Updating coverage chart in README..."
-                
-                # Extract the chart image URL from coverage-chart.md (line 3)
-                CHART_URL=$(sed -n '3p' coverage-chart.md)
-                
-                # Find the line number with the existing chart in README
-                CHART_LINE=$(grep -n "!\[Coverage Chart\]" README.md | head -1 | cut -d: -f1)
-                
-                if [ -n "$CHART_LINE" ]; then
-                  echo "Found chart at line $CHART_LINE, updating..."
-                  # Replace the chart line
-                  awk -v line="$CHART_LINE" -v new_chart="$CHART_URL" 'NR==line {print new_chart; next} {print}' README.md > README.md.tmp
-                  mv README.md.tmp README.md
-                else
-                  echo "Chart line not found in README"
-                fi
-              fi
-              
-              echo "Committing deduplicated history and updated chart..."
-              git add README.md tools/S1APICoverageAnalyzer/coverage-history.json
-              git commit -m "chore: deduplicate coverage history and update chart [skip ci]"
-              git push
-            else
-              echo "No changes to commit"
-            fi
-            
-            exit 0
-          fi
-          
+
           # Coverage changed - update README badge and chart
-          if [ -f coverage-badge.md ]; then
+          if [ "$COVERAGE_CHANGED" = "true" ] && [ -f coverage-badge.md ]; then
             # Read the new badge markdown (trim whitespace)
             NEW_BADGE=$(cat coverage-badge.md | tr -d '\n\r')
-            
+
             # Replace the link to point to the GitHub Actions workflow
             # Extract the badge image URL and replace the link URL
             WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/workflows/coverage.yml"
             NEW_BADGE=$(echo "$NEW_BADGE" | sed "s|](docs/coverage-report.json)|]($WORKFLOW_URL)|g")
-            
+
             echo "New badge: $NEW_BADGE"
-            
+
             # Find the line number with the API Coverage badge in README
             BADGE_LINE=$(grep -n "\[!\[API Coverage\]" README.md | head -1 | cut -d: -f1)
-            
+
             if [ -n "$BADGE_LINE" ]; then
               echo "Found API Coverage badge at line $BADGE_LINE, updating..."
               # Update the badge line in README.md
@@ -299,51 +259,70 @@ jobs:
             else
               echo "Warning: API Coverage badge not found in README.md"
             fi
-            
-            # Update coverage chart in README if chart file exists
-            if [ -f coverage-chart.md ]; then
-              echo "Updating coverage chart in README..."
-              
-              # Extract the chart image URL from coverage-chart.md (line 3)
-              CHART_URL=$(sed -n '3p' coverage-chart.md)
-              
-              # Find the line number with the existing chart in README
-              CHART_LINE=$(grep -n "!\[Coverage Chart\]" README.md | head -1 | cut -d: -f1)
-              
-              if [ -n "$CHART_LINE" ]; then
-                echo "Found chart at line $CHART_LINE, updating..."
-                # Replace the chart line
-                awk -v line="$CHART_LINE" -v new_chart="$CHART_URL" 'NR==line {print new_chart; next} {print}' README.md > README.md.tmp
-                mv README.md.tmp README.md
-              else
-                echo "Chart line not found in README"
-              fi
-            fi
-            
-            # Check if there are changes to commit
-            CHANGES_EXIST=false
-            
-            if ! git diff --quiet README.md; then
-              echo "README.md has changes"
-              CHANGES_EXIST=true
-            fi
-            
-            if ! git diff --quiet tools/S1APICoverageAnalyzer/coverage-history.json; then
-              echo "coverage-history.json has changes"
-              CHANGES_EXIST=true
-            fi
-            
-            if [ "$CHANGES_EXIST" = true ]; then
-              echo "Committing changes..."
-              git diff README.md
-              git add README.md tools/S1APICoverageAnalyzer/coverage-history.json
-              git commit -m "chore: update API coverage badge and history [skip ci]"
-              git push
-            else
-              echo "No changes to commit"
-            fi
           else
-            echo "coverage-badge.md not found, skipping README update"
+            echo "Coverage percentage unchanged or badge file unavailable - skipping badge update"
+          fi
+
+          # Regenerate the chart when coverage or the normalized history changed.
+          if { [ "$COVERAGE_CHANGED" = "true" ] || [ "$HISTORY_DEDUPLICATED" = "true" ]; } && [ -f coverage-chart.md ]; then
+            echo "Updating coverage chart in README..."
+            CHART_URL=$(sed -n '3p' coverage-chart.md)
+            CHART_LINE=$(grep -n "!\[Coverage Chart\]" README.md | head -1 | cut -d: -f1)
+
+            if [ -n "$CHART_LINE" ]; then
+              echo "Found chart at line $CHART_LINE, updating..."
+              awk -v line="$CHART_LINE" -v new_chart="$CHART_URL" 'NR==line {print new_chart; next} {print}' README.md > README.md.tmp
+              mv README.md.tmp README.md
+            else
+              echo "Chart line not found in README"
+            fi
+          fi
+
+          if git diff --quiet -- README.md tools/S1APICoverageAnalyzer/coverage-history.json; then
+            echo "No coverage files changed"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Coverage files changed"
+            git diff -- README.md tools/S1APICoverageAnalyzer/coverage-history.json
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open Coverage Update Pull Request
+        if: steps.coverage-files.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          UPDATE_BRANCH: automation/coverage-${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md tools/S1APICoverageAnalyzer/coverage-history.json
+          git commit -m "chore: update API coverage badge and history"
+
+          REMOTE_SHA=$(git ls-remote --heads origin "refs/heads/$UPDATE_BRANCH" | cut -f1)
+          if [ -n "$REMOTE_SHA" ]; then
+            git push --force-with-lease="refs/heads/$UPDATE_BRANCH:$REMOTE_SHA" origin "HEAD:$UPDATE_BRANCH"
+          else
+            git push origin "HEAD:$UPDATE_BRANCH"
+          fi
+
+          EXISTING_PR=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base "$BASE_BRANCH" \
+            --head "$UPDATE_BRANCH" \
+            --state open \
+            --json url \
+            --jq '.[0].url')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Updated existing coverage pull request: $EXISTING_PR"
+          else
+            gh pr create \
+              --repo "${{ github.repository }}" \
+              --base "$BASE_BRANCH" \
+              --head "$UPDATE_BRANCH" \
+              --title "chore: update API coverage badge and history" \
+              --body "Automated coverage metadata update generated by [workflow run ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
           fi
 
       # Save cache even if build fails (to enable beta cache priming)


### PR DESCRIPTION
﻿## Summary

- Keep coverage badge, chart, and history generation in the existing coverage job.
- Publish generated changes to a deterministic `automation/coverage-<base>` branch.
- Open or refresh a pull request instead of pushing directly to protected maintained branches.
- Allow the generated PR to run required checks by removing the previous `[skip ci]` marker.

## Compatibility

- Public/protected API: unchanged.
- Existing defaults and behavior: runtime behavior unchanged; only coverage metadata publication changes.
- Stable IDs, saves, and network payloads: unchanged.

## Validation

- Workflow YAML parsed successfully with PyYAML.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/coverage.yml` ? passed.
- `git diff --check -- .github/workflows/coverage.yml` ? passed.

## Notes

Fixes the post-analysis failure in workflow run https://github.com/ifBars/S1API/actions/runs/30687059054 by preserving the required `documentation` branch-protection gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated coverage reporting and status updates.
  * Coverage badge and chart changes are now proposed for review through a pull request.
  * Automated workflows provide clearer feedback when coverage metadata is updated or remains unchanged.
  * Direct modifications to the primary code branch are avoided during coverage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->