### PR TITLE
chore(release): prepare S1API 3.1.8

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.7", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.8", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.7</Version>
+        <Version>3.1.8</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

Prepare S1API 3.1.8 from the combined `stable` fixes for #189 and #190.

## Included fixes

- custom NPCs summoned through residence doors now remain outside for the native summon dwell window instead of immediately re-entering
- custom customer NPCs created from the `BaseEmployee` fallback no longer inherit the active employee `Hi boss` greeting or other role-specific dialogue state
- summon handling is restricted to wrappers marked `IsCustomNPC`, preserving vanilla NPC behavior

## Versioning

- project/package version: `3.1.8`
- MelonInfo version: `3.1.8`
- release branch: `releases/3.1.8`

## Validation

- Mono full suite: 439/439 passed
- IL2CPP focused regression suite: 11/11 passed
- Mono and IL2CPP builds succeeded with 0 warnings and 0 errors
- package outputs were generated as `S1API.Forked.3.1.8.nupkg` for both configurations
- prior loaded-save verification passed for both fixes on Mono and IL2CPP; #189 also received manual user confirmation