### PR TITLE
chore(release): bump S1API to 3.1.2

### DIFF
--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -1,12 +1,14 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
-using UnityEngine;
-using UnityEngine.UI;
-using Object = UnityEngine.Object;
+using HarmonyLib;
+using MelonLoader;
 using S1API.Internal.Abstraction;
 using S1API.Internal.Patches;
 using S1API.Internal.Utils;
-using System;
-using MelonLoader;
+using UnityEngine;
+using UnityEngine.UI;
+using Object = UnityEngine.Object;
 #if IL2CPPMELON
 using Il2CppScheduleOne.UI;
 using Il2CppScheduleOne.UI.Phone;
@@ -325,16 +327,14 @@ namespace S1API.PhoneApp
                 return;
             }
 
-            // Find the LAST icon (the one most recently added)
-            Transform? lastIcon = appIcons.transform.childCount > 0 ? appIcons.transform.GetChild(appIcons.transform.childCount - 1) : null;
-            if (lastIcon == null)
+            GameObject? iconObj = CreateAppIcon(homeScreenInstance, appIcons.transform);
+            if (iconObj == null)
             {
-                Logger.Error("No icons found in AppIcons.");
+                Logger.Error($"Failed to create an icon for {AppName}.");
                 return;
             }
 
-            GameObject iconObj = lastIcon.gameObject;
-            iconObj.name = AppName; // Rename it now
+            iconObj.name = AppName;
             
             // Cache icon image for future updates
             Transform imageTransform = iconObj.transform.Find("Mask/Image");
@@ -373,6 +373,55 @@ namespace S1API.PhoneApp
                 iconButton.onClick.RemoveAllListeners();
                 global::S1API.Utils.EventHelper.AddListener(OpenApp, iconButton.onClick);
             }
+        }
+
+        /// <summary>
+        /// Creates and registers an independent home-screen icon using the native icon prefab.
+        /// </summary>
+        private static GameObject? CreateAppIcon(HomeScreen homeScreenInstance, Transform parent)
+        {
+#if IL2CPPMELON
+            GameObject? iconPrefab = homeScreenInstance.appIconPrefab;
+#else
+            GameObject? iconPrefab = AccessTools.Field(
+                typeof(HomeScreen),
+                "appIconPrefab")?.GetValue(homeScreenInstance) as GameObject;
+#endif
+            if (iconPrefab == null)
+            {
+                Logger.Error("HomeScreen appIconPrefab was unavailable.");
+                return null;
+            }
+
+            GameObject iconObject = Object.Instantiate(iconPrefab, parent);
+            Button? button = iconObject.GetComponent<Button>();
+            UISelectable? selectable = iconObject.GetComponent<UISelectable>();
+            if (button == null || selectable == null)
+            {
+                Logger.Error("Native phone app icon prefab is missing Button or UISelectable.");
+                Object.Destroy(iconObject);
+                return null;
+            }
+
+#if IL2CPPMELON
+            var nativeButtons = homeScreenInstance.appIcons;
+            var uiPanel = homeScreenInstance.uiPanel;
+#else
+            var appIconsField = AccessTools.Field(typeof(HomeScreen), "appIcons");
+            var uiPanelField = AccessTools.Field(typeof(HomeScreen), "uiPanel");
+            var nativeButtons = appIconsField?.GetValue(homeScreenInstance) as List<Button>;
+            var uiPanel = uiPanelField?.GetValue(homeScreenInstance) as UIPanel;
+#endif
+            if (nativeButtons == null || uiPanel == null)
+            {
+                Logger.Error("HomeScreen icon registration fields were unavailable.");
+                Object.Destroy(iconObject);
+                return null;
+            }
+
+            nativeButtons.Add(button);
+            uiPanel.AddSelectable(selectable);
+            return iconObject;
         }
 
         /// <summary>

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.1", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.2", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.1</Version>
+        <Version>3.1.2</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- backport the phone home-screen icon fix from #173 to the 3.1.1 maintenance line
- bump the package version and MelonLoader metadata from 3.1.1 to 3.1.2
- prepare the exact source that will be tagged as `v3.1.2`

## Validation

- tracked version scan: no stale 3.1.1 product-version strings
- Mono solution build: clean, produced `S1API.Forked.3.1.2.nupkg`
- IL2CPP solution build: clean, produced `S1API.Forked.3.1.2.nupkg`
- phone fix validation from #173: Mono 402/402 tests; IL2CPP isolated matrix 391/391; live smoke passed on both runtimes

## Release plan

After merge, tag the release-branch merge commit as `v3.1.2`, create `releases/3.1.2` from that exact commit, and verify GitHub/Nexus/Thunderstore/NuGet deployment workflows.