### PR TITLE
Release S1API 3.1.5

### DIFF
--- a/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
@@ -76,7 +76,12 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
                 RepresentationTemplateId = "weed",
                 ProviderId = "examplemod:provider",
                 ProviderVersion = 1,
-                ProviderData = "v1"
+                ProviderData = "v1",
+                HasGeneratedMixColor = true,
+                GeneratedMixColorR = 0x12,
+                GeneratedMixColorG = 0x34,
+                GeneratedMixColorB = 0x56,
+                GeneratedMixColorA = 0xFF
             });
         CustomProductDefinitionRegistry.Register(
             "examplemod", firstId, "Alpha", 50f, CreateDefinition(), metadata,
@@ -97,6 +102,11 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
         Assert.Equal(new[] { firstId, secondId }, descriptors.Select(item => item.ProductId));
         Assert.Equal("examplemod:provider", descriptors[1].ProviderId);
         Assert.Equal("v1", descriptors[1].ProviderData);
+        Assert.True(descriptors[1].HasGeneratedMixColor);
+        Assert.Equal(0x12, descriptors[1].GeneratedMixColorR);
+        Assert.Equal(0x34, descriptors[1].GeneratedMixColorG);
+        Assert.Equal(0x56, descriptors[1].GeneratedMixColorB);
+        Assert.Equal(0xFF, descriptors[1].GeneratedMixColorA);
         Assert.DoesNotContain(descriptors, item => item.GetType().GetFields()
             .Any(field => typeof(UnityEngine.Object).IsAssignableFrom(field.FieldType)));
     }

--- a/S1API.Tests/Products/CustomProductMixingIngredientContractTests.cs
+++ b/S1API.Tests/Products/CustomProductMixingIngredientContractTests.cs
@@ -1,0 +1,20 @@
+using S1API.Internal.Patches;
+using Xunit;
+
+namespace S1API.Tests.Products;
+
+public sealed class CustomProductMixingIngredientContractTests
+{
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(2, true)]
+    public void NativeMixerContractAcceptsAnyNonEmptyPropertyList(
+        int propertyCount,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            CustomProductMixingIngredientContract.HasUsableProperty(propertyCount));
+    }
+}

--- a/S1API.Tests/Products/ProductApiCompatibilityTests.cs
+++ b/S1API.Tests/Products/ProductApiCompatibilityTests.cs
@@ -94,11 +94,20 @@ public sealed class ProductApiCompatibilityTests
     {
         var primaryDrugType = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.PrimaryDrugType));
         var drugTypeValues = typeof(ProductDefinition).GetProperty(nameof(ProductDefinition.DrugTypeValues));
+        var propertyColorMixing = typeof(ProductMixingProfileBuilder).GetMethod(
+            nameof(ProductMixingProfileBuilder.WithPropertyColorMixing),
+            Type.EmptyTypes);
+        var usesPropertyColorMixing = typeof(ProductMixingProfile).GetProperty(
+            nameof(ProductMixingProfile.UsePropertyColorMixing));
 
         Assert.NotNull(primaryDrugType);
         Assert.Equal(typeof(DrugType), primaryDrugType.PropertyType);
         Assert.NotNull(drugTypeValues);
         Assert.Equal(typeof(IReadOnlyList<DrugType>), drugTypeValues.PropertyType);
+        Assert.NotNull(propertyColorMixing);
+        Assert.Equal(typeof(ProductMixingProfileBuilder), propertyColorMixing.ReturnType);
+        Assert.NotNull(usesPropertyColorMixing);
+        Assert.Equal(typeof(bool), usesPropertyColorMixing.PropertyType);
     }
 
     [Fact]

--- a/S1API.Tests/Products/ProductMixingColorContractTests.cs
+++ b/S1API.Tests/Products/ProductMixingColorContractTests.cs
@@ -1,0 +1,46 @@
+using S1API.Internal.Products;
+using S1API.Products;
+using Xunit;
+
+namespace S1API.Tests.Products;
+
+public sealed class ProductMixingColorContractTests
+{
+    [Fact]
+    public void CocaineStrategyMatchesNativePrimaryColorFormula()
+    {
+        var lowerTier = new ProductMixingColorSample(
+            3,
+            new ProductMixingColorValue(255, 0, 0, 255));
+        var higherTier = new ProductMixingColorSample(
+            5,
+            new ProductMixingColorValue(0, 0, 255, 255));
+
+        ProductMixingColorValue actual =
+            ProductMixingColorContract.CalculatePrimaryColor(
+            ProductMixingMap.Cocaine,
+            new[] { higherTier, lowerTier });
+
+        Assert.Equal(
+            new ProductMixingColorValue(255, 155, 155, 255),
+            actual);
+    }
+
+    [Theory]
+    [InlineData(ProductMixingMap.Marijuana, 90, 100, 70)]
+    [InlineData(ProductMixingMap.Methamphetamine, 255, 255, 255)]
+    [InlineData(ProductMixingMap.Cocaine, 255, 255, 255)]
+    [InlineData(ProductMixingMap.Shrooms, 168, 125, 43)]
+    public void EmptyPropertiesUseNativePrimaryBaseColor(
+        ProductMixingMap map,
+        byte red,
+        byte green,
+        byte blue)
+    {
+        Assert.Equal(
+            new ProductMixingColorValue(red, green, blue, 255),
+            ProductMixingColorContract.CalculatePrimaryColor(
+                map,
+                Array.Empty<ProductMixingColorSample>()));
+    }
+}

