### PR TITLE
fix(products): show custom visuals in mix discovery

### DIFF
--- a/S1API/Internal/Patches/ProductPresentationPatches.cs
+++ b/S1API/Internal/Patches/ProductPresentationPatches.cs
@@ -1,0 +1,36 @@
+using HarmonyLib;
+using S1API.Internal.Products;
+#if IL2CPPMELON
+using S1Product = Il2CppScheduleOne.Product;
+using EffectList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Effects.Effect>;
+#elif MONOMELON
+using S1Product = ScheduleOne.Product;
+using EffectList = System.Collections.Generic.List<ScheduleOne.Effects.Effect>;
+#endif
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// INTERNAL: Shows registered custom product visuals in the native new-mix display.
+    /// </summary>
+    [HarmonyPatch(
+        typeof(S1Product.NewMixDiscoveryBox),
+        nameof(S1Product.NewMixDiscoveryBox.ShowProduct))]
+    internal static class ProductPresentationPatches
+    {
+        [HarmonyPostfix]
+        private static void ShowProductPostfix(
+            S1Product.NewMixDiscoveryBox __instance,
+            S1Product.ProductDefinition baseDefinition,
+            EffectList properties)
+        {
+            if (__instance?.Visuals == null)
+                return;
+
+            CustomProductPresentationRuntime.ApplyDiscoveryVisual(
+                __instance.Visuals,
+                baseDefinition,
+                properties);
+        }
+    }
+}

--- a/S1API/Internal/Products/CustomProductPresentationRuntime.cs
+++ b/S1API/Internal/Products/CustomProductPresentationRuntime.cs
@@ -1,15 +1,19 @@
 #if IL2CPPMELON
 using S1AvatarEquipping = Il2CppScheduleOne.AvatarFramework.Equipping;
+using S1Effects = Il2CppScheduleOne.Effects;
 using S1Equipping = Il2CppScheduleOne.Equipping;
 using S1Product = Il2CppScheduleOne.Product;
 using S1Station = Il2CppScheduleOne.StationFramework;
 using S1Storage = Il2CppScheduleOne.Storage;
+using EffectList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Effects.Effect>;
 #elif MONOMELON
 using S1AvatarEquipping = ScheduleOne.AvatarFramework.Equipping;
+using S1Effects = ScheduleOne.Effects;
 using S1Equipping = ScheduleOne.Equipping;
 using S1Product = ScheduleOne.Product;
 using S1Station = ScheduleOne.StationFramework;
 using S1Storage = ScheduleOne.Storage;
+using EffectList = System.Collections.Generic.List<ScheduleOne.Effects.Effect>;
 #endif
 
 using System;
@@ -38,6 +42,8 @@ namespace S1API.Internal.Products
         private static readonly Queue<GeneratedIconRequest> GeneratedIconQueue =
             new Queue<GeneratedIconRequest>();
         private static bool _isProcessingGeneratedIcons;
+        private const string DiscoveryVisualRootName =
+            "S1API_CustomProductDiscoveryVisual";
 
         private sealed class GeneratedIconRequest
         {
@@ -96,6 +102,174 @@ namespace S1API.Internal.Products
             }
 
             BuildAndCommit(product, profile);
