### PR TITLE
chore(release): publish S1API 3.1.7

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.6", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.7", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.6</Version>
+        <Version>3.1.7</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- release the merged supplier persistence, bounded custom-mix identity, civilian dialogue, and residence-knock fixes as S1API 3.1.7
- update both authoritative version surfaces

## Validation

- MonoMelon solution build
- MonoMelon full suite: 434 passed
- Il2CppMelon solution build
- Il2CppMelon focused release contracts: 17 passed

## Release flow

After this PR merges, fast-forward `releases/3.1.7` to the resulting `stable` merge commit and tag that shared commit as `v3.1.7`.
