### PR TITLE
fix: release S1API 3.1.4

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -3616,6 +3616,8 @@ namespace S1API.Entities
                 Logger.Error($"[NPC] InitializeRelationshipData: Stack trace: {ex.StackTrace}");
                 /* ignore: base game will handle in its own lifecycle if not ready */
             }
+
+            _relationship?.EnsureUnlockedHook();
         }
 
         private void ApplyRandomInventoryDefaults()
@@ -4195,6 +4197,8 @@ namespace S1API.Entities
                     // NPC was loaded from save, relationship data is already initialized, mark as complete
                     _relationshipDataAppliedFromPrefab = true;
                 }
+
+                _relationship?.EnsureUnlockedHook();
 
                 // Note: Random inventory defaults are applied in InitializeInventoryComponent, not here
                 // to avoid duplicate item insertion when StartupItems is processed by NPCInventory.Awake

--- a/S1API/Entities/NPCRelationship.cs
+++ b/S1API/Entities/NPCRelationship.cs
@@ -1,7 +1,10 @@
 #if (IL2CPPMELON)
+using Il2CppInterop.Runtime;
+using NativeRelationshipUnlockedAction = Il2CppSystem.Action<Il2CppScheduleOne.NPCs.Relation.NPCRelationData.EUnlockType, bool>;
 using S1Relation = Il2CppScheduleOne.NPCs.Relation;
 using S1NPCs = Il2CppScheduleOne.NPCs;
 #elif MONOMELON
+using NativeRelationshipUnlockedAction = System.Action<ScheduleOne.NPCs.Relation.NPCRelationData.EUnlockType, bool>;
 using S1Relation = ScheduleOne.NPCs.Relation;
 using S1NPCs = ScheduleOne.NPCs;
 #endif
