### PR TITLE
fix(npc): restore civilian dialogue in employee fallback

### DIFF
--- a/S1API.Tests/Entities/NPCDialogueDatabasePolicyTests.cs
+++ b/S1API.Tests/Entities/NPCDialogueDatabasePolicyTests.cs
@@ -1,0 +1,18 @@
+using S1API.Internal.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NPCDialogueDatabasePolicyTests
+{
+    [Fact]
+    public void EmployeeFallbackDoesNotReuseEmployeeDialogueDatabase()
+    {
+        Assert.False(NPCDataAccess.ShouldReuseSourceDialogueDatabase(sourceIsEmployee: true));
+    }
+
+    [Fact]
+    public void NonEmployeeSourceRetainsItsDialogueDatabase()
+    {
+        Assert.True(NPCDataAccess.ShouldReuseSourceDialogueDatabase(sourceIsEmployee: false));
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -533,6 +533,7 @@ namespace S1API.Entities
                 }
 
                 RemoveEmployeeComponentsFromBaseEmployeeFallback(prefabRoot);
+                NormalizeBaseEmployeeDialogueComponents(prefabRoot, rootRole);
                 LogBaseEmployeeComponentState("after employee cleanup", prefabRoot);
                 RewireChildNpcReferences(prefabRoot, replacementNpc);
                 RepairNpcPrefabReferences(prefabRoot, replacementNpc);
@@ -819,6 +820,49 @@ namespace S1API.Entities
             catch (Exception ex)
             {
                 Logger.Warning($"[S1API] Failed to remove Employee component(s) from {BaseEmployeePrefabName} fallback prefab: {ex.Message}");
+            }
+        }
+
+        private static void NormalizeBaseEmployeeDialogueComponents(
+            GameObject prefabRoot,
+            NpcRootRole rootRole)
+        {
+            if (prefabRoot == null || rootRole != NpcRootRole.Plain)
+                return;
+
+            try
+            {
+                var employeeControllers =
+                    prefabRoot.GetComponentsInChildren<S1Dialogue.DialogueController_Employee>(true);
+                foreach (S1Dialogue.DialogueController_Employee employeeController in employeeControllers)
+                {
+                    if (employeeController == null)
+                        continue;
+
+                    GameObject controllerObject = employeeController.gameObject;
+                    var civilianController = controllerObject.GetComponent<S1Dialogue.DialogueController>();
+                    if (civilianController == null || civilianController == employeeController)
+                    {
+                        civilianController = controllerObject.AddComponent<S1Dialogue.DialogueController>();
+                        civilianController.IntObj = employeeController.IntObj;
+                        civilianController.GenericDialogue = employeeController.GenericDialogue;
+                        civilianController.DialogueEnabled = employeeController.DialogueEnabled;
+                        civilianController.UseDialogueBehaviour = employeeController.UseDialogueBehaviour;
+                        civilianController.Choices = employeeController.Choices;
+                        civilianController.GreetingOverrides = employeeController.GreetingOverrides;
+                        civilianController.OverrideContainer = employeeController.OverrideContainer;
+                    }
+
+                    RemoveComponentImmediate(employeeController);
+                    Logger.Debug(
+                        $"[S1API][BaseEmployeeFallback][Dialogue] Replaced employee dialogue controller on " +
+                        $"'{controllerObject.name}' with the base civilian controller.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"[S1API][BaseEmployeeFallback][Dialogue] Failed to normalize employee dialogue components: {ex.Message}");
             }
         }
 

--- a/S1API/Internal/Entities/NPCDataAccess.cs
+++ b/S1API/Internal/Entities/NPCDataAccess.cs
@@ -4,6 +4,7 @@ using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
 using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
 using S1Dialogue = Il2CppScheduleOne.Dialogue;
 using S1Economy = Il2CppScheduleOne.Economy;
+using S1Employees = Il2CppScheduleOne.Employees;
 using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using S1Messaging = Il2CppScheduleOne.Messaging;
 using S1NPCFramework = Il2CppScheduleOne.NPCs.Framework;
@@ -14,6 +15,7 @@ using S1AvatarFramework = ScheduleOne.AvatarFramework;
 using S1DevUtilities = ScheduleOne.DevUtilities;
 using S1Dialogue = ScheduleOne.Dialogue;
 using S1Economy = ScheduleOne.Economy;
+using S1Employees = ScheduleOne.Employees;
 using S1ItemFramework = ScheduleOne.ItemFramework;
 using S1Messaging = ScheduleOne.Messaging;
 using S1NPCFramework = ScheduleOne.NPCs.Framework;
@@ -33,6 +35,7 @@ namespace S1API.Internal.Entities
 {
     internal static class NPCDataAccess
     {
+        private static readonly Logging.Log Logger = new Logging.Log("NPCDataAccess");
 #if !IL2CPPMELON
         private static readonly FieldInfo NpcDataObjectField =
             typeof(S1NPCs.NPC).GetField("_npcData", BindingFlags.Instance | BindingFlags.NonPublic)
@@ -387,8 +390,12 @@ namespace S1API.Internal.Entities
                 return;
 
             S1NPCFramework.NPCData? sourceData = GetOriginalData(sourceNpc) ?? GetCurrentData(sourceNpc);
-            if (sourceData?.Dialogue?.DialogueDatabase != null)
+            bool sourceIsEmployee = sourceNpc is S1Employees.Employee;
+            if (ShouldReuseSourceDialogueDatabase(sourceIsEmployee)
+                && sourceData?.Dialogue?.DialogueDatabase != null)
+            {
                 data.Dialogue.DialogueDatabase = sourceData.Dialogue.DialogueDatabase;
+            }
 
             if (data.Dialogue.DialogueDatabase == null)
             {
@@ -408,7 +415,22 @@ namespace S1API.Internal.Entities
 
             if (data.Dialogue.DialogueDatabase == null)
                 throw new InvalidOperationException("No 0.4.6 dialogue database is loaded for the custom NPC.");
+
+            if (sourceIsEmployee)
+            {
+                Logger.Debug(
+                    $"[S1API][BaseEmployeeFallback][Dialogue] Rebased employee source dialogue " +
+                    $"'{sourceData?.Dialogue?.DialogueDatabase?.name ?? "<null>"}' to " +
+                    $"'{data.Dialogue.DialogueDatabase.name}' for the replacement NPC data.");
+            }
         }
+
+        /// <summary>
+        /// Determines whether a source NPC's dialogue database may be inherited by a rebuilt custom NPC.
+        /// Employee databases contain employee-only greeting and transfer content, so the BaseEmployee
+        /// fallback must instead resolve the native default database for the replacement NPC role.
+        /// </summary>
+        internal static bool ShouldReuseSourceDialogueDatabase(bool sourceIsEmployee) => !sourceIsEmployee;
 
         private static void EnsureSupplierDialogueDatabase(
             S1NPCFramework.NPCData data,


### PR DESCRIPTION
## Summary

- Rebase custom NPC data created from the `BaseEmployee` fallback onto the native default dialogue database instead of retaining employee greetings and transfer content.
- Replace inherited `DialogueController_Employee` components on plain fallback NPCs with the base controller while preserving shared controller configuration.
- Add focused policy coverage for employee versus non-employee dialogue-database inheritance.

Refs #190

## Reproduction and root cause

On IL2CPP, the current game exposes `BaseEmployee` as the fallback source for physical custom NPCs. S1API replaced the `Employee` root but `NPCDataAccess.AssignNewData` then copied the removed employee's dialogue database into the plain replacement data object. The employee-specific dialogue-controller subtype could also remain in the child component graph. Those two inherited paths retained employee dialogue such as “Hi boss.”

The local IL2CPP smoke loaded save slot 3, reached `Main`, and registered eight custom NPCs. The fixture set resolved a native civilian source on this install, so it did not enter the `BaseEmployee` branch; the PR adds namespaced fallback diagnostics for that branch rather than claiming direct in-game fallback coverage from this run.

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false ...`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 416 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false ...`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build --filter FullyQualifiedName~NPCDialogueDatabasePolicyTests` — 2 passed
- IL2CPP loaded-save smoke: `PASS|Scene=Main|Ready=True|NpcCount=8`; customer and supplier fixtures remained operational.

The full IL2CPP unit host executed its 330 tests but aborts during `Il2CppInterop` finalization because `GameAssembly` is unavailable to the test process. This is recorded as a host limitation, not a clean full-suite pass.

## Compatibility

- Public/protected API surface: unchanged.
- Source and binary compatibility: unchanged; this modifies only internal fallback normalization.
- Behavioral compatibility: non-employee source dialogue remains inherited; only `BaseEmployee`-derived plain NPCs now receive the default civilian dialogue database and base controller.
- Save/network identity and payloads: unchanged.
- Customer free-sample behavior remains on the existing `Customer` component; dealer and supplier data paths are not converted to the plain controller path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC dialogue handling when converting employee characters to civilian NPCs.
  * Prevented employee dialogue databases from being incorrectly reused.
  * Preserved dialogue configuration while applying appropriate fallback dialogue.
  * Added safeguards and logging for dialogue conversion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->