### PR TITLE
Let mods list the commands registered through S1API

### DIFF
--- a/S1API/Console/ConsoleHelper.cs
+++ b/S1API/Console/ConsoleHelper.cs
@@ -23,6 +23,17 @@ namespace S1API.Console
         private static bool _setPlayerEnergyUnavailableWarningLogged;
 
         /// <summary>
+        /// Every command registered through <see cref="BaseConsoleCommand"/>, keyed by its command word.
+        ///
+        /// These are routed from a prefix on SubmitCommand rather than added to the game's own command list, which
+        /// is what keeps one source compiling for Mono and IL2CPP. The side effect is that they are invisible to
+        /// anything reading <c>Console.Commands</c>: they run when typed, and a mod that lists, completes or
+        /// documents commands cannot tell they exist. This is that list.
+        /// </summary>
+        public static System.Collections.Generic.IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands
+            => CustomConsoleRegistry.RegisteredCommands;
+
+        /// <summary>
         /// Submits a raw console command string (e.g. "settime 1530").
         /// Works across both IL2CPP and Mono builds.
         /// </summary>

--- a/S1API/Console/ConsoleHelper.cs
+++ b/S1API/Console/ConsoleHelper.cs
@@ -23,12 +23,8 @@ namespace S1API.Console
         private static bool _setPlayerEnergyUnavailableWarningLogged;
 
         /// <summary>
-        /// Every command registered through <see cref="BaseConsoleCommand"/>, keyed by its command word.
-        ///
-        /// These are routed from a prefix on SubmitCommand rather than added to the game's own command list, which
-        /// is what keeps one source compiling for Mono and IL2CPP. The side effect is that they are invisible to
-        /// anything reading <c>Console.Commands</c>: they run when typed, and a mod that lists, completes or
-        /// documents commands cannot tell they exist. This is that list.
+        /// The custom commands registered through <see cref="BaseConsoleCommand"/>, keyed by command word.
+        /// They are routed by patches instead of the game's command list, so this is the only way to enumerate them.
         /// </summary>
         public static System.Collections.Generic.IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands
             => CustomConsoleRegistry.RegisteredCommands;

--- a/S1API/Console/CustomConsoleRegistry.cs
+++ b/S1API/Console/CustomConsoleRegistry.cs
@@ -14,9 +14,7 @@ namespace S1API.Console
 
         private static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
 
-        // Wrapped once, not handed out raw: IReadOnlyDictionary<,> on a Dictionary<,> can be cast straight back to
-        // IDictionary<,>, so a caller could add or drop another mod's commands. ReadOnlyDictionary is a live view of
-        // the same storage, so registrations that happen later still show up.
+        // Live view of the same storage; blocks the cast back to IDictionary<,>
         private static readonly ReadOnlyDictionary<string, BaseConsoleCommand> readOnlyRegistry =
             new ReadOnlyDictionary<string, BaseConsoleCommand>(registry);
 

--- a/S1API/Console/CustomConsoleRegistry.cs
+++ b/S1API/Console/CustomConsoleRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace S1API.Console
 {
@@ -13,7 +14,13 @@ namespace S1API.Console
 
         private static readonly Dictionary<string, BaseConsoleCommand> registry = new Dictionary<string, BaseConsoleCommand>(StringComparer.OrdinalIgnoreCase);
 
-        internal static IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands => registry;
+        // Wrapped once, not handed out raw: IReadOnlyDictionary<,> on a Dictionary<,> can be cast straight back to
+        // IDictionary<,>, so a caller could add or drop another mod's commands. ReadOnlyDictionary is a live view of
+        // the same storage, so registrations that happen later still show up.
+        private static readonly ReadOnlyDictionary<string, BaseConsoleCommand> readOnlyRegistry =
+            new ReadOnlyDictionary<string, BaseConsoleCommand>(registry);
+
+        internal static IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands => readOnlyRegistry;
 
         internal static void Register(BaseConsoleCommand command)
         {


### PR DESCRIPTION
Small one: right now a mod can't find out which commands were registered through S1API.

`BaseConsoleCommand` registrations get routed from the SubmitCommand prefix instead of going into the game's own command list, which is what keeps the same source compiling for Mono and IL2CPP. Side effect is that nothing reading `Console.Commands` can tell they exist. They run fine when you type them, but a mod that wants to list them, or complete them while you type, has no way to learn they are there.

I ran into it building an in-game terminal. The only way to show S1API commands next to the vanilla ones today is reflection into `CustomConsoleRegistry`, and that one is internal - so it quietly stops working on a rename, and every mod doing this ends up carrying the same hack.

So this is one property on `ConsoleHelper`, which is public anyway:

```csharp
public static IReadOnlyDictionary<string, BaseConsoleCommand> RegisteredCommands
    => CustomConsoleRegistry.RegisteredCommands;
```

It forwards the read-only view the registry already has. No new type, no behaviour change, nothing copied per call. Mods that register through S1API then show up in autocompletes and help overlays without doing anything themselves.

Built both configs (`Il2CppMelon` and `MonoMelon`), clean. The return type is spelled out as `System.Collections.Generic.IReadOnlyDictionary<...>` on purpose: `ConsoleHelper.cs` imports `Il2CppSystem.Collections.Generic` under `IL2CPPMELON`, so the short name would bind to the wrong namespace there.

Happy to rename it or put it somewhere else if you'd rather have it elsewhere.
