### PR TITLE
fix(ci): stop coverage metadata update loops

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,9 @@ name: API Coverage Analysis
 on:
   push:
     branches: [ master, main, stable ]
+    paths-ignore:
+      - README.md
+      - tools/S1APICoverageAnalyzer/coverage-history.json
   pull_request:
     branches: [ master, main, stable ]
   workflow_dispatch:
@@ -229,15 +232,17 @@ jobs:
           COVERAGE_CHANGED="${{ steps.coverage.outputs.coverage_changed }}"
           echo "Coverage changed status: $COVERAGE_CHANGED"
 
-          # Check if history was deduplicated (has changes)
-          HISTORY_DEDUPLICATED=false
-          if ! git diff --quiet tools/S1APICoverageAnalyzer/coverage-history.json; then
-            echo "History file was deduplicated"
-            HISTORY_DEDUPLICATED=true
+          # The analyzer refreshes the latest history timestamp on every run.
+          # Discard that metadata churn unless the measured coverage changed.
+          if [ "$COVERAGE_CHANGED" != "true" ]; then
+            echo "Coverage percentage unchanged - discarding generated metadata churn"
+            git restore -- README.md tools/S1APICoverageAnalyzer/coverage-history.json
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Coverage changed - update README badge and chart
-          if [ "$COVERAGE_CHANGED" = "true" ] && [ -f coverage-badge.md ]; then
+          if [ -f coverage-badge.md ]; then
             # Read the new badge markdown (trim whitespace)
             NEW_BADGE=$(cat coverage-badge.md | tr -d '\n\r')
 
@@ -261,11 +266,10 @@ jobs:
               echo "Warning: API Coverage badge not found in README.md"
             fi
           else
-            echo "Coverage percentage unchanged or badge file unavailable - skipping badge update"
+            echo "Coverage badge file unavailable - skipping badge update"
           fi
 
-          # Regenerate the chart when coverage or the normalized history changed.
-          if { [ "$COVERAGE_CHANGED" = "true" ] || [ "$HISTORY_DEDUPLICATED" = "true" ]; } && [ -f coverage-chart.md ]; then
+          if [ -f coverage-chart.md ]; then
             echo "Updating coverage chart in README..."
             CHART_URL=$(sed -n '3p' coverage-chart.md)
             CHART_LINE=$(grep -n "!\[Coverage Chart\]" README.md | head -1 | cut -d: -f1)


### PR DESCRIPTION
﻿## Summary

- Ignore stable pushes that only change the generated coverage README/history files.
- Discard analyzer timestamp churn when measured coverage is unchanged.
- Preserve normal pull-request coverage checks and real coverage-change PR generation.

## Compatibility

- Public/protected API: unchanged.
- Existing defaults and behavior: runtime behavior unchanged; coverage metadata is only published for meaningful coverage changes.
- Stable IDs, saves, and network payloads: unchanged.

## Validation

- Workflow YAML parsed successfully with PyYAML.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/coverage.yml` ? passed.
- `git diff --check -- .github/workflows/coverage.yml` ? passed.

## Notes

Closes the loop demonstrated by #167, where unchanged 32.013769% coverage only refreshed the timestamp and would have replaced the retained game-update event.
