### PR TITLE
Release 3.1.1 preparation

### DIFF
--- a/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
+++ b/S1API.Tests/Rendering/PresentationWorkbenchTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using S1API.Internal.Console;
 using S1API.Internal.Rendering;
 using S1API.Rendering;
 using UnityEngine;
@@ -7,6 +8,14 @@ namespace S1API.Tests.Rendering;
 
 public sealed class PresentationWorkbenchTests
 {
+    [Fact]
+    public void ConsoleCommandUsesTheCompactCommandWord()
+    {
+        Assert.Equal(
+            "presentationworkbench",
+            new PresentationWorkbenchCommand().CommandWord);
+    }
+
     [Theory]
     [InlineData("product")]
     [InlineData("PRODUCT")]

--- a/S1API.Tests/Trash/TrashApiCompatibilityTests.cs
+++ b/S1API.Tests/Trash/TrashApiCompatibilityTests.cs
@@ -17,7 +17,7 @@ public sealed class TrashApiCompatibilityTests
     }
 
     [Fact]
-    public void StorableBuilderExposesDefaultAndExplicitTrashIds()
+    public void StorableBuilderExposesBothTrashPrefabOverloads()
     {
         Assert.NotNull(
             typeof(StorableItemDefinitionBuilder).GetMethod(
@@ -27,5 +27,20 @@ public sealed class TrashApiCompatibilityTests
             typeof(StorableItemDefinitionBuilder).GetMethod(
                 nameof(StorableItemDefinitionBuilder.WithTrashPrefab),
                 new[] { typeof(string), typeof(GameObject), typeof(bool) }));
+    }
+
+    [Fact]
+    public void StorableBuilderDerivesDefaultTrashIdFromItemId()
+    {
+        Assert.Equal(
+            "example.mod:precursor_trash",
+            StorableItemDefinitionBuilderBase<StorableItemDefinitionBuilder>
+                .ResolveTrashId("example.mod:precursor", trashId: null));
+        Assert.Equal(
+            "example.mod:empty-bottle",
+            StorableItemDefinitionBuilderBase<StorableItemDefinitionBuilder>
+                .ResolveTrashId(
+                    "example.mod:precursor",
+                    "example.mod:empty-bottle"));
     }
 }

--- a/S1API.Tests/Trash/TrashApiCompatibilityTests.cs
+++ b/S1API.Tests/Trash/TrashApiCompatibilityTests.cs
@@ -1,0 +1,31 @@
+using S1API.Items.Storable;
+using UnityEngine;
+
+namespace S1API.Tests.Trash;
+
+public sealed class TrashApiCompatibilityTests
+{
+    [Fact]
+    public void TrashManagerExposesPrefabRegistration()
+    {
+        var method = typeof(global::S1API.Trash.TrashManager).GetMethod(
+            nameof(global::S1API.Trash.TrashManager.RegisterTrashPrefab),
+            new[] { typeof(string), typeof(GameObject), typeof(bool) });
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(GameObject), method!.ReturnType);
+    }
+
+    [Fact]
+    public void StorableBuilderExposesDefaultAndExplicitTrashIds()
+    {
+        Assert.NotNull(
+            typeof(StorableItemDefinitionBuilder).GetMethod(
+                nameof(StorableItemDefinitionBuilder.WithTrashPrefab),
+                new[] { typeof(GameObject), typeof(bool) }));
+        Assert.NotNull(
+            typeof(StorableItemDefinitionBuilder).GetMethod(
+                nameof(StorableItemDefinitionBuilder.WithTrashPrefab),
+                new[] { typeof(string), typeof(GameObject), typeof(bool) }));
+    }
+}

--- a/S1API/Internal/Console/PresentationWorkbenchCommand.cs
+++ b/S1API/Internal/Console/PresentationWorkbenchCommand.cs
@@ -14,13 +14,13 @@ namespace S1API.Internal.Console
         {
         }
 
-        public override string CommandWord => "presentation_workbench";
+        public override string CommandWord => "presentationworkbench";
 
         public override string CommandDescription =>
             "Open the local icon and equippable presentation authoring workbench.";
 
         public override string ExampleUsage =>
-            "presentation_workbench [product|item] <id> | close";
+            "presentationworkbench [product|item] <id> | close";
 
         public override void ExecuteCommand(List<string> args)
         {

--- a/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
+++ b/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
@@ -356,6 +356,13 @@ namespace S1API.Items.Storable
         /// </remarks>
         /// <param name="trashPrefab">Prefab containing a native TrashItem component.</param>
         /// <param name="replaceExisting">Whether an existing trash registration may be replaced.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="trashPrefab"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="trashPrefab"/> has no native TrashItem component.
+        /// </exception>
         public TSelf WithTrashPrefab(
             GameObject trashPrefab,
             bool replaceExisting = false)
@@ -372,6 +379,14 @@ namespace S1API.Items.Storable
         /// <param name="trashId">Stable trash ID used for spawning and persistence.</param>
         /// <param name="trashPrefab">Prefab containing a native TrashItem component.</param>
         /// <param name="replaceExisting">Whether an existing trash registration may be replaced.</param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="trashPrefab"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="trashPrefab"/> has no native TrashItem component, or
+        /// <paramref name="trashId"/> is empty or whitespace.
+        /// </exception>
         public TSelf WithTrashPrefab(
             string? trashId,
             GameObject trashPrefab,
@@ -466,13 +481,27 @@ namespace S1API.Items.Storable
                     "A station item is required before configuring its trash prefab.");
             }
 
-            string trashId = _trashId ?? $"{Definition.ID}_trash";
+            string trashId = ResolveTrashId(Definition.ID, _trashId);
+            GameObject? existing =
+                global::S1API.Trash.TrashManager.GetTrashPrefab(trashId);
+            if (!_replaceExistingTrash && existing != null)
+            {
+                Logger.Warning(
+                    $"Item '{Definition.ID}' requested trash ID '{trashId}', " +
+                    $"but '{existing.name}' is already registered and will be reused.");
+            }
+
             GameObject registered = global::S1API.Trash.TrashManager.RegisterTrashPrefab(
                 trashId,
                 _trashPrefab,
                 _replaceExistingTrash);
             Definition.StationItem.TrashPrefab =
                 registered.GetComponent<S1Trash.TrashItem>();
+        }
+
+        internal static string ResolveTrashId(string itemId, string? trashId)
+        {
+            return trashId ?? $"{itemId}_trash";
         }
 
         /// <summary>

--- a/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
+++ b/S1API/Items/Storable/StorableItemDefinitionBuilder.cs
@@ -5,6 +5,7 @@ using S1Levelling = Il2CppScheduleOne.Levelling;
 using S1Registry = Il2CppScheduleOne.Registry;
 using S1StationFramework = Il2CppScheduleOne.StationFramework;
 using S1Storage = Il2CppScheduleOne.Storage;
+using S1Trash = Il2CppScheduleOne.Trash;
 #elif MONOMELON
 using S1ItemFramework = ScheduleOne.ItemFramework;
 using S1CoreItemFramework = ScheduleOne.Core.Items.Framework;
@@ -12,6 +13,7 @@ using S1Levelling = ScheduleOne.Levelling;
 using S1Registry = ScheduleOne.Registry;
 using S1StationFramework = ScheduleOne.StationFramework;
 using S1Storage = ScheduleOne.Storage;
+using S1Trash = ScheduleOne.Trash;
 #endif
 using System;
 using System.Collections.Generic;
@@ -99,6 +101,9 @@ namespace S1API.Items.Storable
         protected readonly S1ItemFramework.StorableItemDefinition Definition;
         private readonly GameObject _storedItemPlaceholder;
         private bool _hasCustomStoredItem;
+        private GameObject? _trashPrefab;
+        private string? _trashId;
+        private bool _replaceExistingTrash;
 
         /// <summary>
         /// INTERNAL: Whether a custom StoredItem was assigned via <see cref="WithStoredItem"/>.
@@ -342,6 +347,54 @@ namespace S1API.Items.Storable
         }
 
         /// <summary>
+        /// Assigns and registers the trash prefab spawned after this station item is consumed.
+        /// </summary>
+        /// <remarks>
+        /// The station item must be configured before <see cref="Build"/>. If no explicit trash ID is
+        /// supplied, S1API uses <c>&lt;item ID&gt;_trash</c>. All multiplayer clients must build the
+        /// same registration.
+        /// </remarks>
+        /// <param name="trashPrefab">Prefab containing a native TrashItem component.</param>
+        /// <param name="replaceExisting">Whether an existing trash registration may be replaced.</param>
+        public TSelf WithTrashPrefab(
+            GameObject trashPrefab,
+            bool replaceExisting = false)
+        {
+            return WithTrashPrefab(
+                trashId: null,
+                trashPrefab,
+                replaceExisting);
+        }
+
+        /// <summary>
+        /// Assigns and registers the trash prefab spawned after this station item is consumed.
+        /// </summary>
+        /// <param name="trashId">Stable trash ID used for spawning and persistence.</param>
+        /// <param name="trashPrefab">Prefab containing a native TrashItem component.</param>
+        /// <param name="replaceExisting">Whether an existing trash registration may be replaced.</param>
+        public TSelf WithTrashPrefab(
+            string? trashId,
+            GameObject trashPrefab,
+            bool replaceExisting = false)
+        {
+            if (trashPrefab == null)
+                throw new ArgumentNullException(nameof(trashPrefab));
+            if (trashPrefab.GetComponent<S1Trash.TrashItem>() == null)
+            {
+                throw new ArgumentException(
+                    "Trash prefab must have a TrashItem component.",
+                    nameof(trashPrefab));
+            }
+            if (trashId != null && string.IsNullOrWhiteSpace(trashId))
+                throw new ArgumentException("Trash ID cannot be empty.", nameof(trashId));
+
+            _trashId = trashId;
+            _trashPrefab = trashPrefab;
+            _replaceExistingTrash = replaceExisting;
+            return Self;
+        }
+
+        /// <summary>
         /// Sets whether this item is available in the demo version of the game.
         /// </summary>
         /// <param name="available">True if available in demo, false otherwise.</param>