@@ -10,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using S1API.Entities.Relation;
+using S1API.Logging;
 
 namespace S1API.Entities
 {
@@ -23,6 +27,8 @@ namespace S1API.Entities
     /// </remarks>
     public sealed class NPCRelationship
     {
+        private static readonly Log Logger = new Log("NPCRelationship");
+
         #region Types
 
         /// <summary>
@@ -43,12 +49,11 @@ namespace S1API.Entities
         /// </summary>
         internal readonly NPC NPC;
         private readonly Dictionary<Action<float>, Delegate> _relationshipChangedHandlers = new Dictionary<Action<float>, Delegate>();
-        private readonly Dictionary<Action<UnlockType, bool>, Delegate> _relationshipUnlockedHandlers = new Dictionary<Action<UnlockType, bool>, Delegate>();
+        private Action<UnlockType, bool>? _relationshipUnlockedHandlers;
+        private S1Relation.NPCRelationData? _subscribedRelationship;
+        private NativeRelationshipUnlockedAction? _nativeRelationshipUnlockedDispatcher;
         private static readonly MemberInfo? RelationshipChangedMember =
             ResolveNativeEventMember("OnRelationshipChange", "onRelationshipChange");
-        private static readonly MemberInfo? RelationshipUnlockedMember =
-            ResolveNativeEventMember("OnUnlocked", "onUnlocked");
-
         internal NPCRelationship(NPC npc)
         {
             NPC = npc;
@@ -236,75 +241,26 @@ namespace S1API.Entities
 
         /// <summary>
         /// Subscribes to unlocked events. Callback receives unlock type and notify flag.
-        /// Best-effort under IL2CPP; silently no-ops if delegate bridging is unavailable.
+        /// The wrapper retains a native dispatcher and bridges it explicitly under IL2CPP.
         /// </summary>
         public event Action<UnlockType, bool> OnUnlocked
         {
             add
             {
-                if (value == null || Component == null)
+                if (value == null)
                     return;
 
-                if (_relationshipUnlockedHandlers.ContainsKey(value))
-                    return;
-
-                try
-                {
-                    MemberInfo? member = RelationshipUnlockedMember;
-                    if (member == null)
-                        return;
-
-                    object? existing = GetNativeEventValue(member, Component);
-#if IL2CPPMELON
-                    System.Action<S1Relation.NPCRelationData.EUnlockType, bool> wrapped = new System.Action<S1Relation.NPCRelationData.EUnlockType, bool>((t, notify) =>
-                    {
-                        try { value(FromS1(t), notify); } catch { }
-                    });
-                    var combined = (Il2CppSystem.Delegate)Il2CppSystem.Delegate.Combine(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped);
-                    SetNativeEventValue(member, Component, combined);
-                    _relationshipUnlockedHandlers[value] = wrapped;
-#else
-                    Action<S1Relation.NPCRelationData.EUnlockType, bool> wrapped = (t, notify) =>
-                    {
-                        try { value(FromS1(t), notify); } catch { }
-                    };
-                    var combined = Delegate.Combine(existing as Delegate, wrapped);
-                    SetNativeEventValue(member, Component, combined);
-                    _relationshipUnlockedHandlers[value] = wrapped;
-#endif
-                }
-                catch { }
+                _relationshipUnlockedHandlers += value;
+                EnsureUnlockedHook();
             }
             remove
             {
-                if (value == null || Component == null)
+                if (value == null)
                     return;
 
-                if (!_relationshipUnlockedHandlers.TryGetValue(value, out var wrapped))
-                    return;
-
-                _relationshipUnlockedHandlers.Remove(value);
-                try
-                {
-                    MemberInfo? member = RelationshipUnlockedMember;
-                    if (member == null)
-                        return;
-
-#if IL2CPPMELON
-                    var existing = GetNativeEventValue(member, Component);
-                    var remaining = existing != null
-                        ? Il2CppSystem.Delegate.Remove(existing as Il2CppSystem.Delegate, (Il2CppSystem.Delegate)(object)wrapped)
-                        : null;
-                    SetNativeEventValue(member, Component, remaining);
-#else
-                    var existing = GetNativeEventValue(member, Component);
-                    var remaining = existing != null
-                        ? Delegate.Remove(existing as Delegate, (Delegate)wrapped)
-                        : null;
-                    SetNativeEventValue(member, Component, remaining);
-#endif
-                }
-                catch { }
+                _relationshipUnlockedHandlers -= value;
+                if (_relationshipUnlockedHandlers == null)
+                    RemoveUnlockedHook();
             }
         }
 
@@ -320,6 +276,94 @@ namespace S1API.Entities
         #endregion
 
         #region Private Helpers
+
+        private void EnsureUnlockedHook()
+        {
+            if (_relationshipUnlockedHandlers == null)
+                return;
+
+            S1Relation.NPCRelationData? relationship = Component;
+            if (relationship == null || ReferenceEquals(relationship, _subscribedRelationship))
+                return;
+
+            RemoveUnlockedHook();
+            NativeRelationshipUnlockedAction dispatcher =
+                GetOrCreateNativeUnlockedDispatcher();
+
+#if IL2CPPMELON
+            relationship.OnUnlocked = relationship.OnUnlocked == null
+                ? dispatcher
+                : Il2CppSystem.Delegate.Combine(
+                        relationship.OnUnlocked,
+                        dispatcher)
+                    .Cast<NativeRelationshipUnlockedAction>();
+#else
+            relationship.OnUnlocked += dispatcher;
+#endif
+            _subscribedRelationship = relationship;
+        }
+
+        private NativeRelationshipUnlockedAction GetOrCreateNativeUnlockedDispatcher()
+        {
+            if (_nativeRelationshipUnlockedDispatcher != null)
+                return _nativeRelationshipUnlockedDispatcher;
+
+#if IL2CPPMELON
+            _nativeRelationshipUnlockedDispatcher =
+                DelegateSupport.ConvertDelegate<NativeRelationshipUnlockedAction>(
+                    new Action<S1Relation.NPCRelationData.EUnlockType, bool>(
+                        DispatchUnlocked))
+                ?? throw new InvalidOperationException(
+                    "Could not create the native relationship-unlocked dispatcher.");
+#else
+            _nativeRelationshipUnlockedDispatcher = DispatchUnlocked;
+#endif
+            return _nativeRelationshipUnlockedDispatcher;
+        }
+
+        private void RemoveUnlockedHook()
+        {
+            if (_subscribedRelationship == null ||
+                _nativeRelationshipUnlockedDispatcher == null)
+            {
+                _subscribedRelationship = null;
+                return;
+            }
+
+#if IL2CPPMELON
+            Il2CppSystem.Delegate? remaining = Il2CppSystem.Delegate.Remove(
+                _subscribedRelationship.OnUnlocked,
+                _nativeRelationshipUnlockedDispatcher);
+            _subscribedRelationship.OnUnlocked =
+                remaining?.Cast<NativeRelationshipUnlockedAction>();
+#else
+            _subscribedRelationship.OnUnlocked -=
+                _nativeRelationshipUnlockedDispatcher;
+#endif
+            _subscribedRelationship = null;
+        }
+
+        private void DispatchUnlocked(
+            S1Relation.NPCRelationData.EUnlockType type,
+            bool notify)
+        {
+            Action<UnlockType, bool>? handlers = _relationshipUnlockedHandlers;
+            if (handlers == null)
+                return;
+
+            foreach (Action<UnlockType, bool> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(FromS1(type), notify);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(
+                        $"An NPCRelationship.OnUnlocked subscriber failed: {ex.Message}");
+                }
+            }
+        }
 
         internal static MemberInfo? ResolveNativeEventMember(
             string canonicalName,

--- a/S1API/Entities/NPCRelationship.cs
+++ b/S1API/Entities/NPCRelationship.cs
@@ -250,6 +250,14 @@ namespace S1API.Entities
                 if (value == null)
                     return;
 
+                if (_relationshipUnlockedHandlers != null &&
+                    Array.IndexOf(
+                        _relationshipUnlockedHandlers.GetInvocationList(),
+                        value) >= 0)
+                {
+                    return;
+                }
+
                 _relationshipUnlockedHandlers += value;
                 EnsureUnlockedHook();
             }
@@ -277,7 +285,7 @@ namespace S1API.Entities
 
         #region Private Helpers
 
-        private void EnsureUnlockedHook()
+        internal void EnsureUnlockedHook()
         {
             if (_relationshipUnlockedHandlers == null)
                 return;
@@ -286,21 +294,29 @@ namespace S1API.Entities
             if (relationship == null || ReferenceEquals(relationship, _subscribedRelationship))
                 return;
 
-            RemoveUnlockedHook();
-            NativeRelationshipUnlockedAction dispatcher =
-                GetOrCreateNativeUnlockedDispatcher();
+            try
+            {
+                RemoveUnlockedHook();
+                NativeRelationshipUnlockedAction dispatcher =
+                    GetOrCreateNativeUnlockedDispatcher();
 
 #if IL2CPPMELON
-            relationship.OnUnlocked = relationship.OnUnlocked == null
-                ? dispatcher
-                : Il2CppSystem.Delegate.Combine(
-                        relationship.OnUnlocked,
-                        dispatcher)
-                    .Cast<NativeRelationshipUnlockedAction>();
+                relationship.OnUnlocked = relationship.OnUnlocked == null
+                    ? dispatcher
+                    : Il2CppSystem.Delegate.Combine(
+                            relationship.OnUnlocked,
+                            dispatcher)
+                        .Cast<NativeRelationshipUnlockedAction>();
 #else
-            relationship.OnUnlocked += dispatcher;
+                relationship.OnUnlocked += dispatcher;
 #endif
-            _subscribedRelationship = relationship;
+                _subscribedRelationship = relationship;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"Could not attach the native relationship-unlocked hook: {ex}");
+            }
         }
 
         private NativeRelationshipUnlockedAction GetOrCreateNativeUnlockedDispatcher()
@@ -330,17 +346,28 @@ namespace S1API.Entities
                 return;
             }
 
