### PR TITLE
docs(npc): clarify explicit voice selection

### DIFF
--- a/S1API/docs/custom-npcs.md
+++ b/S1API/docs/custom-npcs.md
@@ -148,7 +148,9 @@ Supported identifiers are `cold`, `crackhead`, `female-1`, `female-2`, `goblin`,
 
 These identifiers name reusable voice databases, not individual NPCs. For example, Ray's native configuration combines the `tyler` database with a character-specific pitch; use the pitch overload when reproducing that kind of voice profile.
 
-The pitch overload accepts values from `0.1` through `4.0`. Omitting the pitch preserves the selected base prefab's inherited pitch. Omitting `WithVoice(...)` entirely preserves both the inherited voice database and pitch. Invalid identifiers, unavailable databases, and out-of-range pitch values throw an actionable configuration error.
+The pitch overload accepts values from `0.1` through `4.0`. Omitting the pitch preserves the selected base prefab's inherited pitch. Omitting `WithVoice(...)` entirely preserves both the inherited voice database and pitch.
+
+Call `WithVoice(...)` when the NPC should keep a specific voice across game updates. Inherited voices depend on S1API's current donor prefab and may change when the game changes that prefab. A missing donor voice also leaves the NPC silent. Invalid identifiers, unavailable databases, and out-of-range pitch values throw an actionable configuration error.
 
 Voice selection controls which clips normal NPC dialogue and reactions play. It does not play an individual voice line.
 


### PR DESCRIPTION
## Summary

- clarify that omitting `WithVoice(...)` inherits the current donor prefab's voice, which can be absent
- recommend explicit voice selection for NPCs that must remain audible across game updates

## Reproduction

Issue #202 was reproduced on the public IL2CPP game with S1API 3.1.8 and the reporter's `ScheduleEnhanced_Il2cpp.dll` on a fresh save. ScheduleEnhanced defines physical NPCs but contains no calls to `WithVoice(...)`.

- implicit ScheduleEnhanced NPC: `Database=<null>`, `Clip=<null>`, `Playing=False`
- equivalent explicit-voice NPC: `Database=Tyler VO`, `Clip=Greeting3`, `Playing=True`

The current native donor prefab is unvoiced. S1API preserves that donor state as documented; assigning an arbitrary default would change existing NPC identity and behavior.

## Testing

- Mono restore and build: passed with 0 warnings
- Mono contract suite: 445 passed
- IL2CPP restore and build: passed with 0 warnings
- IL2CPP contract suite: 360 passed before the known out-of-game `GameAssembly` finalizer crash aborted the host
- public IL2CPP fresh-save runtime comparison: reproduced implicit silence and confirmed explicit greeting playback
- human-writing clarity audit: no findings in the changed text

## Compatibility

No public or protected symbols, durable IDs, save data, or network payloads changed. Runtime behavior is unchanged; this PR documents the existing donor-inheritance behavior and its limit.

Closes #202