+        }
+
+        internal static void ApplyDiscoveryVisual(
+            S1Product.MultiTypeVisualsSetter setter,
+            S1Product.ProductDefinition product,
+            EffectList properties)
+        {
+            if (setter == null)
+                return;
+
+            RemoveDiscoveryVisual(setter.transform);
+            if (product == null ||
+                properties == null ||
+                !CustomProductDefinitionRegistry.TryGetMetadata(
+                    product,
+                    out CustomProductDefinitionMetadata? metadata) ||
+                metadata == null ||
+                !ProductPresentationProfileRegistry.TryResolve(
+                    product.ID,
+                    metadata.ProductKind.Id,
+                    out ProductPresentationProfileRegistration? registration) ||
+                registration == null)
+            {
+                return;
+            }
+
+            ProductPresentationProfile profile = registration.Profile;
+            if (!profile.TryGetVisualProvider(
+                    ProductPresentationContext.FunctionalProduct,
+                    out Func<GameObject?>? provider) ||
+                provider == null)
+            {
+                return;
+            }
+
+            GameObject? source;
+            try
+            {
+                source = provider();
+            }
+            catch (Exception exception)
+            {
+                MelonLogger.Warning(
+                    $"[ProductPresentationProfile] Discovery visual provider for " +
+                    $"'{product.ID}' failed: {exception.Message}");
+                return;
+            }
+
+            if (source == null)
+                return;
+
+            GameObject? root = null;
+            try
+            {
+                root = new GameObject(DiscoveryVisualRootName);
+                root.transform.SetParent(setter.transform, false);
+                root.SetActive(false);
+                GameObject visual = Object.Instantiate(source);
+                visual.transform.SetParent(root.transform, false);
+                ApplyVisualTransform(
+                    visual.transform,
+                    profile,
+                    ProductPresentationContext.FunctionalProduct);
+                ApplyDiscoveryMixColor(
+                    visual,
+                    metadata,
+                    properties);
+                visual.SetActive(true);
+
+                ResetMultiTypeVisuals(setter);
+                root.SetActive(true);
+            }
+            catch (Exception exception)
+            {
+                if (root != null)
+                    Object.Destroy(root);
+                MelonLogger.Warning(
+                    $"[ProductPresentationProfile] Could not show the discovery " +
+                    $"visual for '{product.ID}'; retaining the native fallback: " +
+                    exception.Message);
+            }
+        }
+
+        private static void ApplyDiscoveryMixColor(
+            GameObject visual,
+            CustomProductDefinitionMetadata metadata,
+            EffectList properties)
+        {
+            if (!ProductMixingProfiles.TryGet(
+                    metadata.ProductKind.Id,
+                    out ProductMixingProfile? mixingProfile) ||
+                mixingProfile == null ||
+                !mixingProfile.UsePropertyColorMixing)
+            {
+                return;
+            }
+
+            var samples =
+                new List<ProductMixingColorSample>(properties.Count);
+            for (int i = 0; i < properties.Count; i++)
+            {
+                S1Effects.Effect property = properties[i];
+                if (property == null)
+                    continue;
+                Color32 color = property.ProductColor;
+                samples.Add(
+                    new ProductMixingColorSample(
+                        (int)property.Tier,
+                        new ProductMixingColorValue(
+                            color.r,
+                            color.g,
+                            color.b,
+                            color.a)));
+            }
+
+            Color mixedColor =
+                ProductMixingColorContract.CalculatePrimaryColor(
+                    mixingProfile.MixerMap,
+                    samples).ToColor32();
+            Renderer[] renderers =
+                visual.GetComponentsInChildren<Renderer>(true);
+            var propertyBlock = new MaterialPropertyBlock();
+            for (int i = 0; i < renderers.Length; i++)
+            {
+                Renderer renderer = renderers[i];
+                renderer.GetPropertyBlock(propertyBlock);
+                Material[] materials = renderer.sharedMaterials;
+                for (int materialIndex = 0;
+                     materialIndex < materials.Length;
+                     materialIndex++)
+                {
+                    Material material = materials[materialIndex];
+                    if (material == null)
+                        continue;
+                    if (material.HasProperty("_BaseColor"))
+                        propertyBlock.SetColor("_BaseColor", mixedColor);
+                    if (material.HasProperty("_Color"))
+                        propertyBlock.SetColor("_Color", mixedColor);
+                }
+
+                renderer.SetPropertyBlock(propertyBlock);
+                propertyBlock.Clear();
+            }
+        }
+
+        private static void ResetMultiTypeVisuals(
+            S1Product.MultiTypeVisualsSetter setter)
+        {
+            setter.WeedVisuals?.ResetVisuals();
+            setter.MethVisuals?.ResetVisuals();
+            setter.CocaineVisuals?.ResetVisuals();
+            setter.ShroomVisuals?.ResetVisuals();
+        }
+
+        private static void RemoveDiscoveryVisual(Transform parent)
+        {
+            for (int i = parent.childCount - 1; i >= 0; i--)
+            {
+                Transform child = parent.GetChild(i);
+                if (string.Equals(
+                        child.name,
+                        DiscoveryVisualRootName,
+                        StringComparison.Ordinal))
+                {
+                    child.gameObject.SetActive(false);
+                    Object.Destroy(child.gameObject);
+                }
+            }
         }
 
         private static void BuildAndCommit(

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.5", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.6", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.5</Version>
+        <Version>3.1.6</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- route custom product presentation profiles into the native new-mix discovery display
- preserve the native discovery visual as a fallback if a custom provider fails
- apply opt-in property-derived mix color before the generated product is named
- bump S1API to 3.1.6

## Validation

- dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false
- dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build (414 passed)
- dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false
- targeted IL2CPP presentation/mixing tests (33 passed)
- public-game IL2CPP smoke against SaveGame_3: invoked the native NewMixDiscoveryBox.ShowProduct flow for MDMA + banana and verified one active heart-pill renderer with the expected FFE0C7 property color

The complete IL2CPP test process reports all 304 discovered tests passed, then hits the existing test-host finalizer crash because GameAssembly is unavailable outside the game process; the focused affected group exits cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom visuals in product discovery displays.
  * Custom visuals now adapt to product properties, including color effects, while preserving native visuals when custom presentation is unavailable.

* **Bug Fixes**
  * Improved cleanup and replacement of previously applied custom discovery visuals.
  * Added safeguards to prevent presentation errors when required visual or product data is unavailable.

* **Chores**
  * Updated the application and package version to 3.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->