--- a/S1API.Tests/Products/ProductMixingProfileTests.cs
+++ b/S1API.Tests/Products/ProductMixingProfileTests.cs
@@ -1,4 +1,5 @@
 using System;
+using S1API.Internal.Products;
 using S1API.Products;
 using Xunit;
 
@@ -20,11 +21,61 @@ namespace S1API.Tests.Products
 
             Assert.Same(profile, ProductMixingProfiles.Get(kind));
             Assert.Equal(ProductMixingMap.Marijuana, profile.MixerMap);
+            Assert.False(profile.UsePropertyColorMixing);
             ProductMixingOutputDefinition output = profile.OutputFactory(
                 new ProductMixingOutput("example:output", "Named Mix", "example:source", kind, 20f));
             Assert.Equal("Named Mix Output", output.Name);
             Assert.Same(kind, output.ProductKind);
             Assert.Equal(30f, output.Price);
+        }
+
+        [Fact]
+        public void PropertyColorMixingIsExplicitlyOptIn()
+        {
+            ProductKind kind = CreateKind();
+
+            ProductMixingProfile profile = new ProductMixingProfileBuilder(kind)
+                .WithMixerMap(ProductMixingMap.Cocaine)
+                .WithPropertyColorMixing()
+                .WithOutputFactory(input => new ProductMixingOutputDefinition(
+                    input.MixName,
+                    input.SourceKind,
+                    input.SourcePrice))
+                .Build();
+
+            Assert.True(profile.UsePropertyColorMixing);
+        }
+
+        [Fact]
+        public void PropertyColorMixingParticipatesInMultiplayerCompatibility()
+        {
+            ProductKind kind = CreateKind();
+            ProductMixingProfile baseline = new ProductMixingProfileBuilder(kind)
+                .WithMixerMap(ProductMixingMap.Cocaine)
+                .WithOutputFactoryCompatibility("mixingtests:factory", 1)
+                .WithOutputFactory(input => new ProductMixingOutputDefinition(
+                    input.MixName,
+                    input.SourceKind,
+                    input.SourcePrice))
+                .Build();
+            ProductKind coloredKind = CreateKind();
+            ProductMixingProfile colored = new ProductMixingProfileBuilder(coloredKind)
+                .WithMixerMap(ProductMixingMap.Cocaine)
+                .WithPropertyColorMixing()
+                .WithOutputFactoryCompatibility("mixingtests:factory", 1)
+                .WithOutputFactory(input => new ProductMixingOutputDefinition(
+                    input.MixName,
+                    input.SourceKind,
+                    input.SourcePrice))
+                .Build();
+
+            var baselineEntry = CustomProductMixingProfileManifestEntryData.Create(baseline);
+            var coloredEntry = CustomProductMixingProfileManifestEntryData.Create(colored);
+            coloredEntry.ProductKindId = baselineEntry.ProductKindId;
+
+            Assert.Equal(
+                "property-color mixing strategy differs",
+                baselineEntry.DescribeMismatch(coloredEntry));
         }
 
         [Fact]

--- a/S1API/Internal/Patches/MixReactionPatches.cs
+++ b/S1API/Internal/Patches/MixReactionPatches.cs
@@ -224,6 +224,31 @@ namespace S1API.Internal.Patches
                     packaging.Add(metadata.ValidPackaging[i].S1PackagingDefinition);
 
                 S1Product.ProductDefinition template = metadata.RepresentationTemplate ?? source;
+                UnityEngine.Color32? generatedMixColor = null;
+                if (profile.UsePropertyColorMixing)
+                {
+                    var colorSamples =
+                        new System.Collections.Generic.List<
+                            ProductMixingColorSample>(resolvedProperties.Count);
+                    for (int i = 0; i < resolvedProperties.Count; i++)
+                    {
+                        UnityEngine.Color32 propertyColor =
+                            resolvedProperties[i].ProductColor;
+                        colorSamples.Add(
+                            new ProductMixingColorSample(
+                                (int)resolvedProperties[i].Tier,
+                                new ProductMixingColorValue(
+                                    propertyColor.r,
+                                    propertyColor.g,
+                                    propertyColor.b,
+                                    propertyColor.a)));
+                    }
+
+                    generatedMixColor =
+                        ProductMixingColorContract.CalculatePrimaryColor(
+                            profile.MixerMap,
+                            colorSamples).ToColor32();
+                }
                 S1Product.ProductDefinition generated = CustomProductDefinitionFactory.Create(
                     mixID,
                     output.Name,
@@ -241,7 +266,8 @@ namespace S1API.Internal.Patches
                     output.ProductKind,
                     metadata.DefaultQuality,
                     metadata.ValidPackaging,
-                    template);
+                    template,
+                    generatedMixColor);
                 var saveDescriptor = new CustomProductSaveDescriptorData
                 {
                     ProductId = mixID,
@@ -259,7 +285,12 @@ namespace S1API.Internal.Patches
                     NpcEffectDurationSeconds = source.NPCEffectDuration,
                     PropertyIds = resolvedProperties.ConvertAll(property => property.ID).ToArray(),
                     PackagingIds = metadata.ValidPackaging.Select(packagingDefinition => packagingDefinition.ID).ToArray(),
-                    IsGeneratedMix = true
+                    IsGeneratedMix = true,
+                    HasGeneratedMixColor = generatedMixColor.HasValue,
+                    GeneratedMixColorR = generatedMixColor?.r ?? 0,
+                    GeneratedMixColorG = generatedMixColor?.g ?? 0,
+                    GeneratedMixColorB = generatedMixColor?.b ?? 0,
+                    GeneratedMixColorA = generatedMixColor?.a ?? 0
                 };
                 try
                 {
@@ -271,6 +302,8 @@ namespace S1API.Internal.Patches
                         generated,
                         generatedMetadata,
                         saveDescriptor);
