### PR TITLE
fix(products): bound generated custom mix IDs

### DIFF
--- a/S1API.Tests/Products/CustomProductMixingIdentityTests.cs
+++ b/S1API.Tests/Products/CustomProductMixingIdentityTests.cs
@@ -19,11 +19,61 @@ public sealed class CustomProductMixingIdentityTests
             nativePostSanitizationId);
 
         Assert.StartsWith("moredrugs:mix/mdma/", generated);
+        Assert.Equal(83, generated.Length);
         Assert.Equal("moredrugs",
             CustomProductDefinitionBuilderContract.GetOwnerId(generated));
         Assert.Equal(generated, CustomProductMixingIdentity.CreateGeneratedProductId(
             "moredrugs:mdma", nativePostSanitizationId));
         Assert.True(CustomProductMixingIdentity.IsGeneratedIdForSource(
             "moredrugs:mdma", generated));
+    }
+
+    [Fact]
+    public void FourthAndDeeperGeneratedMixesStayWithinManifestIdentifierLimit()
+    {
+        string source = "ifbars.moredrugs:products/mdma";
+
+        for (int depth = 1; depth <= 16; depth++)
+        {
+            string generated = CustomProductMixingIdentity.CreateGeneratedProductId(
+                source,
+                "native-mix-" + depth);
+
+            Assert.True(CustomProductManifestData.IsBoundedIdentifier(generated));
+            if (depth == 4)
+                Assert.Equal(150, generated.Length);
+            Assert.True(CustomProductMixingIdentity.IsGeneratedIdForSource(
+                source,
+                generated));
+            source = generated;
+        }
+    }
+
+    [Fact]
+    public void LongManifestValidSourceUsesBoundedFrameworkFallbackOwner()
+    {
+        string source = new string('a', 250) + ":x";
+
+        string generated = CustomProductMixingIdentity.CreateGeneratedProductId(
+            source,
+            "native-mix");
+
+        Assert.True(CustomProductManifestData.IsBoundedIdentifier(generated));
+        Assert.StartsWith("s1api:mix/", generated);
+        Assert.True(CustomProductMixingIdentity.IsGeneratedIdForSource(
+            source,
+            generated));
+    }
+
+    [Fact]
+    public void LegacyGeneratedMixIdRemainsRecognizedForItsSource()
+    {
+        const string source = "moredrugs:mdma";
+        const string legacyGenerated = "moredrugs:mix/mdma/"
+            + "7b1f0cb91f2bb6ca444caa221377fcc14c1354e500f8d0b1a2b039d0f73fe78b";
+
+        Assert.True(CustomProductMixingIdentity.IsGeneratedIdForSource(
+            source,
+            legacyGenerated));
     }
 }

--- a/S1API/Internal/Products/CustomProductMixingIdentity.cs
+++ b/S1API/Internal/Products/CustomProductMixingIdentity.cs
@@ -6,6 +6,8 @@ namespace S1API.Internal.Products
     /// <summary>INTERNAL: Allocates stable IDs after the native mix-name sanitizer has run.</summary>
     internal static class CustomProductMixingIdentity
     {
+        private const string FallbackOwnerId = "s1api";
+
         internal static string CreateGeneratedProductId(
             string sourceProductId,
             string nativeMixId)
@@ -16,10 +18,15 @@ namespace S1API.Internal.Products
 
             int separator = sourceId.IndexOf(':');
             string ownerId = sourceId.Substring(0, separator);
-            string sourceName = sourceId.Substring(separator + 1);
+            // Do not embed the prior generated ID here. A generated output can itself
+            // be mixed, and retaining that full lineage adds another "/mix/..." segment
+            // on every generation until it cannot be advertised in the bounded manifest.
+            // Hashing the complete normalized source keeps distinct source products
+            // distinct when an overflowing lineage needs a bounded replacement ID.
+            string sourceHash = CustomProductManifestData.ComputeHash(sourceId);
             string nativeHash = CustomProductManifestData.ComputeHash(nativeMixId);
             return ProductKindId.Normalize(
-                ownerId + ":mix/" + sourceName + "/" + nativeHash,
+                CreateGeneratedPrefix(sourceId, ownerId, sourceHash) + nativeHash,
                 nameof(nativeMixId));
         }
 
@@ -27,9 +34,49 @@ namespace S1API.Internal.Products
         {
             string sourceId = ProductKindId.Normalize(sourceProductId, nameof(sourceProductId));
             int separator = sourceId.IndexOf(':');
-            string prefix = sourceId.Substring(0, separator) + ":mix/" +
+            string ownerId = sourceId.Substring(0, separator);
+            string boundedPrefix = CreateGeneratedPrefix(
+                sourceId,
+                ownerId,
+                CustomProductManifestData.ComputeHash(sourceId));
+            if (productId.StartsWith(boundedPrefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            // Keep already-persisted generated IDs recognizable even when a source
+            // reached the bounded source-hash form in an earlier runtime.
+            string sourceHashPrefix = CreateBoundedSourceHashPrefix(
+                ownerId,
+                CustomProductManifestData.ComputeHash(sourceId));
+            if (productId.StartsWith(sourceHashPrefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            string legacyPrefix = ownerId + ":mix/" +
                 sourceId.Substring(separator + 1) + "/";
-            return productId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+            return productId.StartsWith(legacyPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string CreateGeneratedPrefix(
+            string sourceId,
+            string ownerId,
+            string sourceHash)
+        {
+            int separator = sourceId.IndexOf(':');
+            string legacyPrefix = ownerId + ":mix/" +
+                sourceId.Substring(separator + 1) + "/";
+            return legacyPrefix.Length + 64 <=
+                   CustomProductManifestData.MaximumIdentifierLength
+                ? legacyPrefix
+                : CreateBoundedSourceHashPrefix(ownerId, sourceHash);
+        }
+
+        private static string CreateBoundedSourceHashPrefix(
+            string ownerId,
+            string sourceHash)
+        {
+            string prefix = ownerId + ":mix/" + sourceHash + "/";
+            return prefix.Length + 64 <= CustomProductManifestData.MaximumIdentifierLength
+                ? prefix
+                : FallbackOwnerId + ":mix/" + sourceHash + "/";
         }
     }
 }


### PR DESCRIPTION
## Summary

- preserve valid legacy generated mix IDs until a lineage would exceed the 256-character multiplayer manifest limit
- switch the overflowing output to a deterministic source-hash identity, with a framework-owner fallback for unusually long source namespaces
- cover the fourth mix and deeper generations, long valid source IDs, and legacy ID recognition

## Testing

- `dotnet build S1API.sln -c MonoMelon --no-restore` and `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` (417 passed)
- `dotnet build S1API.sln -c Il2CppMelon --no-restore` and focused `CustomProductMixingIdentityTests` (4 passed)
- MoreDrugs consumer builds against these S1API assemblies for Mono and Il2Cpp; MoreDrugs tests: 46 passed

## Compatibility

No public API surface changed. Existing valid generated IDs retain their prior format and remain recognized for save and registry behavior. New hashed IDs are used only where the previous ID would exceed the bounded multiplayer manifest; the fourth MoreDrugs MDMA mix is the first such case. Save and network payload shapes are unchanged.

Relates to ifBars/MoreDrugs#8.