+            try
+            {
 #if IL2CPPMELON
-            Il2CppSystem.Delegate? remaining = Il2CppSystem.Delegate.Remove(
-                _subscribedRelationship.OnUnlocked,
-                _nativeRelationshipUnlockedDispatcher);
-            _subscribedRelationship.OnUnlocked =
-                remaining?.Cast<NativeRelationshipUnlockedAction>();
+                Il2CppSystem.Delegate? remaining = Il2CppSystem.Delegate.Remove(
+                    _subscribedRelationship.OnUnlocked,
+                    _nativeRelationshipUnlockedDispatcher);
+                _subscribedRelationship.OnUnlocked =
+                    remaining?.Cast<NativeRelationshipUnlockedAction>();
 #else
-            _subscribedRelationship.OnUnlocked -=
-                _nativeRelationshipUnlockedDispatcher;
+                _subscribedRelationship.OnUnlocked -=
+                    _nativeRelationshipUnlockedDispatcher;
 #endif
-            _subscribedRelationship = null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"Could not remove the native relationship-unlocked hook: {ex}");
+            }
+            finally
+            {
+                _subscribedRelationship = null;
+            }
         }
 
         private void DispatchUnlocked(
@@ -360,7 +387,9 @@ namespace S1API.Entities
                 catch (Exception ex)
                 {
                     Logger.Warning(
-                        $"An NPCRelationship.OnUnlocked subscriber failed: {ex.Message}");
+                        $"NPCRelationship.OnUnlocked subscriber " +
+                        $"'{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' " +
+                        $"failed: {ex}");
                 }
             }
         }

--- a/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
@@ -343,6 +343,8 @@ namespace S1API.Internal.Entities.Suppliers
                 }
             }
 
+            RemoveGeneratedPrefabStash(supplier);
+
             S1Economy.SupplierStash stash =
                 nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
                 nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