+
+                    CompleteGeneratedMixCreation(generated);
                 }
                 catch
                 {
@@ -285,6 +318,24 @@ namespace S1API.Internal.Patches
                 Logger.Error("Custom product mixing output failed for '" + productID + "': " + exception);
                 return false;
             }
+        }
+
+        private static void CompleteGeneratedMixCreation(
+            S1Product.ProductDefinition generated)
+        {
+            S1Product.ProductManager productManager =
+                S1Product.ProductManager.Instance
+                ?? throw new InvalidOperationException(
+                    "Cannot complete custom product mixing before ProductManager is available.");
+
+            // Match the native Create* lifecycle after the definition has entered the
+            // registry. Discovery makes the output listable, while this event creates
+            // its Product Manager entry and lets S1API route it to the logical kind.
+            productManager.SetProductDiscovered(
+                null,
+                generated.ID,
+                autoList: false);
+            productManager.onNewProductCreated?.Invoke(generated);
         }
     }
 

--- a/S1API/Internal/Patches/MixReactionPatches.cs
+++ b/S1API/Internal/Patches/MixReactionPatches.cs
@@ -17,6 +17,7 @@ using HarmonyLib;
 using S1API.Logging;
 using S1API.Products;
 using S1API.Internal.Products;
+using S1API.Internal.Utils;
 
 namespace S1API.Internal.Patches
 {
@@ -55,7 +56,7 @@ namespace S1API.Internal.Patches
 
                 // The game can return a shared list (e.g. a product definition's Properties for a named recipe),
                 // so never mutate __result directly. Clone once, only if a rule actually fires.
-            EffectList? working = null;
+                EffectList? working = null;
 
                 foreach (var rule in rules)
                 {
@@ -173,14 +174,26 @@ namespace S1API.Internal.Patches
                 if (CustomProductDefinitionRegistry.IsRegistered(mixID))
                     return false;
 
-                S1Product.PropertyItemDefinition? ingredient =
-                    S1Registry.GetItem(ingredientID) as S1Product.PropertyItemDefinition;
-                if (ingredient == null || ingredient.Properties == null || ingredient.Properties.Count != 1)
+                object? ingredientItem = S1Registry.GetItem(ingredientID);
+                if (ingredientItem == null ||
+                    !CrossType.Is(
+                        ingredientItem,
+                        out S1Product.PropertyItemDefinition ingredient))
                 {
-                    Logger.Error("Custom product mix '" + productID + "' has no valid single-property ingredient '" + ingredientID + "'.");
+                    Logger.Error("Custom product mix '" + productID + "' could not resolve ingredient '" + ingredientID + "' as a property item.");
                     return false;
                 }
 
+                if (ingredient.Properties == null ||
+                    !CustomProductMixingIngredientContract.HasUsableProperty(
+                        ingredient.Properties.Count))
+                {
+                    Logger.Error("Custom product mix '" + productID + "' resolved ingredient '" + ingredientID + "' without any properties.");
+                    return false;
+                }
+
+                // Match the native ProductManager contract: mixing ingredients only need
+                // one usable property, and the first property drives the calculation.
                 EffectList properties = S1Effects.EffectMixCalculator.MixProperties(
                     source.Properties,
                     ingredient.Properties[0],
@@ -272,6 +285,14 @@ namespace S1API.Internal.Patches
                 Logger.Error("Custom product mixing output failed for '" + productID + "': " + exception);
                 return false;
             }
+        }
+    }
+
+    internal static class CustomProductMixingIngredientContract
+    {
+        internal static bool HasUsableProperty(int propertyCount)
+        {
+            return propertyCount > 0;
         }
     }
 

--- a/S1API/Internal/Products/CustomProductDefinitionMetadata.cs
+++ b/S1API/Internal/Products/CustomProductDefinitionMetadata.cs
@@ -7,6 +7,7 @@ using S1Product = ScheduleOne.Product;
 using System;
 using System.Collections.Generic;
 using S1API.Products;
