### PR TITLE
Fix Nexus publishing and add changelogs

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -27,6 +27,7 @@ permissions:
 env:
   NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
   NEXUSMODS_FILE_GROUP_ID: ${{ secrets.NEXUSMODS_FILE_GROUP_ID || vars.NEXUSMODS_FILE_GROUP_ID }}
+  NEXUSMODS_MOD_ID: ${{ secrets.NEXUSMODS_MOD_ID || vars.NEXUSMODS_MOD_ID }}
   RELEASE_DESCRIPTION: S1API is an open source collaboration project to help standardize Schedule One modding processes. The goal is to provide a standard place for common functionalities so you can focus on making content versus reverse engineering the game.
   THUNDERSTORE_COMMUNITY: schedule-i
   THUNDERSTORE_TOKEN: ${{ secrets.THUNDERSTORE_TOKEN }}
@@ -320,6 +321,7 @@ jobs:
           echo "thunderstore_zip_path=${thunderstore_zip_path}" >> "$GITHUB_OUTPUT"
 
       - name: Publish or update GitHub release
+        id: github-release
         uses: actions/github-script@v7
         env:
           RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
@@ -375,6 +377,7 @@ jobs:
               tag_name: tag,
               target_commitish: targetCommitish
             });
+            core.setOutput("release_notes", notes.data.body);
 
             const payload = {
               owner,
@@ -422,25 +425,28 @@ jobs:
           gh release upload "${{ steps.metadata.outputs.tag }}" "${{ steps.package.outputs.zip_path }}" --clobber
 
       - name: Upload Nexus Mods release
-        if: ${{ steps.metadata.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' && env.NEXUSMODS_FILE_GROUP_ID != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.7
+        if: ${{ steps.metadata.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' && env.NEXUSMODS_FILE_GROUP_ID != '' && env.NEXUSMODS_MOD_ID != '' }}
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
         with:
           api_key: ${{ env.NEXUSMODS_API_KEY }}
-          file_group_id: ${{ env.NEXUSMODS_FILE_GROUP_ID }}
+          file_id: ${{ env.NEXUSMODS_FILE_GROUP_ID }}
+          mod_id: ${{ env.NEXUSMODS_MOD_ID }}
           filename: ${{ steps.package.outputs.zip_path }}
           version: ${{ steps.metadata.outputs.release_version }}
           display_name: S1API Forked ${{ steps.metadata.outputs.release_version }}
           description: ${{ env.RELEASE_DESCRIPTION }}
-          file_category: main
-          archive_existing_file: true
+          changelog: ${{ github.event_name == 'push' && github.run_attempt == 1 && steps.github-release.outputs.release_notes || '' }}
+          category: main
+          archive_existing_version: true
+          update_mod_version: true
           primary_mod_manager_download: true
           allow_mod_manager_download: true
           show_requirements_pop_up: false
 
       - name: Skip Nexus Mods upload
-        if: ${{ steps.metadata.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && (env.NEXUSMODS_API_KEY == '' || env.NEXUSMODS_FILE_GROUP_ID == '') }}
+        if: ${{ steps.metadata.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && (env.NEXUSMODS_API_KEY == '' || env.NEXUSMODS_FILE_GROUP_ID == '' || env.NEXUSMODS_MOD_ID == '') }}
         shell: bash
-        run: echo "::notice::Skipping Nexus Mods upload because NEXUSMODS_API_KEY or NEXUSMODS_FILE_GROUP_ID is not configured."
+        run: echo "::notice::Skipping Nexus Mods upload because NEXUSMODS_API_KEY, NEXUSMODS_FILE_GROUP_ID, or NEXUSMODS_MOD_ID is not configured."
 
       - name: Upload Thunderstore release
         if: ${{ steps.metadata.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_thunderstore) && env.THUNDERSTORE_TOKEN != '' }}

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -120,7 +120,8 @@ The GitHub release workflow packages public mod archives and can publish the sam
 - The Thunderstore archive is `S1API-TS-x.y.z.zip` and contains `icon.png`, `README.md`, `manifest.json`, `Mods/`, and `Plugins/` at the archive root, but it is only used for Thunderstore publishing.
 - The uppercase `Mods/` and `Plugins/` paths are intentional so case-sensitive filesystems do not create parallel lowercase install folders.
 - The GitHub release asset is always uploaded by the workflow.
-- Nexus Mods upload runs when `NEXUSMODS_API_KEY` and `NEXUSMODS_FILE_GROUP_ID` are configured.
+- Nexus Mods upload runs when `NEXUSMODS_API_KEY`, `NEXUSMODS_FILE_GROUP_ID`, and `NEXUSMODS_MOD_ID` are configured.
+- The first tag-triggered attempt sends the generated GitHub release notes as the Nexus Mods changelog. Manual dispatches and reruns leave the changelog empty so the additive Nexus endpoint does not append the same notes twice.
 - Thunderstore upload runs when `THUNDERSTORE_TOKEN` is configured.
 - `workflow_dispatch` exposes `publish_nexus` and `publish_thunderstore` toggles for refreshing GitHub assets without re-publishing external platforms.
 


### PR DESCRIPTION
- Updates the Nexus upload action to beta.10 and fixes renamed inputs.
- Publishes release notes as the Nexus changelog.

Requires `NEXUSMODS_MOD_ID`.