@@ -362,6 +364,19 @@ namespace S1API.Internal.Entities.Suppliers
 
             ConfiguredStashes.Add(stash.GetInstanceID());
             ConfiguredStashGuids[supplierKey] = deadDrop.GUID;
+        }
+
+        private static void RemoveGeneratedPrefabStash(S1Economy.Supplier supplier)
+        {
+            S1Economy.SupplierStash? generatedStash = FindInHierarchy(supplier.gameObject);
+            if (generatedStash == null)
+                return;
+
+            if (generatedStash.IntObj != null)
+                generatedStash.IntObj.enabled = false;
+
+            generatedStash.gameObject.SetActive(false);
+            Destroy(generatedStash.gameObject);
         }
 
         internal static bool IsReservedDeadDrop(S1Economy.DeadDrop deadDrop)

--- a/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
@@ -343,16 +343,17 @@ namespace S1API.Internal.Entities.Suppliers
                 }
             }
 
-            RemoveGeneratedPrefabStash(supplier);
-
-            S1Economy.SupplierStash stash =
-                nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
-                nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
             S1Storage.StorageEntityInteractable interactable =
                 nativeDeadDrop.Storage.GetComponent<S1Storage.StorageEntityInteractable>() ??
                 nativeDeadDrop.Storage.GetComponentInChildren<S1Storage.StorageEntityInteractable>(true) ??
                 throw new InvalidOperationException(
                     $"Dead drop '{deadDrop.Name}' has no storage interaction component.");
+
+            RemoveGeneratedPrefabStash(supplier);
+
+            S1Economy.SupplierStash stash =
+                nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
+                nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
 
             stash.Supplier = supplier;
             stash.Storage = nativeDeadDrop.Storage;
@@ -368,15 +369,26 @@ namespace S1API.Internal.Entities.Suppliers
 
         private static void RemoveGeneratedPrefabStash(S1Economy.Supplier supplier)
         {
-            S1Economy.SupplierStash? generatedStash = FindInHierarchy(supplier.gameObject);
-            if (generatedStash == null)
+            int supplierKey = supplier.GetInstanceID();
+            GameObject? generatedStashObject = null;
+            if (OwnedStashes.TryGetValue(supplierKey, out GameObject? ownedStash))
+            {
+                generatedStashObject = ownedStash;
+                OwnedStashes.Remove(supplierKey);
+            }
+
+            S1Economy.SupplierStash? generatedStash =
+                generatedStashObject?.GetComponent<S1Economy.SupplierStash>() ??
+                FindInHierarchy(supplier.gameObject);
+            generatedStashObject ??= generatedStash?.gameObject;
+            if (generatedStashObject == null)
                 return;
 
-            if (generatedStash.IntObj != null)
+            if (generatedStash?.IntObj != null)
                 generatedStash.IntObj.enabled = false;
 
-            generatedStash.gameObject.SetActive(false);
-            Destroy(generatedStash.gameObject);
+            generatedStashObject.SetActive(false);
+            Destroy(generatedStashObject);
         }
 
         internal static bool IsReservedDeadDrop(S1Economy.DeadDrop deadDrop)

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.3", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.4", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.3</Version>
+        <Version>3.1.4</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- retain a native relationship-unlock dispatcher so IL2CPP subscribers continue receiving NPC unlock events
- remove the generated supplier-prefab stash when a supplier is bound to a native dead drop
- bump the S1API assembly and package version to 3.1.4

## Compatibility

- Public and protected API signatures are unchanged.
- Source and binary compatibility are unchanged.
- Registry IDs, save representations, and network payloads are unchanged.
- Existing generated supplier stashes remain the default unless a native dead drop is explicitly configured.
- The relationship event change restores the documented callback behavior and isolates subscriber exceptions.

## Validation

- MonoMelon solution build: passed with 0 warnings and 0 errors
- MonoMelon contract suite: 404/404 passed
- Il2CppMelon solution build: passed with 0 warnings and 0 errors
- affected Il2CppMelon contract groups: 8/8 passed
- in-game IL2CPP save-load smoke: an already-unlocked custom supplier retained its recipe unlock callback, bound to the configured Behind Bank dead drop, and left no generated world stash

The complete local IL2CPP test host reached 319 passing tests before its finalizer attempted to load the unavailable native GameAssembly. The affected IL2CPP tests and release build complete cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC relationship unlock event handling for greater reliability across supported platforms.
  * Prevented duplicate generated supplier stashes when binding configured dead drops.
  * Removed obsolete generated stash objects cleanly when replaced.

* **Chores**
  * Updated the S1API package and assembly version to 3.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->