+using UnityEngine;
 
 namespace S1API.Internal.Products
 {
@@ -39,7 +40,8 @@ namespace S1API.Internal.Products
             ProductKind productKind,
             Quality defaultQuality,
             IReadOnlyList<PackagingDefinition> validPackaging,
-            S1Product.ProductDefinition? representationTemplate)
+            S1Product.ProductDefinition? representationTemplate,
+            Color32? generatedMixColor = null)
         {
             ProductKind = productKind;
             DefaultQuality = defaultQuality;
@@ -49,6 +51,7 @@ namespace S1API.Internal.Products
             ValidPackaging =
                 new List<PackagingDefinition>(validPackaging).AsReadOnly();
             RepresentationTemplate = representationTemplate;
+            GeneratedMixColor = generatedMixColor;
         }
 
         internal ProductKind ProductKind { get; }
@@ -58,5 +61,7 @@ namespace S1API.Internal.Products
         internal IReadOnlyList<PackagingDefinition> ValidPackaging { get; }
 
         internal S1Product.ProductDefinition? RepresentationTemplate { get; }
+
+        internal Color32? GeneratedMixColor { get; }
     }
 }

--- a/S1API/Internal/Products/CustomProductManifestData.cs
+++ b/S1API/Internal/Products/CustomProductManifestData.cs
@@ -581,6 +581,14 @@ namespace S1API.Internal.Products
             Append(builder, descriptor.DefaultQuality.ToString(CultureInfo.InvariantCulture));
             Append(builder, descriptor.PlayerEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
             Append(builder, descriptor.NpcEffectDurationSeconds.ToString(CultureInfo.InvariantCulture));
+            Append(builder, descriptor.HasGeneratedMixColor ? "1" : "0");
+            if (descriptor.HasGeneratedMixColor)
+            {
+                Append(builder, descriptor.GeneratedMixColorR.ToString(CultureInfo.InvariantCulture));
+                Append(builder, descriptor.GeneratedMixColorG.ToString(CultureInfo.InvariantCulture));
+                Append(builder, descriptor.GeneratedMixColorB.ToString(CultureInfo.InvariantCulture));
+                Append(builder, descriptor.GeneratedMixColorA.ToString(CultureInfo.InvariantCulture));
+            }
             for (int i = 0; i < descriptor.PropertyIds.Length; i++)
                 AppendIdentifier(builder, descriptor.PropertyIds[i]);
             // Provider data remains local; only its deterministic digest participates in compatibility.

--- a/S1API/Internal/Products/CustomProductMixingProfileManifestEntryData.cs
+++ b/S1API/Internal/Products/CustomProductMixingProfileManifestEntryData.cs
@@ -12,6 +12,7 @@ namespace S1API.Internal.Products
         public int MixerMap;
         public string OutputFactoryIdentity = string.Empty;
         public int OutputFactoryVersion;
+        public bool UsePropertyColorMixing;
 
         internal static CustomProductMixingProfileManifestEntryData Create(ProductMixingProfile profile) =>
             new CustomProductMixingProfileManifestEntryData
@@ -19,7 +20,8 @@ namespace S1API.Internal.Products
                 ProductKindId = profile.ProductKind.Id,
                 MixerMap = (int)profile.MixerMap,
                 OutputFactoryIdentity = profile.OutputFactoryIdentity,
-                OutputFactoryVersion = profile.OutputFactoryVersion
+                OutputFactoryVersion = profile.OutputFactoryVersion,
+                UsePropertyColorMixing = profile.UsePropertyColorMixing
             };
 
         internal bool IsValid() =>
@@ -39,6 +41,7 @@ namespace S1API.Internal.Products
             builder.Append(MixerMap.ToString(CultureInfo.InvariantCulture)).Append('|');
             builder.Append(OutputFactoryIdentity.ToUpperInvariant()).Append('|');
             builder.Append(OutputFactoryVersion.ToString(CultureInfo.InvariantCulture)).Append('|');
+            builder.Append(UsePropertyColorMixing ? "1|" : "0|");
         }
 
         internal string? DescribeMismatch(CustomProductMixingProfileManifestEntryData local)
@@ -50,6 +53,8 @@ namespace S1API.Internal.Products
             {
                 return "output-factory compatibility identity or version differs";
             }
+            if (UsePropertyColorMixing != local.UsePropertyColorMixing)
+                return "property-color mixing strategy differs";
             return null;
         }
     }

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -322,12 +322,11 @@ namespace S1API.Internal.Products
             }
 
             station.Visuals =
-                ReplaceVisual(
+                ReplaceStationVisual(
                     station.gameObject,
                     station.Visuals,
                     source,
-                    profile,
-                    ProductPresentationContext.Station);
+                    profile);
             return clone;
         }
 
@@ -894,7 +893,7 @@ namespace S1API.Internal.Products
 
         private static StaticProductVisualsSetter ReplaceVisual(
             GameObject scaffold,
-            S1Product.ProductVisualsSetter oldSetter,
+            S1Product.ProductVisualsSetter? oldSetter,
             GameObject source,
             ProductPresentationProfile profile,
             ProductPresentationContext context)
@@ -912,15 +911,98 @@ namespace S1API.Internal.Products
                 oldSetter.VisualsContainer.gameObject.SetActive(false);
             }
 
-            GameObject visual = Object.Instantiate(source);
-            visual.transform.SetParent(parent, false);
-            ApplyVisualTransform(visual.transform, profile, context);
-            visual.SetActive(true);
+            GameObject visual = CreateVisual(source, parent, profile, context);
 
             StaticProductVisualsSetter setter =
                 scaffold.AddComponent<StaticProductVisualsSetter>();
             setter.VisualsContainer = visual.transform;
             return setter;