@@ -393,12 +446,33 @@ namespace S1API.Items.Storable
                 }
             }
 
+            ApplyTrashPrefab();
+
             // Register with the game's registry
             S1Registry.Instance.AddToRegistry(Definition);
             RuntimeItemDefinitionRegistry.Retain(Definition.ID, Definition);
 
             // Return wrapper
             return CreateWrapper(Definition);
+        }
+
+        private void ApplyTrashPrefab()
+        {
+            if (_trashPrefab == null)
+                return;
+            if (Definition.StationItem == null)
+            {
+                throw new InvalidOperationException(
+                    "A station item is required before configuring its trash prefab.");
+            }
+
+            string trashId = _trashId ?? $"{Definition.ID}_trash";
+            GameObject registered = global::S1API.Trash.TrashManager.RegisterTrashPrefab(
+                trashId,
+                _trashPrefab,
+                _replaceExistingTrash);
+            Definition.StationItem.TrashPrefab =
+                registered.GetComponent<S1Trash.TrashItem>();
         }
 
         /// <summary>

--- a/S1API/Products/CustomProductSaveDescriptor.cs
+++ b/S1API/Products/CustomProductSaveDescriptor.cs
@@ -8,8 +8,8 @@ namespace S1API.Products
     /// </summary>
     /// <remarks>
     /// This descriptor deliberately contains no Unity objects, asset references, delegates, or
-    /// process-local references. A provider may use <see cref="ProviderData"/> to retain its own
-    /// bounded scalar configuration.
+    /// process-local references. A provider may use <see cref="ProviderData"/> for its own
+    /// bounded scalar configuration. It must recreate assets and callbacks from local mod resources.
     /// </remarks>
     public sealed class CustomProductSaveDescriptor
     {
@@ -65,15 +65,19 @@ namespace S1API.Products
     }
 
     /// <summary>Reconstructs a custom product from a persisted scalar descriptor.</summary>
+    /// <remarks>
+    /// Register the provider before save restoration. The returned builder must retain the descriptor's
+    /// stable product ID. Returning <see langword="null"/> preserves S1API's safe missing-content path.
+    /// </remarks>
     public interface ICustomProductSaveProvider
     {
         /// <summary>Gets the stable, namespaced provider ID.</summary>
         string ProviderId { get; }
         /// <summary>Gets the highest provider descriptor version this provider accepts.</summary>
         int MaximumDescriptorVersion { get; }
-        /// <summary>Recreates and registers the descriptor's product.</summary>
+        /// <summary>Returns the fully configured builder that recreates the descriptor's product.</summary>
         /// <param name="descriptor">The validated scalar descriptor.</param>
-        /// <returns>A fully configured, unbuilt definition builder, or <see langword="null"/> to use S1API's safe fallback.</returns>
+        /// <returns>A fully configured, unbuilt definition builder, or <see langword="null"/> to skip restoration safely.</returns>
         CustomProductDefinitionBuilder? Restore(CustomProductSaveDescriptor descriptor);
     }
 }

