### PR TITLE
feat(suppliers): support persistent identity migration

### DIFF
--- a/S1API.Tests/Entities/SupplierPersistentIdentityTests.cs
+++ b/S1API.Tests/Entities/SupplierPersistentIdentityTests.cs
@@ -1,4 +1,5 @@
 using S1API.Entities.Supplier;
+using S1API.Internal.Entities.Suppliers;
 using System.Reflection;
 
 namespace S1API.Tests.Entities;
@@ -45,4 +46,61 @@ public sealed class SupplierPersistentIdentityTests
         Assert.Throws<ArgumentException>(() =>
             builder.WithPersistentId(persistentId));
     }
+
+    [Fact]
+    public void PersistentIdRejectsNullValue()
+    {
+        var builder = new SupplierDataBuilder();
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.WithPersistentId(null!));
+    }
+
+    [Fact]
+    public void PersistentIdKeepsSupplierInfrastructureIdentitiesStable()
+    {
+        const string runtimeId = "disco_davey";
+        const string persistentId = "ifbars.moredrugs:npcs/disco-davey";
+        var configured = new SupplierDataBuilder()
+            .WithPersistentId(persistentId)
+            .BuildInternal();
+
+        SupplierInfrastructureIdentity migrated = GetInfrastructureIdentity(
+            configured.PersistentId ?? runtimeId);
+        SupplierInfrastructureIdentity legacy = GetInfrastructureIdentity(persistentId);
+        SupplierInfrastructureIdentity currentRuntime = GetInfrastructureIdentity(runtimeId);
+
+        Assert.Equal(legacy, migrated);
+        Assert.NotEqual(currentRuntime, migrated);
+        Assert.Equal(migrated, GetInfrastructureIdentity(configured.PersistentId ?? runtimeId));
+    }
+
+    [Fact]
+    public void OmittedPersistentIdFallsBackToRuntimeInfrastructureIdentities()
+    {
+        const string runtimeId = "disco_davey";
+        var configured = new SupplierDataBuilder().BuildInternal();
+
+        Assert.Null(configured.PersistentId);
+        SupplierInfrastructureIdentity fallback = GetInfrastructureIdentity(
+            configured.PersistentId ?? runtimeId);
+
+        Assert.Equal(GetInfrastructureIdentity(runtimeId), fallback);
+        Assert.Equal(fallback, GetInfrastructureIdentity(configured.PersistentId ?? runtimeId));
+    }
+
+    private static SupplierInfrastructureIdentity GetInfrastructureIdentity(string stableId)
+    {
+        return new SupplierInfrastructureIdentity(
+            SupplierRuntimeIds.GetShopName(stableId),
+            SupplierRuntimeIds.GetDeliveryVehiclePrefabName(stableId),
+            SupplierRuntimeIds.GetDeliveryVehicleGuid(stableId),
+            SupplierRuntimeIds.GetStashGuid(stableId));
+    }
+
+    private readonly record struct SupplierInfrastructureIdentity(
+        string ShopName,
+        string DeliveryVehiclePrefabName,
+        Guid DeliveryVehicleGuid,
+        Guid StashGuid);
 }

--- a/S1API.Tests/Entities/SupplierPersistentIdentityTests.cs
+++ b/S1API.Tests/Entities/SupplierPersistentIdentityTests.cs
@@ -1,0 +1,48 @@
+using S1API.Entities.Supplier;
+using System.Reflection;
+
+namespace S1API.Tests.Entities;
+
+public sealed class SupplierPersistentIdentityTests
+{
+    [Fact]
+    public void PersistentIdIsPublicFluentApi()
+    {
+        MethodInfo? method = typeof(SupplierDataBuilder).GetMethod(
+            nameof(SupplierDataBuilder.WithPersistentId),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: [typeof(string)],
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(SupplierDataBuilder), method.ReturnType);
+    }
+
+    [Fact]
+    public void PersistentIdIsOptInAndPreservesTheConfiguredValue()
+    {
+        var defaults = new SupplierDataBuilder().BuildInternal();
+        var builder = new SupplierDataBuilder();
+
+        SupplierDataBuilder result = builder.WithPersistentId(
+            " ifbars.moredrugs:npcs/disco-davey ");
+
+        Assert.Same(builder, result);
+        Assert.Null(defaults.PersistentId);
+        Assert.Equal(
+            "ifbars.moredrugs:npcs/disco-davey",
+            builder.BuildInternal().PersistentId);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void PersistentIdRejectsEmptyValues(string persistentId)
+    {
+        var builder = new SupplierDataBuilder();
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.WithPersistentId(persistentId));
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -975,7 +975,9 @@ namespace S1API.Entities
                         var supplierDefaults = BuildSupplierDefaultsForType(npcType);
                         if (supplierComponent != null && supplierDefaults != null)
                             TryApplySupplierDefaults(supplierComponent, supplierDefaults);
-                        SupplierRuntimeCoordinator.FinalizePrefabInfrastructure(prefabNO.gameObject);
+                        SupplierRuntimeCoordinator.FinalizePrefabInfrastructure(
+                            prefabNO.gameObject,
+                            supplierDefaults?.PersistentId);
                         break;
                     }
                 }
@@ -1062,7 +1064,9 @@ namespace S1API.Entities
             if (prefabRoot == null || GetDeclaredRootRole(npcType) != NpcRootRole.Supplier)
                 return;
 
