### PR TITLE
fix: address 3.1.4 release review

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -3616,6 +3616,8 @@ namespace S1API.Entities
                 Logger.Error($"[NPC] InitializeRelationshipData: Stack trace: {ex.StackTrace}");
                 /* ignore: base game will handle in its own lifecycle if not ready */
             }
+
+            _relationship?.EnsureUnlockedHook();
         }
 
         private void ApplyRandomInventoryDefaults()
@@ -4195,6 +4197,8 @@ namespace S1API.Entities
                     // NPC was loaded from save, relationship data is already initialized, mark as complete
                     _relationshipDataAppliedFromPrefab = true;
                 }
+
+                _relationship?.EnsureUnlockedHook();
 
                 // Note: Random inventory defaults are applied in InitializeInventoryComponent, not here
                 // to avoid duplicate item insertion when StartupItems is processed by NPCInventory.Awake

--- a/S1API/Entities/NPCRelationship.cs
+++ b/S1API/Entities/NPCRelationship.cs
@@ -250,6 +250,14 @@ namespace S1API.Entities
                 if (value == null)
                     return;
 
+                if (_relationshipUnlockedHandlers != null &&
+                    Array.IndexOf(
+                        _relationshipUnlockedHandlers.GetInvocationList(),
+                        value) >= 0)
+                {
+                    return;
+                }
+
                 _relationshipUnlockedHandlers += value;
                 EnsureUnlockedHook();
             }
@@ -277,7 +285,7 @@ namespace S1API.Entities
 
         #region Private Helpers
 
-        private void EnsureUnlockedHook()
+        internal void EnsureUnlockedHook()
         {
             if (_relationshipUnlockedHandlers == null)
                 return;
@@ -286,21 +294,29 @@ namespace S1API.Entities
             if (relationship == null || ReferenceEquals(relationship, _subscribedRelationship))
                 return;
 
-            RemoveUnlockedHook();
-            NativeRelationshipUnlockedAction dispatcher =
-                GetOrCreateNativeUnlockedDispatcher();
+            try
+            {
+                RemoveUnlockedHook();
+                NativeRelationshipUnlockedAction dispatcher =
+                    GetOrCreateNativeUnlockedDispatcher();
 
 #if IL2CPPMELON
-            relationship.OnUnlocked = relationship.OnUnlocked == null
-                ? dispatcher
-                : Il2CppSystem.Delegate.Combine(
-                        relationship.OnUnlocked,
-                        dispatcher)
-                    .Cast<NativeRelationshipUnlockedAction>();
+                relationship.OnUnlocked = relationship.OnUnlocked == null
+                    ? dispatcher
+                    : Il2CppSystem.Delegate.Combine(
+                            relationship.OnUnlocked,
+                            dispatcher)
+                        .Cast<NativeRelationshipUnlockedAction>();
 #else
-            relationship.OnUnlocked += dispatcher;
+                relationship.OnUnlocked += dispatcher;
 #endif
-            _subscribedRelationship = relationship;
+                _subscribedRelationship = relationship;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"Could not attach the native relationship-unlocked hook: {ex}");
+            }
         }
 
         private NativeRelationshipUnlockedAction GetOrCreateNativeUnlockedDispatcher()
@@ -330,17 +346,28 @@ namespace S1API.Entities
                 return;
             }
 