--- a/S1API/Products/CustomProductSaveProviderRegistry.cs
+++ b/S1API/Products/CustomProductSaveProviderRegistry.cs
@@ -4,9 +4,18 @@ using S1API.Internal.Products;
 namespace S1API.Products
 {
     /// <summary>Registers process-lifetime providers for custom-product save descriptors.</summary>
+    /// <remarks>
+    /// Register providers during early mod initialization, before custom-product save restoration.
+    /// Provider IDs are durable and case-insensitive. A conflicting provider cannot replace the
+    /// provider that already owns that ID.
+    /// </remarks>
     public static class CustomProductSaveProviderRegistry
     {
-        /// <summary>Registers a provider, or returns the existing equivalent provider.</summary>
+        /// <summary>Registers a save provider, or returns the existing equivalent provider.</summary>
+        /// <param name="provider">The provider that reconstructs one family of saved custom products.</param>
+        /// <returns>The registered provider, or the existing equivalent provider.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider"/> is <see langword="null"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when another provider already owns the same ID.</exception>
         public static ICustomProductSaveProvider Register(ICustomProductSaveProvider provider)
         {
             return CustomProductSavePersistence.RegisterProvider(provider);

--- a/S1API/Products/PackagingDefinition.cs
+++ b/S1API/Products/PackagingDefinition.cs
@@ -13,8 +13,13 @@ using S1API.Products.Packaging;
 namespace S1API.Products
 {
     /// <summary>
-    /// Represents a type of packaging in-game.
+    /// Represents a native packaging type in the active game runtime.
     /// </summary>
+    /// <remarks>
+    /// Packaging definitions describe capacity and stealth. They do not create packaging assets
+    /// or alter a product's allowed packaging policy. Resolve a live definition through
+    /// <see cref="ProductPopulator.GetPackaging(string)"/> or the item registry.
+    /// </remarks>
     public class PackagingDefinition : ItemDefinition
     {
         /// <summary>
@@ -31,13 +36,13 @@ namespace S1API.Products
             base(s1ItemDefinition) { }
 
         /// <summary>
-        /// The quantity that this packaging can hold.
+        /// Gets the native product quantity this packaging can hold.
         /// </summary>
         public int Quantity =>
             S1PackagingDefinition.Quantity;
 
         /// <summary>
-        /// The stealth level of this packaging.
+        /// Gets the runtime-agnostic stealth level for this packaging.
         /// </summary>
         public StealthLevel StealthLevel =>
             S1PackagingDefinition.StealthLevel.ToAPI();

--- a/S1API/Products/ProductDefinition.cs
+++ b/S1API/Products/ProductDefinition.cs
@@ -20,8 +20,14 @@ using UnityEngine;
 namespace S1API.Products
 {
     /// <summary>
-    /// Represents a product definition in the game.
+    /// Represents one registered product type in the active game runtime.
     /// </summary>
+    /// <remarks>
+    /// A definition supplies the shared identity, price, properties, icon, and packaging policy
+    /// for its instances. It is a wrapper over a native definition, not a new product-registration
+    /// mechanism. Use the custom-product or native-family builders when a mod needs to register
+    /// a definition.
+    /// </remarks>
     public class ProductDefinition : Items.Storable.StorableItemDefinition
     {
         /// <summary>
@@ -39,43 +45,50 @@ namespace S1API.Products
         {
         }
         /// <summary>
-        /// The price associated with this product.
+        /// Gets the current price selected by the native product system.
         /// </summary>
         public float Price =>
             S1ProductDefinition.Price;
 
         /// <summary>
-        /// The base price associated with this product.
+        /// Gets the native base price before market adjustments.
         /// </summary>
         public float BasePrice =>
             S1ProductDefinition.BasePrice;
         
         /// <summary>
-        /// The market value associated with this product.
+        /// Gets the product's native market value.
         /// </summary>
         public float MarketValue =>
             S1ProductDefinition.MarketValue;
 
         /// <summary>
-        /// Creates an instance of this product in-game.
+        /// Creates an unpackaged standard-quality instance of this definition.
         /// </summary>
-        /// <param name="quantity">The quantity of product.</param>
-        /// <returns>An instance of the product.</returns>
+        /// <param name="quantity">The native product quantity for the new instance.</param>
+        /// <returns>A new API wrapper around the native product instance.</returns>
         public override ItemInstance CreateInstance(int quantity = 1) =>
             new ProductInstance(CrossType.As<S1Product.ProductItemInstance>(S1ProductDefinition.GetDefaultInstance(quantity)));
 
         /// <summary>
-        /// Gets the in-game icon associated with the product.
+        /// Gets the current native inventory icon.
         /// </summary>
+        /// <remarks>
+        /// The returned sprite is owned by the active Unity runtime. Do not destroy it. A
+        /// generated custom-product icon can replace this reference after its capture completes.
+        /// </remarks>
         public new Sprite Icon
         {
             get { return S1ProductDefinition.Icon; }
         }
 
         /// <summary>
-        /// The list of product properties for this definition.
-        /// Returns runtime-agnostic property wrappers that work on both Mono and IL2CPP.
+        /// Gets runtime-agnostic wrappers for the definition's product properties.
         /// </summary>
+        /// <remarks>
+        /// Each call creates a read-only snapshot that works on both Mono and IL2CPP. Do not use
+        /// the wrapper objects as stable identity keys; use their IDs when identity matters.
+        /// </remarks>
         public IReadOnlyList<PropertyBase> Properties
         {
             get
@@ -166,11 +179,14 @@ namespace S1API.Products
             S1ProductDefinition.DrugType;
 
         /// <summary>
-        /// Creates a packaged instance of this product with the specified packaging.
+        /// Creates a standard-quality instance with the supplied native packaging.
         /// </summary>
-        /// <param name="quantity">The quantity of the product.</param>
-        /// <param name="packaging">The packaging to apply to the product.</param>
-        /// <returns>A packaged product instance, or null if packaging is not found.</returns>
+        /// <param name="quantity">The native product quantity for the new instance.</param>
+        /// <param name="packaging">A live packaging definition from the active game runtime.</param>
+        /// <returns>
+        /// A packaged product instance, or <see langword="null"/> when the packaging cannot be
+        /// converted for the active runtime or native construction fails.
+        /// </returns>
         public ProductInstance? CreatePackagedInstance(int quantity, PackagingDefinition packaging)
         {
             try

--- a/S1API/Products/ProductDefinitionWrapper.cs
+++ b/S1API/Products/ProductDefinitionWrapper.cs
@@ -10,15 +10,20 @@ using S1Product = ScheduleOne.Product;
 namespace S1API.Products
 {
     /// <summary>
-    /// Provides functionality to wrap and convert generic product definitions into their specific type-derived definitions.
+    /// Selects the most specific API wrapper for a registered native product definition.
     /// </summary>
+    /// <remarks>
+    /// The wrapper exposes native-family types when available and returns
+    /// <see cref="CustomProductDefinition"/> only for definitions registered through S1API's
+    /// custom-product metadata. It never changes the native definition or its identity.
+    /// </remarks>
     public static class ProductDefinitionWrapper
     {
         /// <summary>
-        /// Converts a generic <see cref="ProductDefinition"/> into its corresponding typed wrapper.
+        /// Returns the most specific wrapper available for a product definition.
         /// </summary>
-        /// <param name="def">The raw product definition to be processed and converted.</param>
-        /// <returns>A wrapped instance of <see cref="ProductDefinition"/> with type-specific methods and properties, or the input definition if no specific wrapper applies.</returns>
+        /// <param name="def">The product definition to classify.</param>
+        /// <returns>A typed wrapper, or <paramref name="def"/> when no more specific wrapper applies.</returns>
         public static ProductDefinition Wrap(ProductDefinition def)
         {
             return Wrap(def.S1ProductDefinition, def);

--- a/S1API/Products/ProductInstance.cs
+++ b/S1API/Products/ProductInstance.cs
@@ -12,11 +12,12 @@ using S1ItemInstance = S1API.Items.ItemInstance;
 namespace S1API.Products
 {
     /// <summary>
-    /// Represents an instance of a product in the game.
+    /// Represents one product stack or item in the active game runtime.
     /// </summary>
     /// <remarks>
-    /// This class defines specific properties and behaviors for a product instance,
-    /// such as quality, packaging, and definition, derived from the S1API's item instance structure.
+    /// Product instances inherit quantity and base item behavior from <see cref="S1ItemInstance"/>.
+    /// This wrapper adds product definition, quality, packaging, and property access without
+    /// exposing runtime-specific native types.
     /// </remarks>
     public class ProductInstance : S1ItemInstance
     {
@@ -27,8 +28,7 @@ namespace S1API.Products
             CrossType.As<S1Product.ProductItemInstance>(S1ItemInstance);
 
         /// <summary>
-        /// Represents an instance of a product, derived from a specific in-game product item instance,
-        /// with additional properties for packaging, quality, and product definition.
+        /// Creates a wrapper around a native product item instance.
         /// </summary>
         internal ProductInstance(S1Product.ProductItemInstance productInstance)
             : base(productInstance)
@@ -36,22 +36,26 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Indicates whether the product instance has applied packaging.
+        /// Gets whether the instance currently has native packaging.
         /// </summary>
         public bool IsPackaged => S1ProductInstance.AppliedPackaging;
 
         /// <summary>
-        /// Provides access to the packaging information applied to the product,
-        /// represented as a specific packaging definition instance.
+        /// Gets the packaging applied to this instance.
         /// </summary>
+        /// <remarks>
+        /// Check <see cref="IsPackaged"/> before reading this property. The native runtime only
+        /// provides a packaging definition for packaged instances.
+        /// </remarks>
         public PackagingDefinition AppliedPackaging =>
             new PackagingDefinition(S1ProductInstance.AppliedPackaging);
 
         /// <summary>
-        /// Represents the quality level of the product instance.
+        /// Gets the runtime-agnostic quality level assigned to this instance.
         /// </summary>
         /// <remarks>
-        /// Quality levels provide a measure of the product's grading, ranging from "Trash" to "Heavenly".
+        /// This value comes from the native instance. Creating an instance through
+        /// <see cref="ProductDefinition.CreateInstance(int)"/> uses the native standard quality.
         /// </remarks>
         public Quality Quality => S1ProductInstance.Quality.ToAPI();
 
@@ -63,12 +67,11 @@ namespace S1API.Products
                 CrossType.As<S1Product.ProductDefinition>(S1ProductInstance.Definition));
 
         /// <summary>
-        /// Gets the list of properties associated with the product definition.
+        /// Gets runtime-agnostic wrappers for the properties on <see cref="Definition"/>.
         /// </summary>
         /// <remarks>
-        /// This property provides an unmodifiable list of properties associated
-        /// with the underlying product definition. Each property represents
-        /// a specific characteristic or behavior of the corresponding product.
+        /// Properties belong to the definition, not the individual stack. The returned list is a
+        /// read-only snapshot from <see cref="ProductDefinition.Properties"/>.
         /// </remarks>
         public IReadOnlyList<PropertyBase> Properties => Definition.Properties;
     }

--- a/S1API/Products/ProductMixingProfileBuilder.cs
+++ b/S1API/Products/ProductMixingProfileBuilder.cs
@@ -14,7 +14,9 @@ namespace S1API.Products
         private string? _outputFactoryIdentity;
         private int _outputFactoryVersion;
 
-        /// <summary>Creates a profile builder for a registered logical product kind.</summary>
+        /// <summary>Creates a mixing-profile builder for a registered logical product kind.</summary>
+        /// <param name="productKind">The stable logical kind that opts into mixing.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="productKind"/> is <see langword="null"/>.</exception>
         public ProductMixingProfileBuilder(ProductKind productKind)
         {
             _productKind = productKind ?? throw new ArgumentNullException(nameof(productKind));
@@ -35,7 +37,10 @@ namespace S1API.Products
             return this;
         }
 
-        /// <summary>Sets the deterministic factory used to name, price, and optionally transform generated outputs.</summary>
+        /// <summary>Sets the deterministic factory that names, prices, and optionally transforms generated outputs.</summary>
+        /// <param name="outputFactory">A deterministic factory invoked for each native mixing output.</param>
+        /// <returns>This builder.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="outputFactory"/> is <see langword="null"/>.</exception>
         public ProductMixingProfileBuilder WithOutputFactory(Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory)
         {
             _outputFactory = outputFactory ?? throw new ArgumentNullException(nameof(outputFactory));
@@ -63,7 +68,9 @@ namespace S1API.Products
             return this;
         }
 
-        /// <summary>Registers this immutable profile.</summary>
+        /// <summary>Builds and registers this immutable mixing profile.</summary>
+        /// <returns>The registered profile, or the existing equivalent profile.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when no output factory was configured.</exception>
         public ProductMixingProfile Build()
         {
             if (_outputFactory == null)

--- a/S1API/Products/ProductPopulator.cs
+++ b/S1API/Products/ProductPopulator.cs
@@ -19,15 +19,20 @@ using UnityEngine;
 namespace S1API.Products
 {
     /// <summary>
-    /// Utility methods for populating storage with product instances.
+    /// Creates product instances and adds them to storage for mod-owned setup flows.
     /// </summary>
+    /// <remarks>
+    /// These helpers read products discovered in the active save. They do not register,
+    /// discover, list, or stock products in a shop. Use explicit custom-product lifecycle APIs
+    /// before calling them for mod-owned definitions.
+    /// </remarks>
     public static class ProductPopulator
     {
         /// <summary>
-        /// Gets a packaging definition by its ID.
+        /// Resolves a native packaging definition by its item ID.
         /// </summary>
         /// <param name="packagingId">The ID of the packaging (e.g., "baggie", "jar", "brick").</param>
-        /// <returns>The packaging definition, or null if not found.</returns>
+        /// <returns>The live packaging definition, or <see langword="null"/> when the item is absent or not packaging.</returns>
         public static PackagingDefinition? GetPackaging(string packagingId)
         {
             var packaging = ItemManager.GetDefinition(packagingId);
@@ -44,9 +49,9 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Gets all available product definitions from the game registry.
+        /// Gets product definitions discovered in the active save.
         /// </summary>
-        /// <returns>A list of product definitions.</returns>
+        /// <returns>A new list of discovered product definitions. It is empty when the save has discovered none.</returns>
         public static List<ProductDefinition> GetAllProductDefinitions()
         {
             Debug.Log("[ProductPopulator] Getting all product definitions from ProductManager.DiscoveredProducts");
@@ -67,7 +72,7 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Gets weed product definitions from the game registry.
+        /// Gets discovered marijuana-family product definitions.
         /// </summary>
         /// <returns>A list of weed product definitions.</returns>
         public static List<WeedDefinition> GetWeedDefinitions()
@@ -79,7 +84,7 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Gets meth product definitions from the game registry.
+        /// Gets discovered methamphetamine-family product definitions.
         /// </summary>
         /// <returns>A list of meth product definitions.</returns>
         public static List<MethDefinition> GetMethDefinitions()
@@ -91,7 +96,7 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Gets cocaine product definitions from the game registry.
+        /// Gets discovered cocaine-family product definitions.
         /// </summary>
         /// <returns>A list of cocaine product definitions.</returns>
         public static List<CocaineDefinition> GetCocaineDefinitions()
@@ -103,7 +108,7 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Gets shroom product definitions from the game registry.
+        /// Gets discovered shroom-family product definitions.
         /// </summary>
         /// <returns>A list of shroom product definitions.</returns>
         public static List<ShroomDefinition> GetShroomDefinitions()
@@ -115,12 +120,12 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container with packaged products.
+        /// Fills available storage slots with packaged discovered products.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
         /// <param name="packagingId">The ID of the packaging to use (e.g., "baggie", "jar", "brick").</param>
         /// <param name="quantityPerItem">The quantity of each product item.</param>
-        /// <returns>The number of items successfully added.</returns>
+        /// <returns>The number of stacks added before storage fills, a product cannot fit, or setup fails.</returns>
         public static int PopulateWithPackagedProducts(StorageInstance storage, string packagingId, int quantityPerItem = 1)
         {
             Debug.Log($"[ProductPopulator] PopulateWithPackagedProducts called with packaging: {packagingId}");
@@ -190,13 +195,13 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container with specific packaged products by ID.
+        /// Adds one packaged stack for each supplied product ID that resolves and fits.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
-        /// <param name="productIds">List of product IDs to add.</param>
+        /// <param name="productIds">Product IDs to resolve through the item registry.</param>
         /// <param name="packagingId">The ID of the packaging to use (e.g., "baggie", "jar", "brick").</param>
         /// <param name="quantityPerProduct">Quantity of each product to add (default 1).</param>
-        /// <returns>The number of items successfully added.</returns>
+        /// <returns>The number of stacks added. Unknown IDs and stacks that do not fit are skipped.</returns>
         public static int PopulateWithSpecificPackagedProducts(StorageInstance storage, List<string> productIds, string packagingId, int quantityPerProduct = 1)
         {
             if (storage == null)
@@ -245,12 +250,12 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Creates a packaged product instance.
+        /// Creates a standard-quality packaged product instance.
         /// </summary>
         /// <param name="productDef">The product definition.</param>
         /// <param name="packaging">The packaging definition.</param>
         /// <param name="quantity">The quantity of the product.</param>
-        /// <returns>The created product instance, or null if failed.</returns>
+        /// <returns>A new product instance, or <see langword="null"/> when native packaging conversion or construction fails.</returns>
         public static ProductInstance? CreatePackagedProduct(ProductDefinition productDef, PackagingDefinition packaging, int quantity)
         {
             try
@@ -283,11 +288,11 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container with non-packaged products.
+        /// Fills available storage slots with unpackaged discovered products.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
         /// <param name="quantityPerItem">The quantity of each product item.</param>
-        /// <returns>The number of items successfully added.</returns>
+        /// <returns>The number of stacks added before storage fills, a product cannot fit, or setup fails.</returns>
         public static int PopulateWithUnpackagedProducts(StorageInstance storage, int quantityPerItem = 1)
         {
             Debug.Log("[ProductPopulator] PopulateWithUnpackagedProducts called");
@@ -350,12 +355,12 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container with specific non-packaged products by ID.
+        /// Adds one unpackaged stack for each supplied product ID that resolves and fits.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
-        /// <param name="productIds">List of product IDs to add.</param>
+        /// <param name="productIds">Product IDs to resolve through the item registry.</param>
         /// <param name="quantityPerProduct">Quantity of each product to add (default 1).</param>
-        /// <returns>The number of items successfully added.</returns>
+        /// <returns>The number of stacks added. Unknown IDs and stacks that do not fit are skipped.</returns>
         public static int PopulateWithSpecificProducts(StorageInstance storage, List<string> productIds, int quantityPerProduct = 1)
         {
             if (storage == null)
@@ -397,8 +402,7 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container with packaged weed products in jars.
-        /// Fills all available slots with 20 units (4 jars) of each product.
+        /// Fills available storage slots with discovered products in native jar packaging.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
         /// <returns>The number of items successfully added.</returns>
@@ -408,13 +412,12 @@ namespace S1API.Products
         }
 
         /// <summary>
-        /// Populates a storage container by finding it from a GameObject.
-        /// Fills all slots with packaged products in the specified packaging.
+        /// Finds a storage entity on a game object or one of its children, then fills it with packaged products.
         /// </summary>
         /// <param name="gameObject">The GameObject with a StorageEntity component.</param>
         /// <param name="packagingId">The ID of the packaging to use (e.g., "baggie", "jar", "brick").</param>
         /// <param name="quantityPerItem">The quantity of each product item.</param>
-        /// <returns>The number of items successfully added, or -1 if storage not found.</returns>
+        /// <returns>The number of stacks added, or <c>-1</c> when no storage entity is found.</returns>
         public static int PopulateFromGameObject(GameObject gameObject, string packagingId, int quantityPerItem = 1)
         {
             Debug.Log($"[ProductPopulator] PopulateFromGameObject called for '{gameObject?.name}' with packaging '{packagingId}'");

--- a/S1API/Products/ProductPopulator.cs
+++ b/S1API/Products/ProductPopulator.cs
@@ -22,9 +22,10 @@ namespace S1API.Products
     /// Creates product instances and adds them to storage for mod-owned setup flows.
     /// </summary>
     /// <remarks>
-    /// These helpers read products discovered in the active save. They do not register,
-    /// discover, list, or stock products in a shop. Use explicit custom-product lifecycle APIs
-    /// before calling them for mod-owned definitions.
+    /// Discovery-based helpers read products discovered in the active save. ID-based helpers
+    /// resolve registered definitions through the item registry, while direct-creation helpers
+    /// use the supplied definition. These APIs do not register products or stock shops. Use
+    /// explicit custom-product lifecycle APIs before calling them for mod-owned definitions.
     /// </remarks>
     public static class ProductPopulator
     {
@@ -405,7 +406,7 @@ namespace S1API.Products
         /// Fills available storage slots with discovered products in native jar packaging.
         /// </summary>
         /// <param name="storage">The storage instance to populate.</param>
-        /// <returns>The number of items successfully added.</returns>
+        /// <returns>The number of stacks successfully added.</returns>
         public static int PopulateWithWeedProducts(StorageInstance storage)
         {
             return PopulateWithPackagedProducts(storage, "jar", 20);

--- a/S1API/Trash/TrashManager.cs
+++ b/S1API/Trash/TrashManager.cs
@@ -1,7 +1,11 @@
 using System;
+using System.Collections.Generic;
+using S1API.Lifecycle;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 #if (IL2CPPMELON)
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using S1Trash = Il2CppScheduleOne.Trash;
 #elif MONOMELON
 using S1Trash = ScheduleOne.Trash;
@@ -14,6 +18,13 @@ namespace S1API.Trash
     /// </summary>
     public static class TrashManager
     {
+        private static readonly object RegistrationGate = new object();
+        private static readonly Dictionary<string, S1Trash.TrashItem>
+            RegisteredPrefabs =
+                new Dictionary<string, S1Trash.TrashItem>(StringComparer.OrdinalIgnoreCase);
+        private static GameObject? _prefabRoot;
+        private static bool _lifecycleSubscribed;
+
         /// <summary>
         /// Maximum number of trash items allowed in the world (2000).
         /// </summary>
@@ -48,8 +59,75 @@ namespace S1API.Trash
         /// <returns>The trash prefab GameObject, or null if not found.</returns>
         public static GameObject? GetTrashPrefab(string id)
         {
-            var prefab = S1Trash.TrashManager.Instance.GetTrashPrefab(id);
-            return prefab?.gameObject;
+            var manager = S1Trash.TrashManager.Instance;
+            var nativePrefab = manager != null
+                ? manager.GetTrashPrefab(id)
+                : null;
+            if (nativePrefab != null)
+                return nativePrefab.gameObject;
+
+            lock (RegistrationGate)
+            {
+                return RegisteredPrefabs.TryGetValue(id, out var registered)
+                    ? registered.gameObject
+                    : null;
+            }
+        }
+
+        /// <summary>
+        /// Registers a stable trash prefab that can be spawned by ID and referenced by station items.
+        /// </summary>
+        /// <remarks>
+        /// The supplied prefab is cloned under an inactive, persistent cache root. Registrations are
+        /// reapplied after game loads so network trash spawning can resolve the same ID on every client.
+        /// All clients must register the same ID and prefab behavior for multiplayer consistency.
+        /// </remarks>
+        /// <param name="id">Stable trash ID used for spawning and persistence.</param>
+        /// <param name="trashPrefab">Prefab containing a native TrashItem component.</param>
+        /// <param name="replaceExisting">Whether an existing registration with the same ID may be replaced.</param>
+        /// <returns>The cached registered prefab.</returns>
+        public static GameObject RegisterTrashPrefab(
+            string id,
+            GameObject trashPrefab,
+            bool replaceExisting = false)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Trash ID is required.", nameof(id));
+            if (trashPrefab == null)
+                throw new ArgumentNullException(nameof(trashPrefab));
+
+            var source = trashPrefab.GetComponent<S1Trash.TrashItem>();
+            if (source == null)
+            {
+                throw new ArgumentException(
+                    "Trash prefab must have a TrashItem component.",
+                    nameof(trashPrefab));
+            }
+
+            S1Trash.TrashItem cached;
+            lock (RegistrationGate)
+            {
+                if (RegisteredPrefabs.TryGetValue(id, out var existing) &&
+                    existing != null)
+                {
+                    if (!replaceExisting)
+                        return existing.gameObject;
+
+                    Object.Destroy(existing.gameObject);
+                }
+
+                var root = GetOrCreatePrefabRoot();
+                cached = Object.Instantiate(source, root.transform, false);
+                cached.name = $"S1API_Trash_{id}";
+                cached.ID = id;
+                cached.gameObject.hideFlags = HideFlags.HideAndDontSave;
+                cached.gameObject.SetActive(true);
+                RegisteredPrefabs[id] = cached;
+                EnsureLifecycleSubscription();
+            }
+
+            ApplyRegistration(id, cached, replaceExisting: true);
+            return cached.gameObject;
         }
 
         /// <summary>
@@ -60,6 +138,108 @@ namespace S1API.Trash
         {
             var prefab = S1Trash.TrashManager.Instance.GetRandomGeneratableTrashPrefab();
             return prefab?.gameObject;
+        }
+
+        private static void EnsureLifecycleSubscription()
+        {
+            if (_lifecycleSubscribed)
+                return;
+
+            GameLifecycle.OnPreLoad += ApplyAllRegistrations;
+            GameLifecycle.OnLoadComplete += ApplyAllRegistrations;
+            _lifecycleSubscribed = true;
+        }
+
+        private static void ApplyAllRegistrations()
+        {
+            KeyValuePair<string, S1Trash.TrashItem>[] registrations;
+            lock (RegistrationGate)
+            {
+                registrations =
+                    new KeyValuePair<string, S1Trash.TrashItem>[RegisteredPrefabs.Count];
+                int index = 0;
+                foreach (var registration in RegisteredPrefabs)
+                    registrations[index++] = registration;
+            }
+
+            foreach (var registration in registrations)
+            {
+                if (registration.Value != null)
+                {
+                    ApplyRegistration(
+                        registration.Key,
+                        registration.Value,
+                        replaceExisting: true);
+                }
+            }
+        }
+
+        private static void ApplyRegistration(
+            string id,
+            S1Trash.TrashItem prefab,
+            bool replaceExisting)
+        {
+            var manager = S1Trash.TrashManager.Instance;
+            if (manager == null)
+                return;
+
+#if (IL2CPPMELON)
+            Il2CppReferenceArray<S1Trash.TrashItem>? prefabs = manager.TrashPrefabs;
+            int count = prefabs?.Length ?? 0;
+            for (int index = 0; index < count; index++)
+            {
+                var existing = prefabs![index];
+                if (!string.Equals(existing?.ID, id, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (replaceExisting)
+                {
+                    prefabs[index] = prefab;
+                    manager.TrashPrefabs = prefabs;
+                }
+                return;
+            }
+
+            var expanded = new Il2CppReferenceArray<S1Trash.TrashItem>(count + 1);
+            for (int index = 0; index < count; index++)
+                expanded[index] = prefabs![index];
+            expanded[count] = prefab;
+            manager.TrashPrefabs = expanded;
+#else
+            S1Trash.TrashItem[] prefabs =
+                manager.TrashPrefabs ?? Array.Empty<S1Trash.TrashItem>();
+            for (int index = 0; index < prefabs.Length; index++)
+            {
+                var existing = prefabs[index];
+                if (!string.Equals(existing?.ID, id, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (replaceExisting)
+                {
+                    prefabs[index] = prefab;
+                    manager.TrashPrefabs = prefabs;
+                }
+                return;
+            }
+
+            Array.Resize(ref prefabs, prefabs.Length + 1);
+            prefabs[prefabs.Length - 1] = prefab;
+            manager.TrashPrefabs = prefabs;
+#endif
+        }
+
+        private static GameObject GetOrCreatePrefabRoot()
+        {
+            if (_prefabRoot != null)
+                return _prefabRoot;
+
+            _prefabRoot = new GameObject("S1API_TrashPrefabs")
+            {
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            _prefabRoot.SetActive(false);
+            Object.DontDestroyOnLoad(_prefabRoot);
+            return _prefabRoot;
         }
     }
 }

--- a/S1API/Trash/TrashManager.cs
+++ b/S1API/Trash/TrashManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using S1API.Lifecycle;
+using S1API.Logging;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -18,6 +19,7 @@ namespace S1API.Trash
     /// </summary>
     public static class TrashManager
     {
+        private static readonly Log Logger = new Log("TrashManager");
         private static readonly object RegistrationGate = new object();
         private static readonly Dictionary<string, S1Trash.TrashItem>
             RegisteredPrefabs =
@@ -68,7 +70,8 @@ namespace S1API.Trash
 
             lock (RegistrationGate)
             {
-                return RegisteredPrefabs.TryGetValue(id, out var registered)
+                return RegisteredPrefabs.TryGetValue(id, out var registered) &&
+                    registered != null
                     ? registered.gameObject
                     : null;
             }
@@ -111,7 +114,14 @@ namespace S1API.Trash
                     existing != null)
                 {
                     if (!replaceExisting)
+                    {
+                        Logger.Warning(
+                            $"Trash ID '{id}' is already registered. " +
+                            $"Keeping '{existing.gameObject.name}' and ignoring " +
+                            $"'{trashPrefab.name}'. Set replaceExisting to true " +
+                            "to replace the existing prefab.");
                         return existing.gameObject;
+                    }
 
                     Object.Destroy(existing.gameObject);
                 }

--- a/S1API/docs/generic-custom-products.md
+++ b/S1API/docs/generic-custom-products.md
@@ -86,7 +86,7 @@ appropriate, or explicitly select `WithNativeMixerMap(...)` for a logical kind
 that has no base-game enum. Neither option changes the logical kind's identity.
 
 To give the logical kind a Product Manager section, separately register
-[`ProductKindMetadata`](product-kinds.md#register-presentation-and-product-manager-metadata).
+[`ProductKindMetadata`](product-kinds.md#add-optional-presentation-and-product-manager-metadata).
 This catalog metadata does not change definition construction, discovery, or
 listing.
 

--- a/S1API/docs/presentation-workbench.md
+++ b/S1API/docs/presentation-workbench.md
@@ -37,16 +37,16 @@ Open the native developer console after the local player has spawned. The
 explicit forms are:
 
 ```text
-presentation_workbench product example.mod:products/focus-tablet
-presentation_workbench item example.mod:items/storage-pallet
-presentation_workbench close
+presentationworkbench product example.mod:products/focus-tablet
+presentationworkbench item example.mod:items/storage-pallet
+presentationworkbench close
 ```
 
 For convenience, omit the target kind to resolve a value in product, then
 item order:
 
 ```text
-presentation_workbench example.mod:products/focus-tablet
+presentationworkbench example.mod:products/focus-tablet
 ```
 
 A consuming mod does not need initialization code for the workbench. If the

--- a/S1API/docs/product-kinds.md
+++ b/S1API/docs/product-kinds.md
@@ -39,7 +39,7 @@ Building the same case-insensitive ID with the same compatibility metadata retur
 
 This makes per-load setup calls safe when they repeat an equivalent registration while rejecting two mods that claim the same logical ID differently.
 
-## Register presentation and Product Manager metadata
+## Add optional presentation and Product Manager metadata
 
 Product-kind identity and UI registration are separate. Register immutable
 metadata only when the kind needs a user-facing name, color, search aliases, or
@@ -119,7 +119,7 @@ discover or list a definition.
 
 ## Keep definition and catalog actions explicit
 
-These operations remain separate:
+Keep these operations separate:
 
 1. `ProductKindBuilder.Build()` registers logical identity.
 2. `ProductKindMetadataBuilder.Build()` registers optional presentation and

--- a/S1API/docs/products-api.md
+++ b/S1API/docs/products-api.md
@@ -1,8 +1,10 @@
 # Products API
 
-This page documents the API surface in `S1API/Products/` (definitions, instances, quality, and packaging).
+Use this page to inspect existing product definitions, create item instances,
+work with properties and packaging, or register effect callbacks.
 
-If you want customer preference configuration, see `S1API/docs/products-system.md`.
+For a task-based map of the product APIs, see [Products system](products-system.md).
+Customer preferences belong in [Customer behavior](customer-behavior.md).
 
 ## Key types
 
@@ -32,7 +34,7 @@ For creation and lifecycle guidance, see [Logical Product Kinds](product-kinds.m
 
 ## Getting product definitions
 
-### From the current save (discovered products)
+### From the current save
 
 `ProductManager.DiscoveredProducts` returns product definitions discovered on the current save.
 
@@ -47,7 +49,7 @@ foreach (var product in ProductManager.DiscoveredProducts)
 }
 ```
 
-### By item ID
+### From an item ID
 
 Products are also item definitions, so you can look them up by item ID.
 
@@ -118,7 +120,7 @@ compatible, and therefore require conditional compilation in cross-runtime mods.
 `DrugType.MDMA` and `DrugType.Heroin` mirror values present in the native enum. Their presence does
 not mean that every native product system supports those types.
 
-## Overriding product effect behavior with callbacks
+## Product effect callbacks
 
 You can register callbacks for both player and NPC product effects.
 
@@ -252,7 +254,7 @@ save/load, reconnect, or late join. If an apply callback fails, S1API immediatel
 callback and permits the next native apply lifecycle call to retry. `TargetId` is the native stable
 player code for players and the native NPC ID for NPCs; it is not a display name.
 
-## Creating product instances
+## Create product instances
 
 ### Unpackaged
 
@@ -310,8 +312,8 @@ void Log(ProductInstance inst)
 }
 ```
 
-## See Also
+## See also
 
-- `S1API/docs/products-system.md` (customer preferences and properties)
-- `S1API/docs/products-populator.md` (filling storages with products)
+- [Products system](products-system.md)
+- [ProductPopulator](products-populator.md)
 - <xref:S1API.Products> (API reference)

--- a/S1API/docs/products-populator.md
+++ b/S1API/docs/products-populator.md
@@ -1,91 +1,65 @@
-# ProductPopulator (Storage Helpers)
+# ProductPopulator
 
-`S1API.Products.ProductPopulator` contains convenience helpers for creating product instances (optionally packaged) and adding them to a `S1API.Storages.StorageInstance`.
+`ProductPopulator` creates product instances and adds them to a
+`S1API.Storages.StorageInstance`. Use it for scripted rewards, test setups, or
+stock that your mod owns. It does not register products, discover them, or add
+them to shops.
 
-This is mainly useful for:
-
-- shop/vendor inventories
-- debug/testing
-- scripted rewards and stashes
-
-## Get packaging by ID
+## Resolve packaging
 
 ```csharp
 using S1API.Products;
 
-var jar = ProductPopulator.GetPackaging("jar");
-var baggie = ProductPopulator.GetPackaging("baggie");
+PackagingDefinition? jar = ProductPopulator.GetPackaging("jar");
 ```
 
-Common IDs depend on the base game (examples mentioned in code include: `baggie`, `jar`, `brick`).
+Packaging IDs come from the installed game. Check for `null` before using one.
 
-## Enumerate discovered products
+## Read discovered products
 
-`ProductPopulator.GetAllProductDefinitions()` reads `ProductManager.DiscoveredProducts` and returns the discovered product definitions for the current save.
+`GetAllProductDefinitions()` returns products discovered in the current save.
+It returns an empty collection until that save has discovered products.
 
 ```csharp
+using System.Collections.Generic;
 using S1API.Products;
 
-var defs = ProductPopulator.GetAllProductDefinitions();
+IReadOnlyList<ProductDefinition> products =
+    ProductPopulator.GetAllProductDefinitions();
 ```
 
-There are also typed filters:
-
-- `GetWeedDefinitions()`
-- `GetMethDefinitions()`
-- `GetCocaineDefinitions()`
-- `GetShroomDefinitions()`
+Use `GetWeedDefinitions()`, `GetMethDefinitions()`, `GetCocaineDefinitions()`,
+or `GetShroomDefinitions()` when the native family matters.
 
 ## Create a packaged instance
 
 ```csharp
-using S1API.Products;
+PackagingDefinition? packaging = ProductPopulator.GetPackaging("jar");
+IReadOnlyList<ProductDefinition> products =
+    ProductPopulator.GetAllProductDefinitions();
 
-var packaging = ProductPopulator.GetPackaging("jar");
-if (packaging != null)
+if (packaging != null && products.Count > 0)
 {
-    var productDef = ProductPopulator.GetAllProductDefinitions()[0];
-    var inst = ProductPopulator.CreatePackagedProduct(productDef, packaging, quantity: 20);
+    ProductInstance? instance = ProductPopulator.CreatePackagedProduct(
+        products[0], packaging, quantity: 20);
 }
 ```
 
-## Populate a storage
-
-### From a StorageInstance
+## Populate storage
 
 ```csharp
-using S1API.Products;
-using S1API.Storages;
-
-int added = ProductPopulator.PopulateWithPackagedProducts(storage, packagingId: "jar", quantityPerItem: 20);
+int added = ProductPopulator.PopulateWithPackagedProducts(
+    storage,
+    packagingId: "jar",
+    quantityPerItem: 20);
 ```
 
-### From a GameObject
+Use `PopulateFromGameObject(...)` when you have a game object that contains a
+storage entity. Use `PopulateWithSpecificPackagedProducts(...)` when the mod
+owns an explicit list of product IDs.
 
-If you have a `GameObject` containing a storage entity (or in children), you can populate it directly:
+## See also
 
-```csharp
-using S1API.Products;
-
-int added = ProductPopulator.PopulateFromGameObject(someGameObject, packagingId: "jar", quantityPerItem: 20);
-```
-
-### Specific product IDs
-
-```csharp
-using S1API.Products;
-
-var ids = new System.Collections.Generic.List<string> { "weed", "cocaine" };
-int added = ProductPopulator.PopulateWithSpecificPackagedProducts(storage, ids, packagingId: "baggie", quantityPerProduct: 5);
-```
-
-## Notes
-
-- `ProductManager.DiscoveredProducts` is save-dependent; if nothing is discovered yet, populators that rely on it will add nothing.
-- The helper methods log a lot via `UnityEngine.Debug` (intended for debugging).
-
-## See Also
-
-- `S1API/docs/products-api.md`
+- [Products API](products-api.md)
+- [Generic custom products](generic-custom-products.md)
 - <xref:S1API.Products.ProductPopulator>
-- <xref:S1API.Storages>

--- a/S1API/docs/products-populator.md
+++ b/S1API/docs/products-populator.md
@@ -47,6 +47,9 @@ if (packaging != null && products.Count > 0)
 
 ## Populate storage
 
+In this example, `storage` already refers to the target
+`S1API.Storages.StorageInstance`.
+
 ```csharp
 int added = ProductPopulator.PopulateWithPackagedProducts(
     storage,

--- a/S1API/docs/products-system.md
+++ b/S1API/docs/products-system.md
@@ -1,421 +1,79 @@
-# Products System
-
-S1API provides a comprehensive system for working with products (drugs, goods) in Schedule One, including product definitions, properties, and market dynamics.
-
-## Overview
-
-The Products system allows you to:
-- Access existing product definitions (Weed, Cocaine, Meth, etc.)
-- Create marijuana-family weed variants through the native product lifecycle
-- Work with product property tokens such as `Munchies`, `Energizing`, and `Cyclopean`
-- Retrieve product information and pricing
-- Integrate products with dealers and customers
-
-## Product Definitions
-
-Products in Schedule One are represented by `ProductDefinition` wrappers that provide access to the game's internal product system.
-
-### Accessing Products
-
-Product definitions are discovered per-save. Use `ProductManager.DiscoveredProducts` to enumerate what's available:
-
-```csharp
-using S1API.Products;
-
-foreach (var product in ProductManager.DiscoveredProducts)
-{
-    MelonLoader.MelonLogger.Msg($"{product.ID}: {product.Name} (${product.MarketValue})");
-}
-```
-
-If you already know an item ID, you can resolve it via `ItemManager` and cast to `ProductDefinition`.
-
-To create a weed variant with native registration, saves, and multiplayer
-replication, see [Native Weed Variants](weed-variants.md). Other custom product
-families are not currently exposed by this builder.
-
-### Drug Types
-
-S1API exposes an API-safe `S1API.Products.DrugType` enum for use in affinities:
-
-```csharp
-using S1API.Products;
-
-// Mirrors the base game's drug types
-public enum DrugType
-{
-    Marijuana,
-    Methamphetamine,
-    Cocaine,
-    MDMA,
-    Shrooms,
-    Heroin
-}
-```
-
-## Product Properties
-
-Products have effect properties that affect value, customer preferences, and callbacks. S1API exposes these as `PropertyBase` tokens so mods do not need to reference runtime-specific game effect types directly.
-
-### Common Properties
-
-```csharp
-using S1API.Properties;
-using S1API.Products;
-
-// Properties are accessed through the Property class
-Property.Munchies
-Property.Energizing
-Property.Cyclopean
-Property.Calming
-Property.Euphoric
-// ... many more
-```
-
-### Working with Properties
-
-```csharp
-using S1API.Properties;
-using S1API.Products;
-
-// Get a product instance
-var weedProduct = ProductDefinition.GetByType(DrugType.Marijuana);
-
-if (weedProduct != null)
-{
-    // Properties are accessed through the product's internal system
-    // You'll typically use properties when configuring customers
-
-    // Example: Customer preferences for properties
-    .WithPreferredProperties(Property.Munchies, Property.Energizing, Property.Cyclopean)
-}
-```
-
-## Product Instances
-
-`ProductInstance` represents an actual instance of a product with specific properties:
-
-```csharp
-using S1API.Products;
-
-// Product instances are typically created/managed by the game
-// Access them through game systems or events
-
-public void HandleProductSold(ProductInstance instance)
-{
-    if (instance != null)
-    {
-        var definition = instance.Definition;  // Get the product definition
-        // Work with the specific product instance
-    }
-}
-```
-
-## Using Products with Customers
-
-Products are most commonly used when configuring customer NPCs:
-
-```csharp
-using S1API.Entities;
-using S1API.Economy;
-using S1API.Growing;
-using S1API.Properties;
-
-.WithCustomerDefaults(cd =>
-{
-    // Customer spending and order frequency
-    cd.WithSpending(minWeekly: 500f, maxWeekly: 2000f)
-      .WithOrdersPerWeek(2, 5)
-
-    // Drug preferences and affinities
-    .WithAffinities(new[]
-    {
-        (DrugType.Marijuana, 0.45f),   // Likes weed
-        (DrugType.Cocaine, -0.2f),     // Dislikes cocaine
-        (DrugType.Methamphetamine, 0.0f)  // Neutral on meth
-    })
-
-    // Preferred product properties
-    .WithPreferredProperties(
-        Property.Munchies,
-        Property.Energizing,
-        Property.Cyclopean
-    )
-
-    // Quality standards
-    .WithStandards(CustomerStandard.High);
-});
-```
-
-## Product Properties Reference
-
-The current `Property` helper exposes these built-in tokens:
-
-- `Property.Munchies`
-- `Property.AntiGravity`
-- `Property.Energizing`
-- `Property.Focused`
-- `Property.Smelly`
-- `Property.Euphoric`
-- `Property.Cyclopean`
-- `Property.Slippery`
-- `Property.Shrinking`
-- `Property.Seizure`
-- `Property.Electrifying`
-- `Property.Zombifying`
-- `Property.Disorienting`
-- `Property.Sedating`
-- `Property.CalorieDense`
-- `Property.TropicThunder`
-- `Property.Toxic`
-- `Property.ThoughtProvoking`
-- `Property.Lethal`
-- `Property.Calming`
-- `Property.Schizophrenic`
-- `Property.Spicy`
-- `Property.Laxative`
-- `Property.BrightEyed`
-- `Property.Sneaky`
-- `Property.Jennerising`
-- `Property.Balding`
-- `Property.Glowie`
-- `Property.Refreshing`
-- `Property.Athletic`
-- `Property.LongFaced`
-- `Property.Paranoia`
-- `Property.Gingeritis`
-- `Property.Foggy`
-- `Property.Explosive`
-
-## Customer Affinities
-
-Customer affinities determine how much a customer likes or dislikes specific drugs:
-
-```csharp
-// Affinity values range from -1.0 to 1.0
-.WithAffinities(new[]
-{
-    (DrugType.Marijuana, 0.8f),        // Strongly prefers
-    (DrugType.Cocaine, 0.3f),          // Somewhat likes
-    (DrugType.Methamphetamine, 0.0f),  // Neutral
-    (DrugType.Heroin, -0.5f)           // Dislikes
-})
-```
-
-- **Positive values (0.0 to 1.0)**: Customer likes this drug type
-- **Negative values (-1.0 to 0.0)**: Customer dislikes this drug type
-- **Zero (0.0)**: Customer is neutral
-
-## Customer Standards
-
-Quality standards determine what quality products a customer will accept:
-
-```csharp
-public enum CustomerStandard
-{
-    VeryLow,    // Accepts any quality
-    Low,        // Accepts poor to good quality
-    Medium,     // Accepts average to good quality
-    High,       // Only accepts good to excellent quality
-    VeryHigh    // Only accepts excellent quality
-}
-
-// Usage
-.WithCustomerDefaults(cd =>
-{
-    cd.WithStandards(CustomerStandard.High);  // Picky customer
-});
-```
-
-## Complete Customer Example
-
-Here's a complete example of an NPC customer with detailed product preferences:
-
-```csharp
-using S1API.Entities;
-using S1API.Economy;
-using S1API.GameTime;
-using S1API.Growing;
-using S1API.Properties;
-using UnityEngine;
-
-public sealed class SelectiveCustomer : NPC
-{
-    public override bool IsPhysical => true;
-
-    protected override void ConfigurePrefab(NPCPrefabBuilder builder)
-    {
-        builder.WithIdentity("selective_customer", "Sarah", "Johnson")
-            .WithSpawnPosition(new Vector3(0, 0, 0))
-            .WithAppearanceDefaults(av =>
-            {
-                av.Gender = 1.0f;
-                av.Height = 0.95f;
-            })
-            .EnsureCustomer()
-            .WithCustomerDefaults(cd =>
-            {
-                // High spending, selective customer
-                cd.WithSpending(minWeekly: 800f, maxWeekly: 3000f)
-                  .WithOrdersPerWeek(2, 4)
-                  .WithPreferredOrderDay(Day.Friday)
-                  .WithOrderTime(1800)  // 6 PM
-
-                // Quality conscious
-                .WithStandards(CustomerStandard.High)
-                .AllowDirectApproach(false)  // Must be introduced
-                .GuaranteeFirstSample(true)
-
-                // Relationship requirements
-                .WithMutualRelationRequirement(minAt50: 3.0f, maxAt100: 4.5f)
-                .WithCallPoliceChance(0.05f)  // Low risk
-
-                // Addiction profile
-                .WithDependence(baseAddiction: 0.2f, dependenceMultiplier: 1.2f)
-
-                // Drug preferences - loves weed, dislikes hard drugs
-                .WithAffinities(new[]
-                {
-                    (DrugType.Marijuana, 0.9f),        // Strongly prefers
-                    (DrugType.Cocaine, -0.6f),         // Strongly dislikes
-                    (DrugType.Methamphetamine, -0.8f)  // Very much dislikes
-                })
-
-                // Property preferences
-                .WithPreferredProperties(
-                    Property.Calming,
-                    Property.Euphoric,
-                    Property.Munchies
-                );
-            })
-            .WithRelationshipDefaults(r =>
-            {
-                r.WithDelta(2.0f)
-                 .SetUnlocked(false)
-                 .SetUnlockType(NPCRelationship.UnlockType.Introduction);
-            });
-    }
-
-    protected override void OnCreated()
-    {
-        base.OnCreated();
-        Appearance.Build();
-
-        Dialogue.BuildAndSetDatabase(db =>
-        {
-            db.WithModuleEntry("Reactions", "GREETING",
-                "I only deal with quality products. No junk.");
-        });
-
-        Aggressiveness = 1f;
-        Region = Region.Downtown;
-        Schedule.Enable();
-    }
-}
-```
-
-## Best Practices
-
-1. **Balanced Affinities**: Don't make all affinities extreme - mix preferences for realistic customers
-
-2. **Property Consistency**: Match preferred property tokens with drug affinities. Use actual `S1API.Properties.Property` constants, not inferred product stats.
-
-3. **Quality Standards**: Match standards with spending levels
-   - High spenders → High/VeryHigh standards
-   - Low spenders → Low/Medium standards
-
-4. **Addiction Progression**: Use `WithDependence()` to create realistic addiction dynamics
-
-5. **Risk Assessment**: Balance `WithCallPoliceChance()` with customer value and relationship
-
-## Property Discovery
-
-To discover all available properties, you can enumerate them at runtime:
-
-```csharp
-using S1API.Properties;
-using S1API.Properties.Interfaces;
-using System.Reflection;
-
-// Get all static Property fields
-var propertyType = typeof(Property);
-var properties = propertyType.GetFields(
-    BindingFlags.Public | BindingFlags.Static
-);
-
-foreach (var field in properties)
-{
-    if (field.FieldType == typeof(PropertyBase))
-    {
-        var prop = (PropertyBase)field.GetValue(null);
-        MelonLogger.Msg($"Property: {field.Name}");
-    }
-}
-```
-
-## Common Patterns
-
-### Creating a Weed Enthusiast
-
-```csharp
-.WithCustomerDefaults(cd =>
-{
-    cd.WithAffinities(new[] { (DrugType.Marijuana, 0.9f) })
-      .WithPreferredProperties(
-          Property.Calming,
-          Property.Munchies,
-          Property.Euphoric
-      )
-      .WithStandards(CustomerStandard.High);
-});
-```
-
-### Creating a Party Customer
-
-```csharp
-.WithCustomerDefaults(cd =>
-{
-    cd.WithAffinities(new[]
-      {
-          (DrugType.Cocaine, 0.7f),
-          (DrugType.Marijuana, 0.4f)
-      })
-      .WithPreferredProperties(
-          Property.Energizing,
-          Property.Euphoric,
-          Property.Focused
-      )
-      .WithStandards(CustomerStandard.Medium);
-});
-```
-
-### Creating a Desperate Customer
-
-```csharp
-.WithCustomerDefaults(cd =>
-{
-    cd.WithSpending(50f, 200f)  // Low budget
-      .WithAffinities(new[]
-      {
-          (DrugType.Methamphetamine, 0.8f)
-      })
-      .WithStandards(CustomerStandard.VeryLow)  // Accepts anything
-      .WithDependence(0.8f, 1.5f);  // Highly addicted
-});
-```
-
-## Technical Notes
-
-- Product definitions are wrappers around the game's internal product system
-- Properties use a token-based system internally for cross-runtime compatibility
-- Customer preferences are saved with the game's save system
-- Addiction levels affect order frequency and spending over time
-
-## See Also
-
-- [Customer Behavior](customer-behavior.md) - Detailed customer configuration
-- [Dealer System](dealer-system.md) - Creating dealers who distribute products
-- [Custom NPCs](custom-npcs.md) - Core NPC creation
-- [CustomNPCTest Example](https://github.com/ifBars/S1API/tree/main/CustomNPCTest)
-- <xref:S1API.Products> - Products API Reference
-- <xref:S1API.Property> - Properties API Reference
+# Products system
+
+Use the product APIs to work with existing products or register fixed,
+mod-owned product definitions. S1API keeps product identity, save data, and
+network behavior explicit so a visual or catalog addition does not silently
+change gameplay state.
+
+## Choose the product path
+
+- **Read or create instances of an existing product:** start with
+  [Products API](products-api.md).
+- **Create a marijuana-family variant through the native game path:** use
+  [Native weed variants](weed-variants.md).
+- **Create a fixed product outside the native drug families:** use
+  [Generic custom products](generic-custom-products.md).
+- **Group mod-owned products under a durable logical ID:** use
+  [Logical product kinds](product-kinds.md).
+- **Fill a storage, reward, or test inventory with product instances:** use
+  [ProductPopulator](products-populator.md).
+- **Register runtime additives for growing:** use
+  [Runtime additives](runtime-additives.md).
+
+## Product concepts
+
+`ProductDefinition` describes a product type. `ProductInstance` is one stack
+or item of that product. A product definition can have properties, a price,
+legal status, valid packaging, and presentation data.
+
+Use `ProductManager.DiscoveredProducts` only for products discovered in the
+current save. A custom definition is registered separately, then discovery and
+listing are explicit host-side actions after loading.
+
+## Registration order
+
+Register custom product kinds, profiles, and definitions during
+`GameLifecycle.OnPreLoad`. Register the same stable IDs on every peer before
+native save restoration. Defer discovery, Product Manager listing, and shop
+inventory changes until `GameLifecycle.OnLoadComplete`.
+
+Do not use a display name as an ID. Published product and product-kind IDs are
+durable, namespaced, and case-insensitive.
+
+## Presentation and packaging
+
+Generic products borrow the game's interaction scaffolding from a native
+representation template. Add a `ProductPresentationProfile` only when the
+product needs mod-owned loose, held, station, functional-product, or icon
+visuals. Add a packaging-content profile when a filled baggie, jar, or brick
+needs mod-owned contents.
+
+The [presentation workbench](presentation-workbench.md) is a local authoring
+tool for registered product and item visuals. It does not persist edits or
+transfer assets between peers.
+
+## Product Manager and shops
+
+`ProductKind` establishes logical identity. `ProductKindMetadata` optionally
+adds a display name, color, icon, aliases, and an S1API-managed Product Manager
+section. It does not create a definition, discover a product, list it, or add
+it to a shop.
+
+Discovery, listing, and shop stock are independent actions. This lets a mod
+register a product before save loading without forcing it into a player's
+catalog or a vendor inventory.
+
+## Customer preferences
+
+Customers use `DrugType`, property tokens, affinities, and standards when they
+choose orders. Configure that behavior through the NPC builders in
+[Customer behavior](customer-behavior.md), not through product registration.
+
+## Read next
+
+1. Read [Products API](products-api.md) for wrappers, instances, packaging, and
+   effect callbacks.
+2. Choose [Native weed variants](weed-variants.md) or
+   [Generic custom products](generic-custom-products.md) for registration.
+3. Add [Logical product kinds](product-kinds.md) only when another system needs
+   a durable category or Product Manager metadata.

--- a/S1API/docs/runtime-additives.md
+++ b/S1API/docs/runtime-additives.md
@@ -1,97 +1,66 @@
-# Runtime Additives
+# Runtime additives
 
-Create runtime additives (`AdditiveDefinition`) through the additive builder API.
+Create `AdditiveDefinition` instances with the additive builder. Definitions
+are read-only after registration, so configure their effects before `Build()`.
 
-## Important Notes
+Register additives before save restoration, preferably in
+`GameLifecycle.OnPreLoad`. An additive that registers later may not be
+available to restored items or grow containers.
 
-- `AdditiveDefinition` is builder-only and intentionally read-only after registration to avoid mid-session mutation issues
-- Configure additive effects during build time
-- For best results, register additives before save data loads
-- Prefer `GameLifecycle.OnPreLoad` when possible
-
-## Example: Recommended Timing
+## Register an additive
 
 ```csharp
-using MelonLoader;
 using S1API.Items;
 using S1API.Lifecycle;
 
-public class MyMod : MelonMod
+GameLifecycle.OnPreLoad += () =>
 {
-    public override void OnSceneWasLoaded(int buildIndex, string sceneName)
-    {
-        if (sceneName != "Main")
-            return;
-
-        GameLifecycle.OnPreLoad += RegisterItems;
-    }
-
-    private static void RegisterItems()
-    {
-        var growthBooster = AdditiveItemCreator.CreateBuilder()
-            .WithBasicInfo(
-                id: "mymod_growth_booster",
-                name: "Growth Booster",
-                description: "A custom growth enhancer additive.",
-                category: ItemCategory.Growing
-            )
-            .WithStackLimit(10)
-            .WithPricing(basePurchasePrice: 150f, resellMultiplier: 0.5f)
-            .WithEffects(
-                yieldMultiplier: 1.5f,
-                instantGrowth: 0.5f,
-                qualityChange: 1.0f
-            )
-            .Build();
-
-        MelonLogger.Msg($"Registered additive: {growthBooster.Name} ({growthBooster.ID})");
-    }
-}
+    AdditiveDefinition growthBooster = AdditiveItemCreator.CreateBuilder()
+        .WithBasicInfo(
+            id: "my-mod:growth-booster",
+            name: "Growth Booster",
+            description: "A custom growing additive.",
+            category: ItemCategory.Growing)
+        .WithStackLimit(10)
+        .WithPricing(basePurchasePrice: 150f, resellMultiplier: 0.5f)
+        .WithEffects(
+            yieldMultiplier: 1.5f,
+            instantGrowth: 0.5f,
+            qualityChange: 1f)
+        .Build();
+};
 ```
 
-## Cloning an Existing Additive
+## Clone a native additive
 
 ```csharp
-var variant = AdditiveItemCreator.CloneFrom("pgr")
-    .WithBasicInfo("mymod_pgr_variant", "PGR Variant", "A tweaked PGR.", ItemCategory.Growing)
-    .WithEffects(1.25f, 0.25f, 0.0f)
+AdditiveDefinition variant = AdditiveItemCreator.CloneFrom("pgr")
+    .WithBasicInfo(
+        "my-mod:pgr-variant",
+        "PGR Variant",
+        "A modified growing additive.",
+        ItemCategory.Growing)
+    .WithEffects(1.25f, 0.25f, 0f)
     .Build();
 ```
 
-## Allowing Additives on Grow Containers
+## Allow an additive in grow containers
 
-Grow containers have a fixed additive allowlist (`GrowContainer.AllowedAdditives`). S1API can extend that allowlist globally so mods do not need to patch `GrowContainer.InitializeGridItem`.
-
-Notes:
-
-- Applies to all grow containers
-- Duplicate `AllowAdditive(...)` calls are a no-op
-- If an ID cannot be resolved to an `AdditiveDefinition` at runtime, S1API warns once and skips it
+Grow containers use a global allowlist. Register the additive first, then add
+its stable ID during `OnPreLoad`:
 
 ```csharp
-using MelonLoader;
 using S1API.Growing;
-using S1API.Lifecycle;
 
-public class MyMod : MelonMod
-{
-    public override void OnSceneWasLoaded(int buildIndex, string sceneName)
-    {
-        if (sceneName != "Main")
-            return;
-
-        GameLifecycle.OnPreLoad += () =>
-        {
-            GrowContainerAdditives.AllowAdditive("mymod_growth_booster");
-        };
-    }
-}
+GameLifecycle.OnPreLoad += () =>
+    GrowContainerAdditives.AllowAdditive("my-mod:growth-booster");
 ```
 
-## See Also
+Repeated calls for the same ID do nothing. If S1API cannot resolve the ID to an
+`AdditiveDefinition`, it logs one warning and skips it.
 
-- [Item Registration & Basics](item-registration-basics.md)
-- [Builder API Reference](item-builder-reference.md)
+## See also
+
+- [Item registration](item-registration-basics.md)
+- [Item builder reference](item-builder-reference.md)
 - <xref:S1API.Items.AdditiveItemCreator>
-- <xref:S1API.Items.AdditiveDefinitionBuilder>
-- <xref:S1API.Items.AdditiveDefinition>

--- a/S1API/index.md
+++ b/S1API/index.md
@@ -84,10 +84,6 @@ _layout: landing
       <h3>Cutscenes</h3>
       <p>Play local camera-driven cinematics with cross-runtime cleanup, skip controls, fades, and title cards.</p>
     </a>
-    <a class="s1-card" href="docs/law-enforcement.md">
-      <h3>Law enforcement</h3>
-      <p>Use checkpoint, curfew, patrol, pursuit, and dispatch abstractions for police-oriented mods.</p>
-    </a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Add opt-in trash-prefab registration for station items.
- Use the compact presentation workbench command and add regression coverage.
- Refine product authoring docs and XML comments, including lifecycle and multiplayer boundaries.
- Remove the Law enforcement card from the DocFX home-page module list.

## Compatibility
- The trash-prefab API is additive and opt-in. Existing item builders keep their previous behavior unless WithTrashPrefab is called.
- Stable trash IDs and matching local registrations are required on every multiplayer peer; no assets are serialized or transferred.
- The internal developer-console command changes from presentation_workbench to presentationworkbench. No compatibility alias is retained.
- Product wrapper behavior, save IDs, network payloads, and native product-family behavior are unchanged.

## Runtime evidence
- Product-focused Mono tests: 276 passed.
- Presentation workbench tests: 23 Mono and 22 IL2CPP passed.
- Focused trash API tests: 3 Mono and 3 IL2CPP passed.
- IL2CPP build passed with no warnings or errors.
- Custom trash spawning still requires manual in-game validation because the unit runner does not host Unity's native TrashManager lifecycle.

## Documentation
- Reworked the product overview into a task-based route page.
- Updated product API, ProductPopulator, runtime additive, product-kind, and presentation workbench guides.
- Expanded public product XML comments around lifecycle, ownership, failure, and multiplayer behavior.
- Removed the Law enforcement card from the DocFX home page.

## Validation
- DocFX HTML build completed with 0 errors; the 4 unresolved external-assembly warnings are pre-existing.
- git diff --check passed.