-            SupplierRuntimeCoordinator.FinalizePrefabInfrastructure(prefabRoot);
+            SupplierRuntimeCoordinator.FinalizePrefabInfrastructure(
+                prefabRoot,
+                BuildSupplierDefaultsForType(npcType)?.PersistentId);
         }
 
         private static NpcRootRole GetDeclaredRootRole(System.Type npcType)

--- a/S1API/Entities/Supplier/SupplierDataBuilder.cs
+++ b/S1API/Entities/Supplier/SupplierDataBuilder.cs
@@ -31,6 +31,7 @@ namespace S1API.Entities.Supplier
             public string SupplierUnlockHint { get; set; } =
                 "You can now order <PRODUCT> from <NAME>. <PRODUCT> can be used to <PURPOSE>.";
             public string? StashDeadDropGuid { get; set; }
+            public string? PersistentId { get; set; }
 
             internal IReadOnlyList<S1ItemFramework.StorableItemDefinition>
                 ResolveDeliveryItems()
@@ -103,6 +104,31 @@ namespace S1API.Entities.Supplier
 
             data.MinimumDeaddropOrderLimit = minimum;
             data.MaximumDeaddropOrderLimit = maximum;
+            return this;
+        }
+
+        /// <summary>
+        /// Keeps this supplier's generated shop, delivery vehicle, and generated stash
+        /// identities on an existing persistent ID.
+        /// </summary>
+        /// <remarks>
+        /// This does not change the NPC's runtime <c>ID</c>. Use it only when a released
+        /// supplier must adopt a new runtime NPC ID while preserving the supplier data
+        /// derived from its former ID.
+        /// </remarks>
+        /// <param name="persistentId">The non-empty ID used by the previous supplier release.</param>
+        /// <returns>The current builder for chaining.</returns>
+        /// <exception cref="ArgumentException">Thrown when the ID is empty or whitespace.</exception>
+        public SupplierDataBuilder WithPersistentId(string persistentId)
+        {
+            if (string.IsNullOrWhiteSpace(persistentId))
+            {
+                throw new ArgumentException(
+                    "The persistent supplier ID cannot be empty.",
+                    nameof(persistentId));
+            }
+
+            data.PersistentId = persistentId.Trim();
             return this;
         }
 

--- a/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
+++ b/S1API/Internal/Entities/SupplierRuntimeCoordinator.cs
@@ -76,7 +76,9 @@ namespace S1API.Internal.Entities
 
             try
             {
-                string stableId = SupplierRuntimeIds.ResolveStableId(supplier.gameObject, supplierId);
+                string stableId = SupplierRuntimeIds.ResolveStableId(
+                    supplier.gameObject,
+                    config?.PersistentId ?? supplierId);
                 SupplierStashRuntime.Bind(
                     supplier,
                     stableId,

--- a/S1API/docs/supplier-system.md
+++ b/S1API/docs/supplier-system.md
@@ -52,7 +52,7 @@ storable to appear in the supplier shop. You can also pass an already registered
 - A custom NPC cannot be both a supplier and a dealer. Choose one native root role per NPC type.
 - `WithOrderLimits(minimum, maximum)` requires finite values, `minimum >= 0`, `maximum > 0`, and `maximum >= minimum`.
 - Every delivery listing must reference a storable item. Register custom items before S1API configures the NPC prefab.
-- Use a permanent, unique ID in `WithIdentity(...)`. S1API derives persistent supplier infrastructure from that ID, so changing it breaks continuity with existing saves.
+- Use a permanent, unique ID in `WithIdentity(...)`. S1API derives persistent supplier infrastructure from that ID, so changing it breaks continuity with existing saves. When a released supplier must adopt a new runtime NPC ID, opt in to `WithPersistentId("old_supplier_id")` in the supplier defaults. The runtime NPC ID changes while the generated shop, delivery vehicle, and stash keep their former persistent identities. New suppliers should omit this migration-only option.
 - Configure supplier defaults in `ConfigurePrefab`, not in `OnCreated`. This keeps host, client, and saved-game prefab data consistent.
 
 S1API creates the native meeting action and supplier-owned stash, shop, and delivery vehicle behind the public API. Do not copy or assign native supplier scene objects yourself.


### PR DESCRIPTION
## Summary
- add opt-in `SupplierDataBuilder.WithPersistentId(...)` for released suppliers that need a new runtime NPC ID
- retain generated supplier shop, delivery-vehicle, and stash identities from the former ID
- document and test the migration contract

## Testing
- `dotnet build S1API.sln -c MonoMelon --no-restore ...`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build ...` (418 passed)
- `dotnet build S1API.sln -c Il2CppMelon --no-restore ...`
- IL2CPP test host compilation succeeded, but runtime tests abort during `Il2CppInterop` finalization outside a live game process (missing/unsafe `GameAssembly` initialization); no IL2CPP test pass is claimed.

## Compatibility
- Source and binary compatibility: additive public fluent method only; existing callers keep the null/default persistence ID.
- Behavioral compatibility: unchanged unless `WithPersistentId(...)` is explicitly configured.
- Save and network compatibility: the opt-in value preserves the existing derived supplier shop, delivery vehicle, and stash identities while the runtime NPC ID can follow native conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional persistent supplier ID configuration.
  - Supplier infrastructure can retain its identity when a supplier’s runtime NPC ID changes.
  - Configured IDs are trimmed, validated, and support fluent setup.

- **Bug Fixes**
  - Supplier identity resolution now honors configured persistent IDs while preserving existing defaults.

- **Documentation**
  - Updated supplier configuration guidance, including migration-only usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->