### PR TITLE
fix(storage): restore saved capacities above default limit

### DIFF
--- a/S1API.Tests/Storage/StorageRestorePolicyTests.cs
+++ b/S1API.Tests/Storage/StorageRestorePolicyTests.cs
@@ -1,0 +1,18 @@
+using S1API.Internal.Patches;
+
+namespace S1API.Tests.Storage;
+
+public sealed class StorageRestorePolicyTests
+{
+    [Fact]
+    public void PersistedSlotCountCanExceedTheDefaultWrapperLimit()
+    {
+        Assert.Equal(24, StoragePatches.ResolveRestoreMaxSlots(20, 24));
+    }
+
+    [Fact]
+    public void PersistedSlotCountDoesNotLowerAnExplicitLimit()
+    {
+        Assert.Equal(32, StoragePatches.ResolveRestoreMaxSlots(32, 24));
+    }
+}

--- a/S1API/Internal/Patches/StoragePatches.cs
+++ b/S1API/Internal/Patches/StoragePatches.cs
@@ -42,6 +42,9 @@ namespace S1API.Internal.Patches
         private static readonly HashSet<int> _processedStorages = new HashSet<int>();
         private const string ExtraSlotMetaKey = "S1API_Storage_SlotMeta";
 
+        internal static int ResolveRestoreMaxSlots(int configuredMaxSlots, int persistedSlotCount) =>
+            Math.Max(configuredMaxSlots, persistedSlotCount);
+
         [Serializable]
         private class StorageSlotMeta : S1Persistence.SaveData
         {
@@ -381,7 +384,14 @@ namespace S1API.Internal.Patches
 
                 // Expand slots before hydrating contents
                 var wrapper = new StorageEntity(storageEntity, placeableStorage!);
-                wrapper.SetSlotCount(targetSlots);
+                wrapper.MaxSlots = ResolveRestoreMaxSlots(wrapper.MaxSlots, targetSlots);
+                if (!wrapper.SetSlotCount(targetSlots))
+                {
+                    string itemId = placeableStorage!.ItemInstance?.Definition?.ID ?? "unknown";
+                    Logger.Warning(
+                        $"Failed to restore {targetSlots} storage slots for item '{itemId}'. " +
+                        "Saved contents may not fit in the available slots.");
+                }
 
                 contents.LoadTo(storageEntity.ItemSlots);
 

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.2", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.3", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.2</Version>
+        <Version>3.1.3</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- allow persisted storage topology to raise the restore-time wrapper limit before hydrating saved contents
- keep the public `StorageEntity.MaxSlots` default and normal `AddSlots` guard unchanged
- report a targeted warning if slot expansion still fails
- bump the S1API package/assembly and Melon versions to 3.1.3

## Root cause

`PlaceableStorageEntityLoader_Load_Prefix` creates a fresh S1API `StorageEntity` wrapper whose `MaxSlots` defaults to 20. A modded storage prefab can legitimately expose more slots (the forklift pallet has 24), and its save metadata/content array preserves that larger topology. During load, `SetSlotCount(24)` was therefore rejected by the wrapper before saved contents were hydrated.

The restore path now treats the persisted slot count as authoritative for that wrapper only. This avoids weakening the normal capacity guard for other API callers.

## Compatibility

- Source compatibility: unchanged; no public or protected API signatures changed.
- Binary compatibility: unchanged; no public or protected members were added, removed, or reshaped.
- Behavioral compatibility: ordinary storage mutation still defaults to a 20-slot ceiling. Only saved topology restoration may raise an individual wrapper's ceiling.
- Save compatibility: no format changes. Existing saves with expanded storage topology can now restore capacities above 20.
- Network compatibility: unchanged.

## Validation

- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon -p:AutomateLocalDeployment=false --no-restore` — 404 passed
- focused storage restore policy tests on MonoMelon — 2 passed
- focused storage restore policy tests on Il2CppMelon — 2 passed
- Il2CppMelon unaffected group — 271 passed together
- Il2CppMelon native-wrapper classes — 122 passed in isolated class processes (393 total)
- built Mono and IL2CPP assemblies both report version `3.1.3.0`

The monolithic IL2CPP test process still hits the repository's existing native-wrapper finalizer contamination when `GameAssembly` is unavailable; the prescribed isolated runs pass.
