### PR TITLE
chore(Release): bump version to 3.1.1

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.0", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.1", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.0</Version>
+        <Version>3.1.1</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## What changed

Aligns the package and MelonLoader assembly metadata with the imminent 3.1.1 stable release.

## Why

The 3.1.1 feature PR was merged without a version metadata bump. Releasing from that commit would package 3.1.1 archives containing DLLs that identify as 3.1.0.

## Validation

- Confirmed both version sources now declare 3.1.1.
- git diff --check