### PR TITLE
fix(storage): release 3.1.3 with expanded capacity restoration

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -2,63 +2,63 @@ name: Publish NuGet Package
 
 on:
   push:
-    branches: [ 'releases/**' ]
-    paths:
-      - S1API/S1API.csproj
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing stable release tag to publish (for example v3.1.3)
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout S1API
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect Version Bump
+      - name: Resolve stable release version
         id: version
         shell: bash
         run: |
-          NEW_VERSION=$(grep -oPm1 '(?<=<Version>)[^<]+' S1API/S1API.csproj)
-
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Publishing version $NEW_VERSION from manual dispatch"
-            exit 0
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF_NAME}"
           fi
 
-          OLD_VERSION=$(git show "${{ github.event.before }}:S1API/S1API.csproj" 2>/dev/null | grep -oPm1 '(?<=<Version>)[^<]+' || true)
-
-          if [[ -z "$NEW_VERSION" ]]; then
-            echo "Unable to read current package version"
+          if [[ ! "$tag" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::error::Tag '$tag' is not a stable semantic version tag"
             exit 1
           fi
 
-          if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-            echo "Version unchanged at $NEW_VERSION; skipping publish"
-            exit 0
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "new_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout S1API
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify source version matches tag
+        shell: bash
+        run: |
+          source_version=$(grep -oPm1 '(?<=<Version>)[^<]+' S1API/S1API.csproj)
+
+          if [[ "$source_version" != "${{ steps.version.outputs.new_version }}" ]]; then
+            echo "::error::S1API project version '$source_version' does not match tag '${{ steps.version.outputs.tag }}'"
+            exit 1
           fi
 
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-          echo "old_version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version bump detected: ${OLD_VERSION:-none} -> $NEW_VERSION"
-
       - name: Setup .NET
-        if: steps.version.outputs.changed == 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
 
       - name: Checkout Game Assemblies
-        if: steps.version.outputs.changed == 'true'
         uses: actions/checkout@v4
         with:
           repository: ${{ secrets.GAME_ASSEMBLIES_REPO }}
@@ -67,7 +67,6 @@ jobs:
           fetch-depth: 1
 
       - name: Prepare Build Inputs
-        if: steps.version.outputs.changed == 'true'
         shell: bash
         run: |
           mkdir -p S1API/ScheduleOneAssemblies/Managed
@@ -111,19 +110,15 @@ jobs:
           EOF
 
       - name: Restore Dependencies
-        if: steps.version.outputs.changed == 'true'
         run: dotnet restore S1API/S1API.csproj -p:Configuration=MonoMelon
 
       - name: Build Package Assembly
-        if: steps.version.outputs.changed == 'true'
         run: dotnet build S1API/S1API.csproj --no-restore -c MonoMelon -v minimal
 
       - name: Pack NuGet Package
-        if: steps.version.outputs.changed == 'true'
         run: dotnet pack S1API/S1API.csproj --no-build --no-restore -c MonoMelon /p:ContinuousIntegrationBuild=true
 
       - name: Publish to NuGet
-        if: steps.version.outputs.changed == 'true'
         shell: bash
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/S1API.Tests/Storage/StorageRestorePolicyTests.cs
+++ b/S1API.Tests/Storage/StorageRestorePolicyTests.cs
@@ -1,0 +1,18 @@
+using S1API.Internal.Patches;
+
+namespace S1API.Tests.Storage;
+
+public sealed class StorageRestorePolicyTests
+{
+    [Fact]
+    public void PersistedSlotCountCanExceedTheDefaultWrapperLimit()
+    {
+        Assert.Equal(24, StoragePatches.ResolveRestoreMaxSlots(20, 24));
+    }
+
+    [Fact]
+    public void PersistedSlotCountDoesNotLowerAnExplicitLimit()
+    {
+        Assert.Equal(32, StoragePatches.ResolveRestoreMaxSlots(32, 24));
+    }
+}

--- a/S1API/Internal/Patches/StoragePatches.cs
+++ b/S1API/Internal/Patches/StoragePatches.cs
@@ -42,6 +42,9 @@ namespace S1API.Internal.Patches
         private static readonly HashSet<int> _processedStorages = new HashSet<int>();
         private const string ExtraSlotMetaKey = "S1API_Storage_SlotMeta";
 
+        internal static int ResolveRestoreMaxSlots(int configuredMaxSlots, int persistedSlotCount) =>
+            Math.Max(configuredMaxSlots, persistedSlotCount);
+
         [Serializable]
         private class StorageSlotMeta : S1Persistence.SaveData
         {
@@ -381,7 +384,14 @@ namespace S1API.Internal.Patches
 
                 // Expand slots before hydrating contents
                 var wrapper = new StorageEntity(storageEntity, placeableStorage!);
-                wrapper.SetSlotCount(targetSlots);
+                wrapper.MaxSlots = ResolveRestoreMaxSlots(wrapper.MaxSlots, targetSlots);
+                if (!wrapper.SetSlotCount(targetSlots))
+                {
+                    string itemId = placeableStorage!.ItemInstance?.Definition?.ID ?? "unknown";
+                    Logger.Warning(
+                        $"Failed to restore {targetSlots} storage slots for item '{itemId}'. " +
+                        "Saved contents may not fit in the available slots.");
+                }
 
                 contents.LoadTo(storageEntity.ItemSlots);
 

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.2", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.3", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.2</Version>
+        <Version>3.1.3</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -5,11 +5,11 @@ This repository uses branch-based version maintenance so active development can 
 ## Core Rules
 
 - `stable` always represents the next planned release line.
-- Every shipped version gets its own maintenance branch named `releases/x.y.z`.
-- Release branches only receive fixes that are safe for that shipped version.
+- Every shipped version gets an immutable branch named `releases/x.y.z` that points to the same commit as its tag.
+- A release branch may be pushed before publication as the pull-request branch for that version, but it becomes immutable once `vX.Y.Z` is tagged.
 - Breaking changes, refactors, and new feature work stay on `stable` unless they are intentionally backported.
 - Each public release is identified by a git tag.
-- NuGet publishing automation only runs from `releases/x.y.z` branches, not from `stable`.
+- Stable package publication is triggered by the exact `vX.Y.Z` tag, not by a branch push.
 
 ## Branch Roles
 
@@ -23,13 +23,22 @@ This repository uses branch-based version maintenance so active development can 
 
 ### `releases/x.y.z`
 
-Each release branch preserves the source for one shipped version.
+Each release branch preserves the source for exactly one shipped version.
 
-- Create the branch immediately after publishing `x.y.z`.
-- For an active maintenance line, work from the newest shipped patch branch in that line.
-- Only put hotfixes, packaging fixes, and other low-risk corrections on that branch.
-- Do not merge unrelated `stable` work into a release branch.
-- If a fix starts on a release branch, cherry-pick it back to `stable` if the issue also exists there.
+- Prepare `releases/X.Y.Z` from the intended stable base and use it as the PR head for that release.
+- Merge the release PR into `stable`, then fast-forward `releases/X.Y.Z` to the resulting stable merge commit.
+- Tag that exact shared commit as `vX.Y.Z`; from that point onward, do not add commits to the release branch.
+- Prepare the next patch on a new branch such as `releases/X.Y.(Z+1)` instead of changing the previous version branch.
+- Do not merge unrelated future `stable` work into a patch release candidate.
+
+### `beta`
+
+`beta` is the optional public-prerelease lane.
+
+- Synchronize it from the intended stable release base before starting a new prerelease series.
+- Use versions such as `X.Y.Z-beta.N` and tags such as `vX.Y.Z-beta.N`.
+- Beta builds use the beta game-assembly branches and publish only as GitHub prereleases.
+- A stable patch does not need to pass through `beta` unless public beta validation is intentionally part of that release.
 
 ## Tag Format
 
@@ -55,48 +64,49 @@ Patch numbers are ordinary integers, not single digits. That means `2.9.10` is t
 
 ### New release line
 
-1. Finish the planned work on `stable`.
-2. Publish the release as tag `vX.Y.Z`.
-3. Branch from that exact release commit to `releases/X.Y.Z`.
-4. Verify the branch name matches the `releases/x.y.z` convention exactly so GitHub automation can detect it.
-5. Continue forward development on `stable` toward the next version.
+1. Prepare the release changes and version bump on `releases/X.Y.Z`, based on the intended `stable` commit.
+2. Open a PR from `releases/X.Y.Z` into `stable` and complete validation.
+3. Merge the PR into `stable` with a merge commit.
+4. Fast-forward `releases/X.Y.Z` to that exact stable merge commit.
+5. Tag the shared commit as `vX.Y.Z` to publish the stable release.
+6. Treat both the tag and release branch as immutable release records.
+7. Continue forward development on `stable` toward the next version.
 
 ### Hotfix release for an existing line
 
-1. Create a short-lived branch from `releases/X.Y.Z`, such as `hotfix/X.Y.Z/fix-name`.
-2. Apply only the fixes intended for that shipped line.
-3. Open a PR back into `releases/X.Y.Z` and merge it after validation.
-4. Bump the version on that release branch to the next patch version by incrementing the patch number normally, such as `2.9.10` after `2.9.9`.
-5. Tag the updated release branch as that new patch version, such as `v2.9.10`.
-6. Create `releases/X.Y.(Z+1)` from that exact tagged commit so the newly shipped version has its own maintenance branch.
-7. Cherry-pick the merged fix back to `stable` if it still applies there, or open a matching PR if adaptation is needed.
+1. Create `releases/X.Y.(Z+1)` from the current stable tree when it still matches the shipped version, or from the `vX.Y.Z` tag when stable has unrelated future work.
+2. Apply only the hotfix and the `X.Y.(Z+1)` version bump to that new release branch.
+3. Open a PR from `releases/X.Y.(Z+1)` into `stable` and merge it after validation.
+4. Fast-forward `releases/X.Y.(Z+1)` to the resulting stable merge commit.
+5. Tag that exact commit as `vX.Y.(Z+1)` to publish the new patch.
+6. Leave `releases/X.Y.Z` and its tag unchanged as the immutable record of the previous release.
 
-Using PRs for hotfixes keeps review history attached to the release line and improves GitHub auto-generated release notes by linking each fix to its PR and author.
+Using the new version's branch as the PR head keeps review history attached to the release while ensuring every version branch continues to identify the assembly it shipped.
 
 ## Pull Request Guidance
 
-- Prefer a dedicated hotfix branch and PR for each maintenance fix.
+- Prefer the new `releases/X.Y.Z` branch and a narrowly scoped PR for each release candidate.
 - Keep hotfix PRs narrowly scoped so release notes stay easy to read.
-- Merge hotfix PRs into `releases/x.y.z` before tagging the next patch release.
-- Backport the merged change to `stable` with a cherry-pick when possible.
-- If `stable` has diverged too far for a clean cherry-pick, use a separate PR into `stable` that references the release-branch PR.
+- Merge release PRs into `stable` before tagging.
+- Fast-forward the release branch to the stable merge commit before creating the tag.
+- Never put a new version bump on a branch named for an already shipped version.
 
 ## NuGet Publishing
 
-The NuGet package publish workflow is intentionally tied to release branches.
+The NuGet package publish workflow uses the stable release tag as its authority.
 
-- Automatic publish only runs for pushes to `releases/**`.
-- Automatic publish only runs when `S1API/S1API.csproj` changes and the `<Version>` value changes.
-- `workflow_dispatch` can be used to rerun the publish workflow manually, but it should be run from the relevant `releases/x.y.z` branch.
-- A version bump on `stable` does not publish to NuGet. That is expected.
-- If a release branch does not exist yet, create `releases/x.y.z` from the tagged release commit before expecting NuGet automation to run.
+- Automatic publication runs for stable `vX.Y.Z` tag pushes.
+- Prerelease tags such as `vX.Y.Z-beta.N` do not publish to NuGet.
+- The workflow checks out the tag and requires `S1API/S1API.csproj` `<Version>` to exactly match it.
+- `workflow_dispatch` can republish an existing stable tag when explicitly supplied.
+- Branch creation, release-PR merges, and ordinary version bumps do not publish packages by themselves.
 
 ### Contributor checklist
 
 Before expecting a NuGet package to publish:
 
-1. Confirm the shipped line has a matching `releases/x.y.z` branch.
-2. Confirm the version change is being merged into that release branch, not only into `stable`.
+1. Confirm `stable`, `releases/x.y.z`, and `vX.Y.Z` identify the same release commit.
+2. Confirm the project and Melon versions match `X.Y.Z`.
 3. Confirm the branch name uses `releases/`, not `release/`.
 4. Confirm the publish workflow secrets are configured in GitHub.
 
@@ -116,26 +126,19 @@ The GitHub release workflow packages public mod archives and can publish the sam
 
 ## Backporting Rules
 
-- Prefer cherry-picking specific commits instead of merging branches.
-- Backport only fixes that are relevant and low risk for the release line.
-- Preserve the original commit message when possible so history stays easy to trace.
-- If a cherry-pick needs adaptation because `stable` has diverged, keep the behavior equivalent and mention the branch-specific adjustment in the commit body or PR notes.
+- When `stable` contains unrelated future work, create the next release branch from the previous stable tag and cherry-pick only the relevant fixes.
+- Preserve original commit messages when possible so history stays easy to trace.
+- Merge the completed release branch back into `stable`; resolve divergence without pulling unrelated stable work into the release candidate.
+- If a cherry-pick needs adaptation, keep the behavior equivalent and mention the branch-specific adjustment in the commit body or PR notes.
 
-## Current Example
+## Example Patch Flow
 
-The current repository state follows this model:
+For a `3.1.3` hotfix after `3.1.2` has shipped:
 
-- `releases/2.9.9` holds the shipped `2.9.9` code line until the next patch in that line ships.
-- If a hotfix release is published from that line, tag it as `v2.9.10` and then create `releases/2.9.10` from that exact release commit.
-- `stable` is already moving toward `3.0.0`.
-- Fixes that still matter to both lines can be cherry-picked between the two branches as needed.
+1. Leave `releases/3.1.2` and `v3.1.2` unchanged.
+2. Prepare the fix and version bump on `releases/3.1.3`.
+3. Merge `releases/3.1.3` into `stable` after validation.
+4. Fast-forward `releases/3.1.3` to the stable merge commit.
+5. Tag that shared commit `v3.1.3` to publish it.
 
-## History Snapshot
-
-At the time this policy was written:
-
-- `stable` and `releases/2.9.9` diverge from `v2.9.9`.
-- `stable` contains forward-looking `3.0.0` work that should not be merged wholesale into the `2.9.9` maintenance branch.
-- `releases/2.9.9` contains hotfix-oriented commits suitable for selective cherry-picking.
-
-This keeps maintenance releases isolated while allowing ongoing development to move ahead without blocking urgent fixes.
+This keeps maintenance work isolated without allowing a version branch to drift away from the artifact named by that branch.


### PR DESCRIPTION
## Summary

- restore persisted storage capacities above the default 20-slot wrapper ceiling
- preserve the public `StorageEntity.MaxSlots` default and ordinary mutation guard
- bump the package/assembly and Melon versions to 3.1.3
- make release branches immutable records of their named versions
- publish NuGet from exact stable tags instead of pushes to `releases/**`

## Root cause

The storage loader creates a fresh S1API wrapper whose `MaxSlots` defaults to 20. A modded prefab can legitimately expose more slots—the forklift pallet has 24—and its saved contents preserve that topology. `SetSlotCount(24)` was rejected before hydration because the restore path had not raised that wrapper's ceiling.

The prior release policy also prepared a new patch by mutating the branch named for the previous release. That allowed `releases/3.1.2` to contain a future 3.1.3 assembly and coupled NuGet publication to branch pushes. The updated flow prepares the new version on `releases/3.1.3`, merges it into `stable`, aligns the release branch to the stable merge commit, and publishes all stable packages from `v3.1.3`.

## Compatibility

- Source compatibility: unchanged; no public or protected API signatures changed.
- Binary compatibility: unchanged; no public or protected members were added, removed, or reshaped.
- Behavioral compatibility: ordinary storage mutation still defaults to a 20-slot ceiling. Only saved topology restoration may raise an individual wrapper's ceiling.
- Save compatibility: no format changes. Existing saves with expanded storage topology can now restore capacities above 20.
- Network compatibility: unchanged.

## Validation

- MonoMelon full suite: 404 passed
- MonoMelon storage restore policy: 2 passed
- Il2CppMelon storage restore policy: 2 passed
- Il2CppMelon unaffected group: 271 passed together
- Il2CppMelon native-wrapper classes: 122 passed in isolated processes (393 total)
- generated Mono and IL2CPP assemblies report version `3.1.3.0`
- NuGet workflow YAML parsed locally; GitHub PR checks provide authoritative workflow validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored storage now automatically accommodates persisted or explicitly configured slot counts beyond the default limit.
  * Failed storage expansion during restoration now produces a warning instead of failing silently.

* **Release**
  * Updated the package and application version to 3.1.3.
  * Stable releases are now published from validated version tags.

* **Documentation**
  * Updated versioning and release guidance, including beta releases and hotfix procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->