### PR TITLE
fix(npc): report invalid mod configuration

### DIFF
--- a/S1API.Tests/Entities/NPCDiagnosticCompatibilityTests.cs
+++ b/S1API.Tests/Entities/NPCDiagnosticCompatibilityTests.cs
@@ -6,6 +6,9 @@ namespace S1API.Tests.Entities;
 
 public sealed class NPCDiagnosticCompatibilityTests
 {
+    private const string RegistrationObsoleteMessage =
+        "S1API automatically pre-registers NPC prefabs. Remove this call.";
+
     [Theory]
     [InlineData("PreRegisterAllNpcPrefabs")]
     [InlineData("PreRegisterPrefabForType")]
@@ -16,6 +19,9 @@ public sealed class NPCDiagnosticCompatibilityTests
         Assert.NotNull(method);
         Assert.True(method.IsStatic);
         Assert.Equal(typeof(void), method.ReturnType);
+        ObsoleteAttribute obsolete = Assert.Single(method.GetCustomAttributes<ObsoleteAttribute>());
+        Assert.Equal(RegistrationObsoleteMessage, obsolete.Message);
+        Assert.False(obsolete.IsError);
 
         ParameterInfo[] parameters = method.GetParameters();
         if (methodName == "PreRegisterAllNpcPrefabs")

--- a/S1API.Tests/Entities/NPCDiagnosticCompatibilityTests.cs
+++ b/S1API.Tests/Entities/NPCDiagnosticCompatibilityTests.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using S1API.Entities;
+using S1API.Entities.Dealer;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NPCDiagnosticCompatibilityTests
+{
+    [Theory]
+    [InlineData("PreRegisterAllNpcPrefabs")]
+    [InlineData("PreRegisterPrefabForType")]
+    public void ManualPrefabRegistrationApisRetainTheirPublicShape(string methodName)
+    {
+        MethodInfo? method = typeof(NPC).GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.True(method.IsStatic);
+        Assert.Equal(typeof(void), method.ReturnType);
+
+        ParameterInfo[] parameters = method.GetParameters();
+        if (methodName == "PreRegisterAllNpcPrefabs")
+        {
+            Assert.Empty(parameters);
+        }
+        else
+        {
+            ParameterInfo parameter = Assert.Single(parameters);
+            Assert.Equal("npcType", parameter.Name);
+            Assert.Equal(typeof(Type), parameter.ParameterType);
+        }
+    }
+
+    [Fact]
+    public void DealerDefaultsDoNotReportUnsupportedOptionsWhenTheyWereOmitted()
+    {
+        var data = new DealerDataBuilder().BuildInternal();
+
+        Assert.False(data.InsufficientQualityConfigured);
+        Assert.False(data.ExcessQualityConfigured);
+        Assert.False(data.CompletedDealsVariableConfigured);
+    }
+
+    [Fact]
+    public void DealerDefaultsRememberEveryExplicitUnsupportedOption()
+    {
+        var data = new DealerDataBuilder()
+            .AllowInsufficientQuality(false)
+            .AllowExcessQuality(true)
+            .WithCompletedDealsVariable(null!)
+            .BuildInternal();
+
+        Assert.True(data.InsufficientQualityConfigured);
+        Assert.True(data.ExcessQualityConfigured);
+        Assert.True(data.CompletedDealsVariableConfigured);
+        Assert.Equal(string.Empty, data.CompletedDealsVariable);
+    }
+}

--- a/S1API/Entities/Dealer/DealerDataBuilder.cs
+++ b/S1API/Entities/Dealer/DealerDataBuilder.cs
@@ -28,6 +28,9 @@ namespace S1API.Entities.Dealer
             public bool SellInsufficientQualityItems { get; set; } = false;
             public bool SellExcessQualityItems { get; set; } = true;
             public string CompletedDealsVariable { get; set; } = string.Empty;
+            public bool InsufficientQualityConfigured { get; set; }
+            public bool ExcessQualityConfigured { get; set; }
+            public bool CompletedDealsVariableConfigured { get; set; }
             public List<DealerRecommendationBuilder.RecommendationConfigData> Recommendations { get; } =
                 new List<DealerRecommendationBuilder.RecommendationConfigData>();
         }
