### PR TITLE
fix(npc): discard employee dialogue overrides

### DIFF
--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -848,9 +848,10 @@ namespace S1API.Entities
                         civilianController.GenericDialogue = employeeController.GenericDialogue;
                         civilianController.DialogueEnabled = employeeController.DialogueEnabled;
                         civilianController.UseDialogueBehaviour = employeeController.UseDialogueBehaviour;
-                        civilianController.Choices = employeeController.Choices;
-                        civilianController.GreetingOverrides = employeeController.GreetingOverrides;
-                        civilianController.OverrideContainer = employeeController.OverrideContainer;
+                        // Customer and other runtime components rebuild their own role-specific dialogue state.
+                        civilianController.Choices = new List<S1Dialogue.DialogueController.DialogueChoice>();
+                        civilianController.GreetingOverrides = new List<S1Dialogue.DialogueController.GreetingOverride>();
+                        civilianController.OverrideContainer = null;
                     }
 
                     RemoveComponentImmediate(employeeController);


### PR DESCRIPTION
## Summary
- keep BaseEmployee's shared interaction and generic-dialogue references when constructing a plain custom NPC
- discard the source employee's role-specific choices, greeting overrides, and conversation override
- allow `Customer.SetUpDialogue` and other runtime components to rebuild only the state appropriate to the custom NPC's configured roles

Fixes #190

## Root cause

S1API 3.1.7 replaced `DialogueController_Employee` and selected a civilian dialogue database, but copied the employee controller's serialized `GreetingOverrides`. `DialogueController.GetActiveGreeting` evaluates those overrides before the database, so the inherited active `Hi boss` entry still won during the free-sample interaction.

## Loaded-save verification

The probe used `example_physical_npc2`, confirmed the native free-sample choice was present, and invoked the same active-greeting selection used by the interaction controller.

| Runtime | S1API 3.1.7 | This fix |
| --- | --- | --- |
| Mono | `Hi boss`; 3 overrides; employee override active | `Good morning`; 2 customer overrides; none active |
| IL2CPP | `Hi boss`; 3 overrides; employee override active | `Good morning`; 2 customer overrides; none active |

In both fixed runs, the controller remained the base civilian controller, `AlbertDialogueDatabase` remained assigned, and `Can I interest you in a free sample?` remained available.

## Automated validation

- Mono focused dialogue policy tests: 2/2 passed
- IL2CPP focused dialogue policy tests: 2/2 passed
- Mono full suite: 434/434 passed
- IL2CPP full host: 347 tests passed before the existing `Il2CppObjectBase` finalizer aborted because `GameAssembly` is unavailable to the .NET test host; the real IL2CPP loaded-save smoke passed
- Mono and IL2CPP builds: succeeded with 0 warnings and 0 errors