### PR TITLE
fix(phoneapp): preserve native home screen icons

### DIFF
--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -1,12 +1,14 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
-using UnityEngine.UI;
-using Object = UnityEngine.Object;
+using HarmonyLib;
+using MelonLoader;
 using S1API.Internal.Abstraction;
 using S1API.Internal.Patches;
 using S1API.Internal.Utils;
-using System;
-using MelonLoader;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
 #if IL2CPPMELON
 using Il2CppScheduleOne.UI;
 using Il2CppScheduleOne.UI.Phone;
@@ -325,16 +327,14 @@ namespace S1API.PhoneApp
                 return;
             }
 
-            // Find the LAST icon (the one most recently added)
-            Transform? lastIcon = appIcons.transform.childCount > 0 ? appIcons.transform.GetChild(appIcons.transform.childCount - 1) : null;
-            if (lastIcon == null)
+            GameObject? iconObj = CreateAppIcon(homeScreenInstance, appIcons.transform);
+            if (iconObj == null)
             {
-                Logger.Error("No icons found in AppIcons.");
+                Logger.Error($"Failed to create an icon for {AppName}.");
                 return;
             }
 
-            GameObject iconObj = lastIcon.gameObject;
-            iconObj.name = AppName; // Rename it now
+            iconObj.name = AppName;
             
             // Cache icon image for future updates
             Transform imageTransform = iconObj.transform.Find("Mask/Image");
@@ -373,6 +373,55 @@ namespace S1API.PhoneApp
                 iconButton.onClick.RemoveAllListeners();
                 global::S1API.Utils.EventHelper.AddListener(OpenApp, iconButton.onClick);
             }
+        }
+
+        /// <summary>
+        /// Creates and registers an independent home-screen icon using the native icon prefab.
+        /// </summary>
+        private static GameObject? CreateAppIcon(HomeScreen homeScreenInstance, Transform parent)
+        {
+#if IL2CPPMELON
+            GameObject? iconPrefab = homeScreenInstance.appIconPrefab;
+#else
+            GameObject? iconPrefab = AccessTools.Field(
+                typeof(HomeScreen),
+                "appIconPrefab")?.GetValue(homeScreenInstance) as GameObject;
+#endif
+            if (iconPrefab == null)
+            {
+                Logger.Error("HomeScreen appIconPrefab was unavailable.");
+                return null;
+            }
+
+            GameObject iconObject = Object.Instantiate(iconPrefab, parent);
+            Button? button = iconObject.GetComponent<Button>();
+            UISelectable? selectable = iconObject.GetComponent<UISelectable>();
+            if (button == null || selectable == null)
+            {
+                Logger.Error("Native phone app icon prefab is missing Button or UISelectable.");
+                Object.Destroy(iconObject);
+                return null;
+            }
+
+#if IL2CPPMELON
+            var nativeButtons = homeScreenInstance.appIcons;
+            var uiPanel = homeScreenInstance.uiPanel;
+#else
+            var appIconsField = AccessTools.Field(typeof(HomeScreen), "appIcons");
+            var uiPanelField = AccessTools.Field(typeof(HomeScreen), "uiPanel");
+            var nativeButtons = appIconsField?.GetValue(homeScreenInstance) as List<Button>;
+            var uiPanel = uiPanelField?.GetValue(homeScreenInstance) as UIPanel;
+#endif
+            if (nativeButtons == null || uiPanel == null)
+            {
+                Logger.Error("HomeScreen icon registration fields were unavailable.");
+                Object.Destroy(iconObject);
+                return null;
+            }
+
+            nativeButtons.Add(button);
+            uiPanel.AddSelectable(selectable);
+            return iconObject;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- instantiate a dedicated icon from the native phone app prefab instead of reusing the last built-in icon
- register the new button and selectable with the native `HomeScreen` collections on Mono and IL2CPP
- preserve the Delivery app and all other native home-screen entries

## Root cause

`PhoneApp.SpawnIcon` treated the final child under `AppIcons` as the custom app icon. In game 0.4.6f11 that final child is the native Delivery icon, so registering a custom app renamed and rewired Delivery instead of creating a new entry.

## Screenshot

<img width="386" height="670" alt="image" src="https://github.com/user-attachments/assets/382dc7ff-f445-4f16-a792-2c1eae614c89" />

## Validation

- reproduced on Mono with S1API 3.1.1: 7 icons; Delivery was renamed and rewired to the smoke app
- fixed Mono smoke: 8 icons; Delivery and the custom app are both present and independently registered
- fixed IL2CPP smoke: 8 icons; Delivery and the custom app are both present and independently registered
- Mono solution build: clean
- Mono tests: 402/402 passed
- IL2CPP solution build: clean
- IL2CPP isolated test matrix: 391/391 passed

No public API, save format, or network payload changes.

Closes #172