+        }
+
+        private static S1Product.ProductVisualsSetter ReplaceStationVisual(
+            GameObject scaffold,
+            S1Product.ProductVisualsSetter? oldSetter,
+            GameObject source,
+            ProductPresentationProfile profile)
+        {
+            S1Station.IngredientPiece? ingredientPiece =
+                scaffold.GetComponentInChildren<S1Station.IngredientPiece>(true);
+            if (ingredientPiece == null ||
+                ingredientPiece.ModelContainer == null ||
+                oldSetter == null ||
+                oldSetter.VisualsContainer == null)
+            {
+                return ReplaceVisual(
+                    scaffold,
+                    oldSetter,
+                    source,
+                    profile,
+                    ProductPresentationContext.Station);
+            }
+
+            Transform? replacementParent =
+                oldSetter.VisualsContainer != scaffold.transform
+                    ? oldSetter.VisualsContainer.parent
+                    : scaffold.transform;
+            GameObject visual =
+                CreateVisual(
+                    source,
+                    replacementParent ?? scaffold.transform,
+                    profile,
+                    ProductPresentationContext.Station);
+
+            Transform interactionRoot = ingredientPiece.transform;
+            RetireStationModel(ingredientPiece.ModelContainer, interactionRoot);
+
+            // Keep the profile-authored pose while moving the replacement under
+            // the native rigidbody/Draggable object that owns station interaction.
+            visual.transform.SetParent(interactionRoot, true);
+            EnsureCollider(visual);
+            ingredientPiece.ModelContainer = visual.transform;
+
+            StaticStationProductVisualsSetter setter =
+                scaffold.AddComponent<StaticStationProductVisualsSetter>();
+            setter.VisualsContainer = visual.transform;
+
+            // The cached prefab is active so native instantiation preserves its
+            // active state. Freeze only the physics child until Initialize()
+            // activates it through the station-specific visuals setter.
+            interactionRoot.gameObject.SetActive(false);
+            return setter;
+        }
+
+        private static GameObject CreateVisual(
+            GameObject source,
+            Transform parent,
+            ProductPresentationProfile profile,
+            ProductPresentationContext context)
+        {
+            GameObject visual = Object.Instantiate(source);
+            visual.transform.SetParent(parent, false);
+            ApplyVisualTransform(visual.transform, profile, context);
+            visual.SetActive(true);
+            return visual;
+        }
+
+        private static void RetireStationModel(
+            Transform modelContainer,
+            Transform interactionRoot)
+        {
+            if (modelContainer != interactionRoot)
+            {
+                modelContainer.gameObject.SetActive(false);
+                return;
+            }
+
+            Renderer[] renderers =
+                modelContainer.GetComponentsInChildren<Renderer>(true);
+            for (int i = 0; i < renderers.Length; i++)
+                renderers[i].enabled = false;
+
+            Collider[] colliders =
+                modelContainer.GetComponentsInChildren<Collider>(true);
+            for (int i = 0; i < colliders.Length; i++)
+                colliders[i].enabled = false;
         }
 
         private static S1AvatarEquipping.AvatarEquippable BuildAvatarEquippable(

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -227,6 +227,10 @@ namespace S1API.Internal.Products
                     source,
                     profile,
                     ProductPresentationContext.Stored);
+            ApplyGeneratedMixColor(
+                stored.Visuals.VisualsContainer.gameObject,
+                product,
+                created);
             return clone;
         }
 
@@ -273,6 +277,10 @@ namespace S1API.Internal.Products
                     source,
                     profile,
                     ProductPresentationContext.Held);
+            ApplyGeneratedMixColor(
+                held.Visuals.VisualsContainer.gameObject,
+                product,
+                created);
             held.ModelContainer = held.Visuals.VisualsContainer;
             GameObject avatarSource =
                 ResolveAvatarHeldSource(product, profile, source, sources);
@@ -327,6 +335,10 @@ namespace S1API.Internal.Products
                     station.Visuals,
                     source,
                     profile);
+            ApplyGeneratedMixColor(
+                station.Visuals.VisualsContainer.gameObject,
+                product,
+                created);
             return clone;
         }
 
@@ -377,6 +389,10 @@ namespace S1API.Internal.Products
                     source,
                     profile,
                     ProductPresentationContext.FunctionalProduct);
