### PR TITLE
fix(npcs): preserve residence summon dwell

### DIFF
--- a/S1API.Tests/Entities/BuildingLookupPolicyTests.cs
+++ b/S1API.Tests/Entities/BuildingLookupPolicyTests.cs
@@ -18,14 +18,14 @@ public sealed class BuildingLookupPolicyTests
     }
 }
 
-public sealed class CustomNpcDoorSelectionPolicyTests
+public sealed class CustomNpcResidenceSummonPolicyTests
 {
     [Theory]
     [InlineData(true, true, true, true)]
     [InlineData(false, true, true, false)]
     [InlineData(true, false, true, false)]
     [InlineData(true, true, false, false)]
-    public void DoorSelection_OnlyExitsAnAuthoritativeCustomNpcThatIsInside(
+    public void SummonCompletion_OnlyExitsAnAuthoritativeCustomNpcThatIsInside(
         bool isServer,
         bool isCustomNpc,
         bool isInsideBuilding,
@@ -33,9 +33,45 @@ public sealed class CustomNpcDoorSelectionPolicyTests
     {
         Assert.Equal(
             expected,
-            global::S1API.Internal.Patches.NPCPatches.ShouldExitCustomNpcAfterDoorSelection(
+            global::S1API.Internal.Patches.NPCPatches.ShouldExitCustomNpcAfterSummon(
                 isServer,
                 isCustomNpc,
                 isInsideBuilding));
+    }
+
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void ResidenceReentry_IsSuppressedOnlyDuringAnAuthoritativeCustomNpcSummon(
+        bool isServer,
+        bool isCustomNpc,
+        bool isSummonBehaviourEnabled,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            global::S1API.Internal.Patches.NPCPatches.ShouldSuppressResidenceReentry(
+                isServer,
+                isCustomNpc,
+                isSummonBehaviourEnabled));
+    }
+
+    [Fact]
+    public void SummonLogicLookup_UsesGeneratedNamePrefixAndNativeSignature()
+    {
+        var method = global::S1API.Internal.Patches.NPCPatches.FindSummonLogicMethod(
+            typeof(SummonLogicFixture));
+
+        Assert.NotNull(method);
+        Assert.Equal(nameof(SummonLogicFixture.RpcLogic___Summon_123), method!.Name);
+    }
+
+    private sealed class SummonLogicFixture
+    {
+        public void RpcLogic___Summon_123(string buildingGuid, int doorIndex, float duration) { }
+
+        public void RpcLogic___Summon_456(string buildingGuid, int doorIndex) { }
     }
 }

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -145,7 +145,8 @@ namespace S1API.Internal.Patches
                 if (npc == null)
                     return;
 
-                bool isCustomNpc = NPC.All.Any(wrapper => wrapper != null && wrapper.S1NPC == npc);
+                bool isCustomNpc = NPC.All.Any(
+                    wrapper => wrapper != null && wrapper.IsCustomNPC && wrapper.S1NPC == npc);
                 var building = npc.CurrentBuilding;
                 bool isInsideBuilding = building != null;
                 if (!ShouldExitCustomNpcAfterSummon(InstanceFinder.IsServer, isCustomNpc, isInsideBuilding))
@@ -187,7 +188,8 @@ namespace S1API.Internal.Patches
             if (!isSummonBehaviourEnabled)
                 return false;
 
-            bool isCustomNpc = NPC.All.Any(wrapper => wrapper != null && wrapper.S1NPC == npc);
+            bool isCustomNpc = NPC.All.Any(
+                wrapper => wrapper != null && wrapper.IsCustomNPC && wrapper.S1NPC == npc);
             return ShouldSuppressResidenceReentry(
                 InstanceFinder.IsServer,
                 isCustomNpc,

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -5,7 +5,6 @@ using S1NPCs = Il2CppScheduleOne.NPCs;
 using S1NPCsBehaviour = Il2CppScheduleOne.NPCs.Behaviour;
 using S1NPCsActions = Il2CppScheduleOne.NPCs.Actions;
 using S1NPCsSchedules = Il2CppScheduleOne.NPCs.Schedules;
-using S1Doors = Il2CppScheduleOne.Doors;
 using S1Map = Il2CppScheduleOne.Map;
 using S1Money = Il2CppScheduleOne.Money;
 using S1Economy = Il2CppScheduleOne.Economy;
@@ -25,7 +24,6 @@ using S1NPCs = ScheduleOne.NPCs;
 using S1NPCsBehaviour = ScheduleOne.NPCs.Behaviour;
 using S1NPCsActions = ScheduleOne.NPCs.Actions;
 using S1NPCsSchedules = ScheduleOne.NPCs.Schedules;
-using S1Doors = ScheduleOne.Doors;
 using FishNet;
 using FishNet.Object;
 using ScheduleOne.DevUtilities;
@@ -66,6 +64,10 @@ namespace S1API.Internal.Patches
     {
         private static readonly Logging.Log Logger = new Logging.Log("NPCPatches");
         private static readonly HashSet<string> _loadingDealers = new HashSet<string>();
+        private static readonly FieldInfo? ScheduleActionNpcField =
+            AccessTools.Field(typeof(S1NPCsSchedules.NPCAction), "npc");
+        private static readonly PropertyInfo? ScheduleActionNpcProperty =
+            AccessTools.Property(typeof(S1NPCsSchedules.NPCAction), "npc");
         private const float DefaultRelationDelta = 2f;
         public static bool CustomNpcsReady = false;
         // Pending custom NPC types to instantiate when using consolidated NPCs.json saves (non-physical/custom contacts).
@@ -94,27 +96,102 @@ namespace S1API.Internal.Patches
             return ReflectionUtils.TrySetFieldOrProperty(inventory, memberName, value);
         }
 
-        internal static bool ShouldExitCustomNpcAfterDoorSelection(
+        internal static bool ShouldExitCustomNpcAfterSummon(
             bool isServer,
             bool isCustomNpc,
             bool isInsideBuilding) =>
             isServer && isCustomNpc && isInsideBuilding;
 
-        [HarmonyPatch(typeof(S1Doors.StaticDoor), "NPCSelected")]
-        [HarmonyPostfix]
-        private static void StaticDoor_NPCSelected_Postfix(S1NPCs.NPC npc)
+        internal static bool ShouldSuppressResidenceReentry(
+            bool isServer,
+            bool isCustomNpc,
+            bool isSummonBehaviourEnabled) =>
+            isServer && isCustomNpc && isSummonBehaviourEnabled;
+
+        internal static MethodBase? FindSummonLogicMethod(Type behaviourType)
         {
+            return behaviourType
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .FirstOrDefault(method =>
+                {
+                    if (!method.Name.StartsWith("RpcLogic___Summon_", StringComparison.Ordinal))
+                        return false;
+
+                    ParameterInfo[] parameters = method.GetParameters();
+                    return method.ReturnType == typeof(void)
+                        && parameters.Length == 3
+                        && parameters[0].ParameterType == typeof(string)
+                        && parameters[1].ParameterType == typeof(int)
+                        && parameters[2].ParameterType == typeof(float);
+                });
+        }
+
+        internal static S1NPCs.NPC? GetScheduleActionNpc(S1NPCsSchedules.NPCAction action)
+        {
+            return ScheduleActionNpcField?.GetValue(action) as S1NPCs.NPC
+                ?? ScheduleActionNpcProperty?.GetValue(action) as S1NPCs.NPC;
+        }
+
+        [HarmonyPatch]
+        private static class NpcBehaviourSummonLogicPatch
+        {
+            private static MethodBase? TargetMethod() =>
+                FindSummonLogicMethod(typeof(S1NPCsBehaviour.NPCBehaviour));
+
+            [HarmonyPostfix]
+            private static void Postfix(S1NPCsBehaviour.NPCBehaviour __instance)
+            {
+                S1NPCs.NPC? npc = __instance?.Npc;
+                if (npc == null)
+                    return;
+
+                bool isCustomNpc = NPC.All.Any(wrapper => wrapper != null && wrapper.S1NPC == npc);
+                var building = npc.CurrentBuilding;
+                bool isInsideBuilding = building != null;
+                if (!ShouldExitCustomNpcAfterSummon(InstanceFinder.IsServer, isCustomNpc, isInsideBuilding))
+                    return;
+
+                Logger.Debug(
+                    $"[NPCDoorKnock] Exiting summoned custom NPC '{npc.ID}' from " +
+                    $"'{building!.BuildingName}' after native summon behaviour activation.");
+                npc.ExitBuilding();
+            }
+        }
+
+        [HarmonyPatch(typeof(S1NPCsSchedules.NPCEvent_StayInBuilding), nameof(S1NPCsSchedules.NPCEvent_StayInBuilding.OnActiveTick))]
+        [HarmonyPrefix]
+        private static bool StayInBuilding_OnActiveTick_Prefix(
+            S1NPCsSchedules.NPCEvent_StayInBuilding __instance)
+        {
+            // Prevent the residence action from scheduling a new entrance during native summon dwell.
+            return !IsCustomNpcSummonedDuringResidence(__instance);
+        }
+
+        [HarmonyPatch(typeof(S1NPCsSchedules.NPCEvent_StayInBuilding), "PlayEnterAnimation")]
+        [HarmonyPrefix]
+        private static bool StayInBuilding_PlayEnterAnimation_Prefix(
+            S1NPCsSchedules.NPCEvent_StayInBuilding __instance)
+        {
+            // Guard callbacks already queued before the NPC was summoned out of the building.
+            return !IsCustomNpcSummonedDuringResidence(__instance);
+        }
+
+        private static bool IsCustomNpcSummonedDuringResidence(
+            S1NPCsSchedules.NPCEvent_StayInBuilding action)
+        {
+            var npc = GetScheduleActionNpc(action);
             if (npc == null)
-                return;
+                return false;
+
+            bool isSummonBehaviourEnabled = npc.Behaviour?.SummonBehaviour?.Enabled == true;
+            if (!isSummonBehaviourEnabled)
+                return false;
 
             bool isCustomNpc = NPC.All.Any(wrapper => wrapper != null && wrapper.S1NPC == npc);
-            var building = npc.CurrentBuilding;
-            bool isInsideBuilding = building != null;
-            if (!ShouldExitCustomNpcAfterDoorSelection(InstanceFinder.IsServer, isCustomNpc, isInsideBuilding))
-                return;
-
-            Logger.Debug($"[NPCDoorKnock] Exiting selected custom NPC '{npc.ID}' from '{building!.BuildingName}'.");
-            npc.ExitBuilding();
+            return ShouldSuppressResidenceReentry(
+                InstanceFinder.IsServer,
+                isCustomNpc,
+                isSummonBehaviourEnabled);
         }
 
         private static bool GetInventoryBool(S1NPCs.NPCInventory inventory, string memberName)


### PR DESCRIPTION
## Summary
- move custom NPC exit handling to the authoritative native summon RPC logic, after summon behavior is active
- suspend `StayInBuilding` re-entry ticks and already-queued entrance callbacks only while that native summon is active
- preserve vanilla NPC behavior and normal custom NPC residence schedules outside the summon window

Fixes #189

## Reproduction and verification

Loaded save slot 3 with `example_physical_npc1` actively scheduled inside North Apartments, then invoked the real static-door NPC selection path.

| Runtime | S1API 3.1.7 baseline | This fix |
| --- | --- | --- |
| Mono | Re-entered after 0.96s | Stayed outside 6.50s with native summon enabled/active |
| IL2CPP | Re-entered after 1.01s | Stayed outside 6.50s with native summon enabled/active |

Automated validation:
- Mono focused policy suite: 9/9 passed
- IL2CPP focused policy suite: 9/9 passed
- Mono full suite: 439/439 passed
- IL2CPP full host: 352 tests passed before the existing `Il2CppObjectBase` finalizer aborted because `GameAssembly` is unavailable to the .NET test host; the real IL2CPP loaded-save smoke passed
- Mono and IL2CPP builds: succeeded with 0 warnings and 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Custom NPCs summoned inside buildings now properly complete their summon behavior and exit when appropriate.
  - Prevented summoned custom NPCs from immediately re-entering or playing conflicting residence behaviors during the summon sequence.
  - Improved compatibility across supported game versions when detecting summon behavior and NPC schedule information.
- **Tests**
  - Added coverage for summon completion, residence reentry suppression, and summon behavior compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->