### PR TITLE
fix(npcs): restore custom residence summons

### DIFF
--- a/S1API.Tests/Entities/BuildingLookupPolicyTests.cs
+++ b/S1API.Tests/Entities/BuildingLookupPolicyTests.cs
@@ -1,0 +1,41 @@
+namespace S1API.Tests.Entities;
+
+public sealed class BuildingLookupPolicyTests
+{
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, true)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    public void TypedBuildingLookup_DefersUntilTheMapIsReady(
+        bool isMenuScene,
+        bool isMainSceneReady,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            global::S1API.Map.Building.ShouldDeferTypedLookup(isMenuScene, isMainSceneReady));
+    }
+}
+
+public sealed class CustomNpcDoorSelectionPolicyTests
+{
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void DoorSelection_OnlyExitsAnAuthoritativeCustomNpcThatIsInside(
+        bool isServer,
+        bool isCustomNpc,
+        bool isInsideBuilding,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            global::S1API.Internal.Patches.NPCPatches.ShouldExitCustomNpcAfterDoorSelection(
+                isServer,
+                isCustomNpc,
+                isInsideBuilding));
+    }
+}

--- a/S1API/Internal/Map/DeferredMapResolver.cs
+++ b/S1API/Internal/Map/DeferredMapResolver.cs
@@ -17,6 +17,8 @@ namespace S1API.Internal.Map
         private static readonly List<DeferredLookup> PendingLookups = new List<DeferredLookup>();
         private static bool MainSceneLoaded = false;
 
+        internal static bool IsMainSceneReady => MainSceneLoaded;
+
         /// <summary>
         /// Registers a deferred lookup that will be resolved when Main scene loads.
         /// </summary>

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -5,6 +5,7 @@ using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1NPCsBehaviour = Il2CppScheduleOne.NPCs.Behaviour;
 using S1NPCsActions = Il2CppScheduleOne.NPCs.Actions;
 using S1NPCsSchedules = Il2CppScheduleOne.NPCs.Schedules;
+using S1Doors = Il2CppScheduleOne.Doors;
 using S1Map = Il2CppScheduleOne.Map;
 using S1Money = Il2CppScheduleOne.Money;
 using S1Economy = Il2CppScheduleOne.Economy;
@@ -24,6 +25,7 @@ using S1NPCs = ScheduleOne.NPCs;
 using S1NPCsBehaviour = ScheduleOne.NPCs.Behaviour;
 using S1NPCsActions = ScheduleOne.NPCs.Actions;
 using S1NPCsSchedules = ScheduleOne.NPCs.Schedules;
+using S1Doors = ScheduleOne.Doors;
 using FishNet;
 using FishNet.Object;
 using ScheduleOne.DevUtilities;
@@ -90,6 +92,29 @@ namespace S1API.Internal.Patches
         private static bool SetInventoryMember(S1NPCs.NPCInventory inventory, string memberName, object? value)
         {
             return ReflectionUtils.TrySetFieldOrProperty(inventory, memberName, value);
+        }
+
+        internal static bool ShouldExitCustomNpcAfterDoorSelection(
+            bool isServer,
+            bool isCustomNpc,
+            bool isInsideBuilding) =>
+            isServer && isCustomNpc && isInsideBuilding;
+
+        [HarmonyPatch(typeof(S1Doors.StaticDoor), "NPCSelected")]
+        [HarmonyPostfix]
+        private static void StaticDoor_NPCSelected_Postfix(S1NPCs.NPC npc)
+        {
+            if (npc == null)
+                return;
+
+            bool isCustomNpc = NPC.All.Any(wrapper => wrapper != null && wrapper.S1NPC == npc);
+            var building = npc.CurrentBuilding;
+            bool isInsideBuilding = building != null;
+            if (!ShouldExitCustomNpcAfterDoorSelection(InstanceFinder.IsServer, isCustomNpc, isInsideBuilding))
+                return;
+
+            Logger.Debug($"[NPCDoorKnock] Exiting selected custom NPC '{npc.ID}' from '{building!.BuildingName}'.");
+            npc.ExitBuilding();
         }
 
         private static bool GetInventoryBool(S1NPCs.NPCInventory inventory, string memberName)

--- a/S1API/Lifecycle/GameLifecycle.cs
+++ b/S1API/Lifecycle/GameLifecycle.cs
@@ -5,6 +5,7 @@ using S1Persistence = ScheduleOne.Persistence;
 #endif
 
 using System;
+using S1API.Internal.Map;
 using UnityEngine.Events;
 
 namespace S1API.Lifecycle
@@ -193,6 +194,7 @@ namespace S1API.Lifecycle
         {
             try
             {
+                DeferredMapResolver.ResolveAll();
                 OnLoadComplete?.Invoke();
             }
             catch (Exception ex)

--- a/S1API/Map/Building.cs
+++ b/S1API/Map/Building.cs
@@ -255,8 +255,12 @@ namespace S1API.Map
             if (byTypeName != null)
                 return byTypeName;
 
-            // If still not found and we're in Menu scene, create deferred wrapper
-            if (DeferredMapResolver.IsMenuScene())
+            // NPC prefab configuration can run after Main becomes the active scene but before
+            // the map registry has finished populating. Keep typed identifiers deferred until
+            // the load-complete resolver has established that the map is ready.
+            if (ShouldDeferTypedLookup(
+                    DeferredMapResolver.IsMenuScene(),
+                    DeferredMapResolver.IsMainSceneReady))
             {
                 string deferredName = !string.IsNullOrEmpty(name) ? name : t.Name;
                 var deferredWrapper = new Building(t, deferredName);
@@ -274,6 +278,9 @@ namespace S1API.Map
 
             return null;
         }
+
+        internal static bool ShouldDeferTypedLookup(bool isMenuScene, bool isMainSceneReady) =>
+            isMenuScene || !isMainSceneReady;
 
         private static string? TryGetNameFromIdentifier(Type t)
         {


### PR DESCRIPTION
Fixes #189

## Summary
- Defer typed building references until the Main map registry is ready, then resolve them before load-complete listeners run.
- On the authoritative host, exit an S1API-owned NPC after the native residence-door selection callback when the native summon behaviour does not do so.
- Add focused policy coverage for the map-readiness and custom-door-selection guards.

## Testing
- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` (422 passed)
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- IL2CPP contract host: 337 passed before its known finalizer abort because `GameAssembly` is unavailable outside the game process.
- Installed-game smoke, Mono and IL2CPP: load a save, create the issue reproduction NPC, bind Holt House, enter it, invoke the native `StaticDoor.Knock` path and select the NPC; both runs passed with the NPC outside the building.

## Compatibility
- No public/protected surface or durable IDs changed; source and binary compatibility are unchanged.
- Save and network payload formats are unchanged. The only runtime behaviour change is the intended opt-in repair for unresolved typed map lookups during loading and selected S1API custom NPCs at a residence door.