+            ApplyGeneratedMixColor(
+                functional.Visuals.VisualsContainer.gameObject,
+                product,
+                created);
             if (profile.UseFunctionalProductConvexMeshColliders)
             {
                 ReplaceWithConvexMeshColliders(
@@ -640,8 +656,13 @@ namespace S1API.Internal.Products
             }
 
             GameObject model = Object.Instantiate(source);
+            var generatedMaterials = new List<Object>();
             try
             {
+                ApplyGeneratedMixColor(
+                    model,
+                    request.Product,
+                    generatedMaterials);
                 if (profile.GeneratedIconTransform != null)
                 {
                     profile.GeneratedIconTransform.ApplyTo(model.transform);
@@ -680,6 +701,7 @@ namespace S1API.Internal.Products
             finally
             {
                 Object.Destroy(model);
+                DestroyAll(generatedMaterials);
             }
 
             icon = global::S1API.Utils.ImageUtils.TextureToSprite(texture);
@@ -1020,6 +1042,7 @@ namespace S1API.Internal.Products
             created.Add(root);
             GameObject visual = Object.Instantiate(source);
             visual.transform.SetParent(root.transform, false);
+            ApplyGeneratedMixColor(visual, product, created);
             if (profile.TryGetAvatarHeldTransform(
                     out ProductPresentationTransform? avatarTransform))
             {
@@ -1097,6 +1120,48 @@ namespace S1API.Internal.Products
                     out ProductPresentationTransform? presentationTransform))
             {
                 presentationTransform?.ApplyTo(target);
+            }
+        }
+
+        private static void ApplyGeneratedMixColor(
+            GameObject visual,
+            CustomProductDefinitionRegistration product,
+            List<Object> created)
+        {
+            Color32? generatedMixColor = product.Metadata?.GeneratedMixColor;
+            if (!generatedMixColor.HasValue)
+                return;
+
+            Color color = generatedMixColor.Value;
+            Renderer[] renderers = visual.GetComponentsInChildren<Renderer>(true);
+            for (int rendererIndex = 0;
+                 rendererIndex < renderers.Length;
+                 rendererIndex++)
+            {
+                Renderer renderer = renderers[rendererIndex];
+                Material[] sourceMaterials = renderer.sharedMaterials;
+                var coloredMaterials = new Material[sourceMaterials.Length];
+                for (int materialIndex = 0;
+                     materialIndex < sourceMaterials.Length;
+                     materialIndex++)
+                {
+                    Material sourceMaterial = sourceMaterials[materialIndex];
+                    if (sourceMaterial == null)
+                        continue;
+
+                    var coloredMaterial = new Material(sourceMaterial)
+                    {
+                        name = sourceMaterial.name + "_S1API_MixedColor"
+                    };
+                    if (coloredMaterial.HasProperty("_BaseColor"))
+                        coloredMaterial.SetColor("_BaseColor", color);
+                    if (coloredMaterial.HasProperty("_Color"))
+                        coloredMaterial.SetColor("_Color", color);
+                    coloredMaterials[materialIndex] = coloredMaterial;
+                    created.Add(coloredMaterial);
+                }
+
+                renderer.sharedMaterials = coloredMaterials;
             }
         }
 

--- a/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
+++ b/S1API/Internal/Products/CustomProductSaveDescriptorData.cs
@@ -25,6 +25,11 @@ namespace S1API.Internal.Products
         public int ProviderVersion;
         public string ProviderData = string.Empty;
         public bool IsGeneratedMix;
+        public bool HasGeneratedMixColor;
+        public byte GeneratedMixColorR;
+        public byte GeneratedMixColorG;
+        public byte GeneratedMixColorB;
+        public byte GeneratedMixColorA;
     }
 
     [Serializable]

--- a/S1API/Internal/Products/CustomProductSavePersistence.cs
+++ b/S1API/Internal/Products/CustomProductSavePersistence.cs
@@ -18,6 +18,7 @@ using System.IO;
 using Newtonsoft.Json;
 using S1API.Products;
 using S1API.Internal.Properties;