@@ -96,6 +99,7 @@ namespace S1API.Entities.Dealer
         public DealerDataBuilder AllowInsufficientQuality(bool allow)
         {
             _data.SellInsufficientQualityItems = allow;
+            _data.InsufficientQualityConfigured = true;
             return this;
         }
 
@@ -105,6 +109,7 @@ namespace S1API.Entities.Dealer
         public DealerDataBuilder AllowExcessQuality(bool allow)
         {
             _data.SellExcessQualityItems = allow;
+            _data.ExcessQualityConfigured = true;
             return this;
         }
 
@@ -114,6 +119,7 @@ namespace S1API.Entities.Dealer
         public DealerDataBuilder WithCompletedDealsVariable(string varName)
         {
             _data.CompletedDealsVariable = varName ?? string.Empty;
+            _data.CompletedDealsVariableConfigured = true;
             return this;
         }
 

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -1469,6 +1469,8 @@ namespace S1API.Entities
         /// Compatibility shim for manually pre-registering a per-type NPC prefab.
         /// </summary>
         /// <remarks>S1API owns prefab registration and retry timing. Mods should not call this method.</remarks>
+        /// <param name="npcType">The custom NPC type whose prefab S1API will pre-register.</param>
+        [Obsolete("S1API automatically pre-registers NPC prefabs. Remove this call.", false)]
         public static void PreRegisterPrefabForType(System.Type npcType)
         {
             if (!_loggedExternalPreRegisterTypeCall)
@@ -1504,6 +1506,7 @@ namespace S1API.Entities
         /// Compatibility shim for manually scanning and pre-registering NPC prefabs.
         /// </summary>
         /// <remarks>S1API owns prefab registration and retry timing. Mods should not call this method.</remarks>
+        [Obsolete("S1API automatically pre-registers NPC prefabs. Remove this call.", false)]
         public static void PreRegisterAllNpcPrefabs()
         {
             if (!_loggedExternalPreRegisterAllCall)

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -185,6 +185,10 @@ namespace S1API.Entities
         };
         private static volatile bool _prefabsConfiguredForLocalProcess;
         private static bool _loggedBaseEmployeeNormalization;
+        private static bool _loggedExternalPreRegisterAllCall;
+        private static bool _loggedExternalPreRegisterTypeCall;
+        private static readonly System.Collections.Generic.HashSet<string> WarnedUnsupportedDealerSettings =
+            new System.Collections.Generic.HashSet<string>(StringComparer.Ordinal);
         private static int _clientNetworkSpawnHydrationDepth;
 #if MONOMELON
         private static readonly FieldInfo BehaviourOwnerField =
@@ -1462,10 +1466,23 @@ namespace S1API.Entities
         }
 
         /// <summary>
-        /// Pre-registers a per-type NPC prefab into FishNet spawnables without creating a live instance.
-        /// Should be called on both server and client before any NPC instances are spawned.
+        /// Compatibility shim for manually pre-registering a per-type NPC prefab.
         /// </summary>
+        /// <remarks>S1API owns prefab registration and retry timing. Mods should not call this method.</remarks>
         public static void PreRegisterPrefabForType(System.Type npcType)
