### PR TITLE
fix(npc): restore non-physical NPCs from existing saves

### DIFF
--- a/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
+++ b/S1API.Tests/Entities/NpcVisibilityPolicyTests.cs
@@ -26,14 +26,19 @@ public sealed class NpcVisibilityPolicyTests
     }
 
     [Theory]
-    [InlineData(false, true)]
-    [InlineData(true, false)]
-    public void LoadedVisibilityIsDeferredForSuppliersUntilAfterSpawn(
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public void LoadedVisibilityIsAppliedBeforeSpawnOnlyForPhysicalNonSuppliers(
+        bool isPhysical,
         bool isSupplier,
         bool expected)
     {
         Assert.Equal(
             expected,
-            NPC.ShouldApplyLoadedVisibilityBeforeSpawn(isSupplier));
+            NPC.ShouldApplyLoadedVisibilityBeforeSpawn(
+                isPhysical,
+                isSupplier));
     }
 }

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -4557,8 +4557,9 @@ namespace S1API.Entities
             isPhysical && (!isSupplier || isSupplierMeeting);
 
         internal static bool ShouldApplyLoadedVisibilityBeforeSpawn(
+            bool isPhysical,
             bool isSupplier) =>
-            !isSupplier;
+            isPhysical && !isSupplier;
 
         private IEnumerator DelayedVisibilityRPC()
         {

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -1450,10 +1450,13 @@ namespace S1API.Internal.Patches
                         }
                     }
 
-                    // SetVisible(false) deactivates the Avatar GameObject. Custom suppliers
-                    // must remain active through FishNet spawn so native NPC.Awake can find
-                    // the Avatar reference; FinalizeNetworkSpawn applies idle visibility.
-                    if (NPC.ShouldApplyLoadedVisibilityBeforeSpawn(wrap.IsSupplier))
+                    // SetVisible(false) deactivates the Avatar GameObject. Invisible NPCs and
+                    // custom suppliers must remain active through FishNet spawn so native
+                    // NPC.Awake can find the Avatar reference; FinalizeNetworkSpawn applies
+                    // their intended visibility.
+                    if (NPC.ShouldApplyLoadedVisibilityBeforeSpawn(
+                        wrap.IsPhysical,
+                        wrap.IsSupplier))
                     {
                         s1BaseNpc.SetVisible(
                             wrap.ShouldBeVisibleAfterSpawn(),


### PR DESCRIPTION
## Summary

- keep non-physical custom NPC Avatar children active through native `NPC.Awake` during existing-save restoration
- defer their intended invisible state to the existing post-spawn finalization
- cover the pre-spawn visibility policy for physical, non-physical, and supplier NPCs

Closes #203.

## Reproduction

Used the reporter-provided `Empire-S1API.dll` and a copied existing Mono save containing `tuco_salamanca` and `todd_alquist`.

Baseline S1API 3.1.7 reproduced the report:

```text
FAIL|tuco_salamanca:wrapper=True,spawned=False|todd_alquist:wrapper=True,spawned=False
Refusing to spawn custom NPC 'tuco_salamanca' ... Avatar(active)
Refusing to spawn custom NPC 'todd_alquist' ... Avatar(active)
```

With this patch:

```text
PASS|tuco_salamanca:wrapper=True,spawned=True|todd_alquist:wrapper=True,spawned=True
```

The save was copied to a disposable fixture; the installed mod set was restored afterward. No game assemblies, saves, smoke sources, logs, or generated artifacts are included.

## Testing

- MonoMelon restore/build: passed, 0 warnings
- MonoMelon full contract suite: 445/445 passed
- Il2CppMelon restore/build: passed, 0 warnings
- Il2CppMelon focused `NpcVisibilityPolicyTests`: 10/10 passed
- Il2CppMelon full contract suite: 358 tests passed before the standalone test host hit the known `GameAssembly`-unavailable finalizer abort
- Mono existing-save Empire runtime smoke: baseline failed; patched build passed for both reported NPCs
- `git diff --check`: passed

## Compatibility

- Source compatibility: unchanged; no public or protected symbols changed
- Binary compatibility: unchanged; only internal helper shape changed
- Behavioral compatibility: physical non-supplier NPCs retain the existing pre-spawn visibility application; invisible NPCs and suppliers now defer visibility until the existing finalization step
- Save compatibility: unchanged; no IDs, serializers, or payloads changed
- Network compatibility: unchanged; no RPCs, NetworkObject registrations, or payloads changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC visibility handling during loading and spawning.
  * Physical, non-supplier NPCs now receive visibility before spawning.
  * Invisible NPCs and custom suppliers remain active long enough to initialize correctly, with their final visibility applied afterward.
  * Updated behavior consistently handles physical and non-physical NPCs, whether or not they are suppliers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->