+using UnityEngine;
 
 namespace S1API.Internal.Products
 {
@@ -203,7 +204,19 @@ namespace S1API.Internal.Products
                 var packagingMetadata = new List<PackagingDefinition>();
                 foreach (NativePackagingDefinition item in packaging)
                     packagingMetadata.Add(new PackagingDefinition(item));
-                var metadata = new CustomProductDefinitionMetadata(kind, (Quality)data.DefaultQuality, packagingMetadata, template);
+                Color32? generatedMixColor = data.HasGeneratedMixColor
+                    ? new Color32(
+                        data.GeneratedMixColorR,
+                        data.GeneratedMixColorG,
+                        data.GeneratedMixColorB,
+                        data.GeneratedMixColorA)
+                    : null;
+                var metadata = new CustomProductDefinitionMetadata(
+                    kind,
+                    (Quality)data.DefaultQuality,
+                    packagingMetadata,
+                    template,
+                    generatedMixColor);
                 try
                 {
                     CustomProductDefinitionRegistry.Register(data.OwnerId, data.ProductId, data.ProductName, data.InitialPrice, native, metadata, data);

--- a/S1API/Internal/Products/ProductMixingColorContract.cs
+++ b/S1API/Internal/Products/ProductMixingColorContract.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using S1API.Products;
+
+namespace S1API.Internal.Products
+{
+    internal readonly struct ProductMixingColorValue : IEquatable<ProductMixingColorValue>
+    {
+        internal ProductMixingColorValue(byte red, byte green, byte blue, byte alpha)
+        {
+            Red = red;
+            Green = green;
+            Blue = blue;
+            Alpha = alpha;
+        }
+
+        internal byte Red { get; }
+
+        internal byte Green { get; }
+
+        internal byte Blue { get; }
+
+        internal byte Alpha { get; }
+
+        internal UnityEngine.Color32 ToColor32() =>
+            new UnityEngine.Color32(Red, Green, Blue, Alpha);
+
+        public bool Equals(ProductMixingColorValue other) =>
+            Red == other.Red &&
+            Green == other.Green &&
+            Blue == other.Blue &&
+            Alpha == other.Alpha;
+
+        public override bool Equals(object? obj) =>
+            obj is ProductMixingColorValue other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Red, Green, Blue, Alpha);
+    }
+
+    internal readonly struct ProductMixingColorSample
+    {
+        internal ProductMixingColorSample(
+            int tier,
+            ProductMixingColorValue color)
+        {
+            Tier = tier;
+            Color = color;
+        }
+
+        internal int Tier { get; }
+
+        internal ProductMixingColorValue Color { get; }
+    }
+
+    internal static class ProductMixingColorContract
+    {
+        internal static ProductMixingColorValue CalculatePrimaryColor(
+            ProductMixingMap mixerMap,
+            IReadOnlyList<ProductMixingColorSample> properties)
+        {
+            if (properties == null)
+                throw new ArgumentNullException(nameof(properties));
+
+            ProductMixingColorValue baseColor = GetBaseColor(mixerMap);
+            if (properties.Count == 0)
+                return baseColor;
+
+            ProductMixingColorSample primary = properties[0];
+            for (int i = 1; i < properties.Count; i++)
+            {
+                if (properties[i].Tier < primary.Tier)
+                    primary = properties[i];
+            }
+
+            float influence = mixerMap switch
+            {
+                ProductMixingMap.Marijuana => primary.Tier * 0.15f,
+                ProductMixingMap.Methamphetamine => primary.Tier * 0.2f,
+                ProductMixingMap.Cocaine => primary.Tier * 0.13f,
+                ProductMixingMap.Shrooms => primary.Tier / 5f,
+                _ => throw new ArgumentOutOfRangeException(nameof(mixerMap))
+            };
+            return Lerp(baseColor, primary.Color, influence);
+        }
+
+        private static ProductMixingColorValue GetBaseColor(
+            ProductMixingMap mixerMap)
+        {
+            return mixerMap switch
+            {
+                ProductMixingMap.Marijuana =>
+                    new ProductMixingColorValue(90, 100, 70, byte.MaxValue),
+                ProductMixingMap.Methamphetamine =>
+                    new ProductMixingColorValue(
+                        byte.MaxValue,
+                        byte.MaxValue,
+                        byte.MaxValue,
+                        byte.MaxValue),
+                ProductMixingMap.Cocaine =>
+                    new ProductMixingColorValue(
+                        byte.MaxValue,
+                        byte.MaxValue,
+                        byte.MaxValue,
+                        byte.MaxValue),
+                ProductMixingMap.Shrooms =>
+                    new ProductMixingColorValue(168, 125, 43, byte.MaxValue),
+                _ => throw new ArgumentOutOfRangeException(nameof(mixerMap))
+            };
+        }
+
+        private static ProductMixingColorValue Lerp(
+            ProductMixingColorValue start,
+            ProductMixingColorValue end,
+            float amount)
+        {
+            float clamped = Math.Max(0f, Math.Min(1f, amount));
+            return new ProductMixingColorValue(
+                LerpByte(start.Red, end.Red, clamped),
+                LerpByte(start.Green, end.Green, clamped),
+                LerpByte(start.Blue, end.Blue, clamped),
+                LerpByte(start.Alpha, end.Alpha, clamped));
+        }
+
+        private static byte LerpByte(byte start, byte end, float amount) =>
+            (byte)(start + ((end - start) * amount));
+    }
+}

--- a/S1API/Internal/Products/ProductMixingProfileRegistry.cs
+++ b/S1API/Internal/Products/ProductMixingProfileRegistry.cs
@@ -21,7 +21,8 @@ namespace S1API.Internal.Products
                 if (existing.MixerMap == profile.MixerMap &&
                     ReferenceEquals(existing.OutputFactory, profile.OutputFactory) &&
                     string.Equals(existing.OutputFactoryIdentity, profile.OutputFactoryIdentity, StringComparison.OrdinalIgnoreCase) &&
-                    existing.OutputFactoryVersion == profile.OutputFactoryVersion)
+                    existing.OutputFactoryVersion == profile.OutputFactoryVersion &&
+                    existing.UsePropertyColorMixing == profile.UsePropertyColorMixing)
                     return existing;
                 throw new InvalidOperationException("A conflicting mixing profile is already registered for product kind '" + profile.ProductKind.Id + "'.");
             }

--- a/S1API/Internal/Products/StaticStationProductVisualsSetter.cs
+++ b/S1API/Internal/Products/StaticStationProductVisualsSetter.cs
@@ -1,0 +1,51 @@
+#if IL2CPPMELON
+using Il2CppInterop.Runtime.Attributes;
+using Il2CppInterop.Runtime.Injection;
+using S1Product = Il2CppScheduleOne.Product;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+#endif
+
+using System;
+using MelonLoader;
+
+namespace S1API.Internal.Products
+{
+    /// <summary>
+    /// INTERNAL: Activates a station visual together with its native interaction root.
+    /// </summary>
+#if IL2CPPMELON
+    [RegisterTypeInIl2Cpp]
+#endif
+    internal sealed class StaticStationProductVisualsSetter :
+        S1Product.ProductVisualsSetter
+    {
+#if IL2CPPMELON
+        public StaticStationProductVisualsSetter(IntPtr pointer)
+            : base(pointer)
+        {
+        }
+
+        public StaticStationProductVisualsSetter()
+            : base(
+                ClassInjector
+                    .DerivedConstructorPointer<StaticStationProductVisualsSetter>())
+        {
+            ClassInjector.DerivedConstructorBody(this);
+        }
+#endif
+
+        /// <inheritdoc />
+        public override void ApplyVisuals(
+            S1Product.ProductDefinition productDefinition)
+        {
+            if (VisualsContainer == null)
+                return;
+
+            if (VisualsContainer.parent != null)
+                VisualsContainer.parent.gameObject.SetActive(true);
+
+            VisualsContainer.gameObject.SetActive(true);
+        }
+    }
+}