+        {
+            if (!_loggedExternalPreRegisterTypeCall)
+            {
+                _loggedExternalPreRegisterTypeCall = true;
+                Logger.Warning(
+                    "[S1API][NPCPrefabRegistration] A mod called the legacy NPC.PreRegisterPrefabForType API. " +
+                    "S1API already owns prefab registration and retry timing; remove this call from mod initialization.");
+            }
+
+            PreRegisterPrefabForTypeInternal(npcType);
+        }
+
+        internal static void PreRegisterPrefabForTypeInternal(System.Type npcType)
         {
             try
             {
@@ -1484,9 +1501,23 @@ namespace S1API.Entities
         }
 
         /// <summary>
-        /// Scans loaded assemblies for subclasses of S1API.Entities.NPC and pre-registers their prefabs.
+        /// Compatibility shim for manually scanning and pre-registering NPC prefabs.
         /// </summary>
+        /// <remarks>S1API owns prefab registration and retry timing. Mods should not call this method.</remarks>
         public static void PreRegisterAllNpcPrefabs()
+        {
+            if (!_loggedExternalPreRegisterAllCall)
+            {
+                _loggedExternalPreRegisterAllCall = true;
+                Logger.Warning(
+                    "[S1API][NPCPrefabRegistration] A mod called the legacy NPC.PreRegisterAllNpcPrefabs API. " +
+                    "S1API already scans and registers NPC prefabs when FishNet is ready; remove this call from mod initialization.");
+            }
+
+            PreRegisterAllNpcPrefabsInternal();
+        }
+
+        internal static void PreRegisterAllNpcPrefabsInternal()
         {
             try
             {
@@ -1524,7 +1555,7 @@ namespace S1API.Entities
                              candidate => candidate.FullName,
                              StringComparer.Ordinal))
                 {
-                    PreRegisterPrefabForType(type);
+                    PreRegisterPrefabForTypeInternal(type);
                 }
 
                 SupplierRuntimeCoordinator.EnsureAllDeliveryPrefabsRegistered();
@@ -1718,13 +1749,69 @@ namespace S1API.Entities
             {
                 var builder = new DealerDataBuilder();
                 configure(builder);
-                TypeToBuiltDealerDefaults[npcType] = builder.BuildInternal();
+                var built = builder.BuildInternal();
+                TypeToBuiltDealerDefaults[npcType] = built;
+                WarnForUnsupportedDealerSettings(DescribeNpcTypeOwner(npcType), built);
             }
             catch (Exception ex)
             {
                 TypeToBuiltDealerDefaults.Remove(npcType);
                 Logger.Warning($"[S1API] Failed to cache dealer defaults for '{npcType.Name}': {ex.Message}");
             }
+        }
+
+        private static void WarnForUnsupportedDealerSettings(
+            string dealerOwner,
+            DealerDataBuilder.DealerConfigData data)
+        {
+            if (data.InsufficientQualityConfigured || data.ExcessQualityConfigured)
+            {
+                var configuredOptions = new System.Collections.Generic.List<string>();
+                if (data.InsufficientQualityConfigured)
+                    configuredOptions.Add("AllowInsufficientQuality");
+                if (data.ExcessQualityConfigured)
+                    configuredOptions.Add("AllowExcessQuality");
+
+                WarnUnsupportedDealerSettingOnce(
+                    dealerOwner,
+                    "quality",
+                    $"{string.Join(" and ", configuredOptions)} cannot be applied because the native dealer quality fields were removed. " +
+                    "Remove these calls; S1API has preserved them as compatibility no-ops.");
+            }
+
+            if (data.CompletedDealsVariableConfigured)
+            {
+                WarnUnsupportedDealerSettingOnce(
+                    dealerOwner,
+                    "completed-deals-variable",
+                    $"WithCompletedDealsVariable('{data.CompletedDealsVariable}') is not supported for custom dealers and is not applied. " +
+                    "Remove this call or track completed deals in the mod's own save data.");
+            }
+        }
+
+        private static void WarnUnsupportedDealerSettingOnce(
+            string dealerOwner,
+            string settingKey,
+            string guidance)
+        {
+            string normalizedOwner = string.IsNullOrWhiteSpace(dealerOwner)
+                ? "<unknown-dealer>"
+                : dealerOwner;
+            string warningKey = normalizedOwner + "|" + settingKey;
+            lock (WarnedUnsupportedDealerSettings)
+            {
+                if (!WarnedUnsupportedDealerSettings.Add(warningKey))
+                    return;
+            }
+
+            Logger.Warning($"[S1API][DealerConfiguration] Dealer '{normalizedOwner}': {guidance}");
+        }
+
+        private static string DescribeNpcTypeOwner(System.Type npcType)
+        {
+            string typeName = npcType.FullName ?? npcType.Name;
+            string assemblyName = npcType.Assembly.GetName().Name ?? "<unknown-assembly>";
+            return $"{typeName} (assembly={assemblyName})";
         }
 
         internal static void RegisterDealerType(System.Type npcType)

