### PR TITLE
chore(release): align stable version to 3.1.2

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.1", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.2", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.1</Version>
+        <Version>3.1.2</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- align stable package metadata with the newly published 3.1.2 maintenance release
- update both the NuGet/project version and MelonLoader assembly metadata

## Validation

- exhaustive tracked-file scan found no remaining 3.1.1 product-version strings
- the identical 3.1.2 version surfaces built clean for Mono and IL2CPP in release PR #174

The phone icon fix itself is already present on stable through #173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the S1API package and assembly version to 3.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->