--- a/S1API/Products/ProductMixingProfile.cs
+++ b/S1API/Products/ProductMixingProfile.cs
@@ -7,13 +7,14 @@ namespace S1API.Products
     /// </summary>
     public sealed class ProductMixingProfile
     {
-        internal ProductMixingProfile(ProductKind productKind, ProductMixingMap mixerMap, Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory, string outputFactoryIdentity, int outputFactoryVersion)
+        internal ProductMixingProfile(ProductKind productKind, ProductMixingMap mixerMap, Func<ProductMixingOutput, ProductMixingOutputDefinition> outputFactory, string outputFactoryIdentity, int outputFactoryVersion, bool usePropertyColorMixing)
         {
             ProductKind = productKind;
             MixerMap = mixerMap;
             OutputFactory = outputFactory;
             OutputFactoryIdentity = outputFactoryIdentity;
             OutputFactoryVersion = outputFactoryVersion;
+            UsePropertyColorMixing = usePropertyColorMixing;
         }
 
         /// <summary>Gets the opted-in logical product kind.</summary>
@@ -24,6 +25,8 @@ namespace S1API.Products
         public string OutputFactoryIdentity { get; }
         /// <summary>Gets the output-factory compatibility version used across peers.</summary>
         public int OutputFactoryVersion { get; }
+        /// <summary>Gets whether generated outputs use a native-style color derived from their properties.</summary>
+        public bool UsePropertyColorMixing { get; }
         internal Func<ProductMixingOutput, ProductMixingOutputDefinition> OutputFactory { get; }
     }
 }

--- a/S1API/Products/ProductMixingProfileBuilder.cs
+++ b/S1API/Products/ProductMixingProfileBuilder.cs
@@ -13,6 +13,7 @@ namespace S1API.Products
         private Func<ProductMixingOutput, ProductMixingOutputDefinition>? _outputFactory;
         private string? _outputFactoryIdentity;
         private int _outputFactoryVersion;
+        private bool _usePropertyColorMixing;
 
         /// <summary>Creates a mixing-profile builder for a registered logical product kind.</summary>
         /// <param name="productKind">The stable logical kind that opts into mixing.</param>
@@ -68,6 +69,21 @@ namespace S1API.Products
             return this;
         }
 
+        /// <summary>
+        /// Colors each generated output from its mixed properties using the selected native
+        /// mixer map's primary-color strategy.
+        /// </summary>
+        /// <remarks>
+        /// This is opt-in. It affects only generated mixes and does not recolor the base custom
+        /// product. The resulting color is persisted with the generated product so save reloads
+        /// and peers render the same appearance.
+        /// </remarks>
+        public ProductMixingProfileBuilder WithPropertyColorMixing()
+        {
+            _usePropertyColorMixing = true;
+            return this;
+        }
+
         /// <summary>Builds and registers this immutable mixing profile.</summary>
         /// <returns>The registered profile, or the existing equivalent profile.</returns>
         /// <exception cref="InvalidOperationException">Thrown when no output factory was configured.</exception>
@@ -84,7 +100,8 @@ namespace S1API.Products
                 _mixerMap,
                 _outputFactory,
                 compatibilityIdentity,
-                _outputFactoryVersion));
+                _outputFactoryVersion,
+                _usePropertyColorMixing));
         }
     }
 }

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.4", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.5", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.4</Version>
+        <Version>3.1.5</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- preserve native Mixing Station interaction and drag behavior for custom products
- resolve native single-property mixing ingredients for custom product mixes
- complete generated custom mixes through the native discovery lifecycle so they stay sellable in their logical product kind
- add opt-in native-style property coloring for generated mixes, including save persistence and multiplayer compatibility validation
- bump S1API to 3.1.5

## Validation

- Mono build and full test suite: 414 passed
- IL2CPP build and product test suite: 276 passed
- exact-save in-game smoke on `SaveGame_3`: generated MDMA mix was discovered, listable under the MDMA product kind, draggable at the Mixing Station, and rendered with its computed property color
- Drug Expansion Mono and IL2CPP consumer builds succeeded against S1API 3.1.5

Closes #178
Closes #179
Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional property-based color mixing for custom product outputs.
  * Generated product colors are now applied consistently across item, station, held, and icon visuals.
  * Generated mix colors are preserved in save data and included in multiplayer compatibility checks.
  * Added support for custom ingredients with usable properties.

* **Bug Fixes**
  * Improved station visual replacement while preserving station interactions.

* **Compatibility**
  * Updated the package version to 3.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->