--- a/S1API/Entities/NPCPrefabBuilder.cs
+++ b/S1API/Entities/NPCPrefabBuilder.cs
@@ -247,9 +247,13 @@ namespace S1API.Entities
                 // Apply settings directly to Avatar component on prefab to prevent destruction issues
                 ApplyAvatarSettingsToPrefab(settings);
             }
-            catch
+            catch (Exception ex)
             {
-                // ignored
+                string ownerName = ownerType?.FullName ?? "<unknown-NPC-type>";
+                string assemblyName = ownerType?.Assembly.GetName().Name ?? "<unknown-assembly>";
+                Logger.Warning(
+                    $"[S1API][NPCAppearanceConfiguration] Failed to configure appearance defaults for " +
+                    $"'{ownerName}' from assembly '{assemblyName}': {ex.GetType().Name}: {ex.Message}");
             }
 
             return this;

--- a/S1API/Internal/Entities/NPCNetworkBootstrap.cs
+++ b/S1API/Internal/Entities/NPCNetworkBootstrap.cs
@@ -131,7 +131,7 @@ namespace S1API.Internal.Entities
                 var spawnables = nm?.SpawnablePrefabs;
                 if (spawnables != null)
                 {
-                    NPC.PreRegisterAllNpcPrefabs();
+                    NPC.PreRegisterAllNpcPrefabsInternal();
                     if (!AllNetworkPrefabsReady)
                         EnsurePrefabsWarmup();
                 }
@@ -169,7 +169,7 @@ namespace S1API.Internal.Entities
                 {
                     try
                     {
-                        NPC.PreRegisterAllNpcPrefabs();
+                        NPC.PreRegisterAllNpcPrefabsInternal();
                         if (AllNetworkPrefabsReady)
                             break;
                     }

--- a/S1API/Internal/Patches/AvatarAccessoryPatches.cs
+++ b/S1API/Internal/Patches/AvatarAccessoryPatches.cs
@@ -37,7 +37,7 @@ namespace S1API.Internal.Patches
                     BindingFlags.Public | BindingFlags.Instance);
             }
 