+            try
+            {
 #if IL2CPPMELON
-            Il2CppSystem.Delegate? remaining = Il2CppSystem.Delegate.Remove(
-                _subscribedRelationship.OnUnlocked,
-                _nativeRelationshipUnlockedDispatcher);
-            _subscribedRelationship.OnUnlocked =
-                remaining?.Cast<NativeRelationshipUnlockedAction>();
+                Il2CppSystem.Delegate? remaining = Il2CppSystem.Delegate.Remove(
+                    _subscribedRelationship.OnUnlocked,
+                    _nativeRelationshipUnlockedDispatcher);
+                _subscribedRelationship.OnUnlocked =
+                    remaining?.Cast<NativeRelationshipUnlockedAction>();
 #else
-            _subscribedRelationship.OnUnlocked -=
-                _nativeRelationshipUnlockedDispatcher;
+                _subscribedRelationship.OnUnlocked -=
+                    _nativeRelationshipUnlockedDispatcher;
 #endif
-            _subscribedRelationship = null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"Could not remove the native relationship-unlocked hook: {ex}");
+            }
+            finally
+            {
+                _subscribedRelationship = null;
+            }
         }
 
         private void DispatchUnlocked(
@@ -360,7 +387,9 @@ namespace S1API.Entities
                 catch (Exception ex)
                 {
                     Logger.Warning(
-                        $"An NPCRelationship.OnUnlocked subscriber failed: {ex.Message}");
+                        $"NPCRelationship.OnUnlocked subscriber " +
+                        $"'{handler.Method.DeclaringType?.FullName}.{handler.Method.Name}' " +
+                        $"failed: {ex}");
                 }
             }
         }

--- a/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
+++ b/S1API/Internal/Entities/Suppliers/SupplierStashRuntime.cs
@@ -343,16 +343,17 @@ namespace S1API.Internal.Entities.Suppliers
                 }
             }
 
-            RemoveGeneratedPrefabStash(supplier);
-
-            S1Economy.SupplierStash stash =
-                nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
-                nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
             S1Storage.StorageEntityInteractable interactable =
                 nativeDeadDrop.Storage.GetComponent<S1Storage.StorageEntityInteractable>() ??
                 nativeDeadDrop.Storage.GetComponentInChildren<S1Storage.StorageEntityInteractable>(true) ??
                 throw new InvalidOperationException(
                     $"Dead drop '{deadDrop.Name}' has no storage interaction component.");
+
+            RemoveGeneratedPrefabStash(supplier);
+
+            S1Economy.SupplierStash stash =
+                nativeDeadDrop.GetComponent<S1Economy.SupplierStash>() ??
+                nativeDeadDrop.gameObject.AddComponent<S1Economy.SupplierStash>();
 
             stash.Supplier = supplier;
             stash.Storage = nativeDeadDrop.Storage;
@@ -368,15 +369,26 @@ namespace S1API.Internal.Entities.Suppliers
 
         private static void RemoveGeneratedPrefabStash(S1Economy.Supplier supplier)
         {
-            S1Economy.SupplierStash? generatedStash = FindInHierarchy(supplier.gameObject);
-            if (generatedStash == null)
+            int supplierKey = supplier.GetInstanceID();
+            GameObject? generatedStashObject = null;
+            if (OwnedStashes.TryGetValue(supplierKey, out GameObject? ownedStash))
+            {
+                generatedStashObject = ownedStash;
+                OwnedStashes.Remove(supplierKey);
+            }
+
+            S1Economy.SupplierStash? generatedStash =
+                generatedStashObject?.GetComponent<S1Economy.SupplierStash>() ??
+                FindInHierarchy(supplier.gameObject);
+            generatedStashObject ??= generatedStash?.gameObject;
+            if (generatedStashObject == null)
                 return;
 
-            if (generatedStash.IntObj != null)
+            if (generatedStash?.IntObj != null)
                 generatedStash.IntObj.enabled = false;
 
-            generatedStash.gameObject.SetActive(false);
-            Destroy(generatedStash.gameObject);
+            generatedStashObject.SetActive(false);
+            Destroy(generatedStashObject);
         }
 
         internal static bool IsReservedDeadDrop(S1Economy.DeadDrop deadDrop)


### PR DESCRIPTION
## Summary

- reattach relationship unlock hooks when relation data is created or refreshed
- preserve duplicate-subscription and no-throw compatibility
- validate native dead-drop interaction before removing the generated stash
- clean both attached and already-detached generated supplier stashes

## Validation

- MonoMelon build: passed with 0 warnings and 0 errors
- MonoMelon contract suite: 404/404 passed
- Il2CppMelon build: passed with 0 warnings and 0 errors
- affected Il2CppMelon contract groups: 8/8 passed