### PR TITLE
fix(release): omit unsupported Nexus changelog

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -435,7 +435,10 @@ jobs:
           version: ${{ steps.metadata.outputs.release_version }}
           display_name: S1API Forked ${{ steps.metadata.outputs.release_version }}
           description: ${{ env.RELEASE_DESCRIPTION }}
-          changelog: ${{ github.event_name == 'push' && github.run_attempt == 1 && steps.github-release.outputs.release_notes || '' }}
+          # Nexus file publishing and changelog publishing use separate API resources.
+          # The changelog endpoint currently rejects this mod even after creating the
+          # file version, which turns a successful upload into a failed release run.
+          # Keep release notes on GitHub and omit the optional Nexus changelog input.
           category: main
           archive_existing_version: true
           update_mod_version: true

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -121,7 +121,7 @@ The GitHub release workflow packages public mod archives and can publish the sam
 - The uppercase `Mods/` and `Plugins/` paths are intentional so case-sensitive filesystems do not create parallel lowercase install folders.
 - The GitHub release asset is always uploaded by the workflow.
 - Nexus Mods upload runs when `NEXUSMODS_API_KEY`, `NEXUSMODS_FILE_GROUP_ID`, and `NEXUSMODS_MOD_ID` are configured.
-- The first tag-triggered attempt sends the generated GitHub release notes as the Nexus Mods changelog. Manual dispatches and reruns leave the changelog empty so the additive Nexus endpoint does not append the same notes twice.
+- Generated release notes are published on GitHub. The Nexus Mods upload intentionally omits the optional changelog input because Nexus handles file versions and changelogs through separate endpoints, and a rejected changelog request would otherwise fail the workflow after a successful file upload.
 - Thunderstore upload runs when `THUNDERSTORE_TOKEN` is configured.
 - `workflow_dispatch` exposes `publish_nexus` and `publish_thunderstore` toggles for refreshing GitHub assets without re-publishing external platforms.
 


### PR DESCRIPTION
## Summary
- omit the optional Nexus changelog input that fails after a successful file-version upload
- keep generated release notes on GitHub
- document the intentional Nexus behavior in the release policy

## Failure evidence
The v3.1.6 tag workflow successfully uploaded and created the Nexus file version, then failed on the separate changelog endpoint with HTTP 404. This also skipped the later Thunderstore step.

## Validation
- parsed publish-github-release.yml with PyYAML
- git diff --check
- confirmed changelog is optional in Nexus-Mods/upload-action@v1.0.0-beta.10