-            static void Prefix(
+            private static void Prefix(
                 S1AvatarFramework.Avatar __instance,
                 S1AvatarFramework.AvatarSettings __0)
             {

--- a/S1API/Internal/Patches/AvatarAccessoryPatches.cs
+++ b/S1API/Internal/Patches/AvatarAccessoryPatches.cs
@@ -5,6 +5,7 @@ using S1AvatarFramework = ScheduleOne.AvatarFramework;
 #endif
 
 using HarmonyLib;
+using S1API.Internal.Rendering;
 using S1API.Internal.Utils;
 using S1API.Logging;
 using S1API.Rendering;
@@ -34,6 +35,13 @@ namespace S1API.Internal.Patches
             {
                 return typeof(S1AvatarFramework.Avatar).GetMethod("ApplyAccessorySettings",
                     BindingFlags.Public | BindingFlags.Instance);
+            }
+
+            static void Prefix(
+                S1AvatarFramework.Avatar __instance,
+                S1AvatarFramework.AvatarSettings __0)
+            {
+                AvatarAccessoryDiagnostics.Validate(__instance, __0);
             }
 
             static void Postfix(S1AvatarFramework.Avatar __instance)

--- a/S1API/Internal/Rendering/AvatarAccessoryDiagnostics.cs
+++ b/S1API/Internal/Rendering/AvatarAccessoryDiagnostics.cs
@@ -1,0 +1,143 @@
+#if (IL2CPPMELON)
+using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
+using S1NPCs = Il2CppScheduleOne.NPCs;
+#elif MONOMELON
+using S1AvatarFramework = ScheduleOne.AvatarFramework;
+using S1NPCs = ScheduleOne.NPCs;
+#endif
+
+using System;
+using System.Collections.Generic;
+using S1API.Internal.Utils;
+using S1API.Logging;
+using UnityEngine;
+
+namespace S1API.Internal.Rendering
+{
+    internal static class AvatarAccessoryDiagnostics
+    {
+        private const int NativeAccessorySlotCount = 9;
+        private static readonly Log Logger = new Log("AvatarAccessoryDiagnostics");
+        private static readonly HashSet<string> WarnedInvalidResources =
+            new HashSet<string>(StringComparer.Ordinal);
+
+        internal static void Validate(
+            S1AvatarFramework.Avatar avatar,
+            S1AvatarFramework.AvatarSettings settings)
+        {
+            try
+            {
+                ValidateCore(avatar, settings);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(
+                    $"[S1API][AvatarAccessoryValidation] Could not validate accessory settings for " +
+                    $"avatar '{DescribeAvatar(avatar)}': {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        private static void ValidateCore(
+            S1AvatarFramework.Avatar avatar,
+            S1AvatarFramework.AvatarSettings settings)
+        {
+            if (settings?.AccessorySettings == null)
+                return;
+
+            int count = Math.Min(settings.AccessorySettings.Count, NativeAccessorySlotCount);
+            for (int index = 0; index < count; index++)
+            {
+                var accessorySetting = settings.AccessorySettings[index];
+                string? path = accessorySetting?.path;
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                // Match the native ApplyAccessorySettings lookup exactly. This also honors assets
+                // registered through RuntimeResourceRegistry/AccessoryFactory at runtime.
+                UnityEngine.Object? resource = Resources.Load(path);
+                if (resource == null)
+                {
+                    WarnInvalidAccessoryOnce(
+                        avatar,
+                        index,
+                        path,
+                        "Resources.Load returned null at runtime");
+                    continue;
+                }
+
+                GameObject? accessoryObject = resource as GameObject;
+                if (accessoryObject == null)
+                {
+                    WarnInvalidAccessoryOnce(
+                        avatar,
+                        index,
+                        path,
+                        $"Resources.Load returned {resource.GetType().FullName}, not a GameObject");
+                    continue;
+                }
+
+                if (accessoryObject.GetComponent<S1AvatarFramework.Accessory>() == null)
+                {
+                    WarnInvalidAccessoryOnce(
+                        avatar,
+                        index,
+                        path,
+                        $"the loaded GameObject '{accessoryObject.name}' has no AvatarFramework.Accessory component");
+                }
+            }
+        }
+
+        private static void WarnInvalidAccessoryOnce(
+            S1AvatarFramework.Avatar avatar,
+            int index,
+            string path,
+            string reason)
+        {
+            string avatarDescription = DescribeAvatar(avatar);
+            string warningKey = avatarDescription + "|" + index + "|" + path + "|" + reason;
+            lock (WarnedInvalidResources)
+            {
+                if (!WarnedInvalidResources.Add(warningKey))
+                    return;
+            }
+
+            Logger.Warning(
+                $"[S1API][AvatarAccessoryValidation] Avatar '{avatarDescription}' has an invalid accessory " +
+                $"at index {index}: path='{path}'; {reason}. Correct or remove the accessory path in " +
+                "WithAppearanceDefaults/AddAccessory, or register the custom accessory with " +
+                "AccessoryFactory before the appearance is applied. S1API left the settings unchanged; " +
+                "the native ApplyAccessorySettings call may throw.");
+        }
+
+        private static string DescribeAvatar(S1AvatarFramework.Avatar? avatar)
+        {
+            if (avatar == null)
+                return "<null-avatar>";
+
+            try
+            {
+                var npc = avatar.GetComponentInParent<S1NPCs.NPC>(true);
+                if (npc != null)
+                {
+                    string id = string.IsNullOrWhiteSpace(npc.ID) ? "<unknown-id>" : npc.ID;
+                    string? name = ReflectionUtils.TryGetFieldOrProperty(npc, "fullName") as string;
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        string? firstName = ReflectionUtils.TryGetFieldOrProperty(npc, "FirstName") as string;
+                        string? lastName = ReflectionUtils.TryGetFieldOrProperty(npc, "LastName") as string;
+                        name = $"{firstName} {lastName}".Trim();
+                    }
+                    if (string.IsNullOrWhiteSpace(name))
+                        name = npc.name;
+                    return $"{name} (ID={id})";
+                }
+            }
+            catch
+            {
+                // Fall back to the avatar object name below.
+            }
+
+            return avatar.gameObject?.name ?? avatar.name ?? "<unknown-avatar>";
+        }
+    }
+}

--- a/S1API/Internal/Rendering/AvatarAccessoryDiagnostics.cs
+++ b/S1API/Internal/Rendering/AvatarAccessoryDiagnostics.cs
@@ -1,9 +1,9 @@
-#if (IL2CPPMELON)
-using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
-using S1NPCs = Il2CppScheduleOne.NPCs;
-#elif MONOMELON
+#if MONOMELON
 using S1AvatarFramework = ScheduleOne.AvatarFramework;
 using S1NPCs = ScheduleOne.NPCs;
+#elif IL2CPPMELON
+using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
+using S1NPCs = Il2CppScheduleOne.NPCs;
 #endif
 
 using System;


### PR DESCRIPTION
## Summary

- formally deprecate manual NPC prefab pre-registration with non-error `Obsolete` guidance while routing S1API-owned registration through internal entry points
- validate accessory paths immediately before native `ApplyAccessorySettings` using the live `Resources.Load` path, including assets registered through `RuntimeResourceRegistry` and `AccessoryFactory`
- report NPC/type/assembly context when appearance-default configuration fails instead of silently swallowing the exception
- warn once per custom dealer when removed quality options or unsupported completed-deals tracking are explicitly configured

## Compatibility

- Source compatibility: existing method names, parameters, and return types remain available; callers of `PreRegisterAllNpcPrefabs` or `PreRegisterPrefabForType` now receive a non-error obsolete warning directing them to remove the redundant call
- Binary compatibility: unchanged; ApiCompat passes against the shipped v3.1.8 Mono assembly with attribute and parameter-name checks enabled
- Behavioral compatibility: unchanged except for new deduplicated warnings; registration shims still forward to the same implementation, invalid avatar settings are not mutated, and unsupported dealer options remain no-ops
- Save compatibility: unchanged
- Network compatibility: unchanged; no payloads, IDs, prefab names, or registration ordering were changed

Migration: remove manual calls to `NPC.PreRegisterAllNpcPrefabs()` and `NPC.PreRegisterPrefabForType(...)`. S1API automatically performs and retries registration when FishNet is ready.

Focused tests cover the legacy registration signatures and formal deprecation contract plus omitted and explicitly configured dealer options.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` (443 passed)
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build --filter FullyQualifiedName~NPCDiagnosticCompatibilityTests` (4 passed)
- full IL2CPP test run reached 331 passes before the desktop test host aborted because native `GameAssembly` is unavailable outside the game process
- DocFX build succeeded (4 existing unresolved-reference warnings)
- public API documentation coverage: 80.70%
- Microsoft ApiCompat 10.0.302: no breaking changes against v3.1.8, including the formal deprecation attributes

## Notes

Accessory validation deliberately uses the same live untyped resource lookup as the native game. Custom accessories registered before appearance application are accepted, while invalid settings are logged and left unchanged so existing exception behavior is preserved.