### PR TITLE
fix(npc): restore dealer lifecycle and mugshots

### DIFF
--- a/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
+++ b/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
@@ -1,0 +1,93 @@
+using S1API.Entities;
+using S1API.Entities.Relation;
+using S1API.Internal.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class DealerLifecyclePolicyTests
+{
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void RecruitmentRequiresTheCompleteNativeDealerDialogueSet(
+        bool hasRecruitDialogue,
+        bool hasCollectCashDialogue,
+        bool hasAssignCustomersDialogue,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPCDataAccess.HasCompleteDealerDialogueSet(
+                hasRecruitDialogue,
+                hasCollectCashDialogue,
+                hasAssignCustomersDialogue));
+    }
+
+    [Fact]
+    public void DealerDialogueFallbackUsesTheNative046AssetNames()
+    {
+        Assert.Equal("Supplier_Recruitment", NPCDataAccess.DealerRecruitDialogueName);
+        Assert.Equal("Dealer_CollectCash", NPCDataAccess.DealerCollectCashDialogueName);
+        Assert.Equal("Dealer_AssignCustomers", NPCDataAccess.DealerAssignCustomersDialogueName);
+    }
+
+    [Fact]
+    public void DealerDealBehaviourMatchesNativePriority()
+    {
+        Assert.Equal(5, NPCPrefabBuilder.DealerAttendDealPriority);
+    }
+
+    [Theory]
+    [InlineData("DealerHomeEvent", true)]
+    [InlineData("HomeEvent", true)]
+    [InlineData("StayInBuilding", false)]
+    [InlineData("StayInBuilding_1", false)]
+    public void DealerHomeEventNeverAliasesAConsumerScheduleAction(string name, bool expected)
+    {
+        Assert.Equal(expected, NPCPrefabBuilder.IsDealerHomeEventName(name));
+    }
+
+    [Fact]
+    public void ConnectionIdsAreStableAcrossSpawnOrderReconciliation()
+    {
+        IReadOnlyList<string> ids = NPCRelationshipDataBuilder.NormalizeConnectionIds(
+            new[] { " thomas_elis ", "", "THOMAS_ELIS", "gennaro_salvadore" });
+
+        Assert.Equal(new[] { "thomas_elis", "gennaro_salvadore" }, ids);
+    }
+
+    [Fact]
+    public void RelationshipReconciliationTreatsOneSidedDeclarationsAsUndirected()
+    {
+        var declarations = new Dictionary<string, IReadOnlyList<string>>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            ["dealer_a"] = new[] { "dealer_b" },
+            ["dealer_b"] = new[] { "customer_c" },
+            ["customer_c"] = Array.Empty<string>()
+        };
+
+        Assert.Equal(
+            new[] { "customer_c", "dealer_a" },
+            NPCRelationshipGraphPolicy.BuildUndirectedConnectionIds("dealer_b", declarations));
+        Assert.Equal(
+            new[] { "dealer_b" },
+            NPCRelationshipGraphPolicy.BuildUndirectedConnectionIds("customer_c", declarations));
+    }
+
+    [Theory]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(false, false, false)]
+    public void ContactIconReadinessIsTrackedPerNpc(
+        bool hasExplicitIcon,
+        bool generationCompleted,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPCAppearance.IsMugshotReady(hasExplicitIcon, generationCompleted));
+    }
+}

--- a/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
+++ b/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
@@ -77,6 +77,18 @@ public sealed class DealerLifecyclePolicyTests
             NPCRelationshipGraphPolicy.BuildUndirectedConnectionIds("customer_c", declarations));
     }
 
+    [Fact]
+    public void ExplicitlyEmptyConnectionsRemainConfiguredForStaleGraphRemoval()
+    {
+        var builder = new NPCRelationshipDataBuilder()
+            .WithConnectionsById(Array.Empty<string>());
+
+        NPCRelationshipDataBuilder.RelationshipDefaultsData snapshot = builder.CaptureData();
+
+        Assert.True(snapshot.ConnectionsConfigured);
+        Assert.Empty(snapshot.ConnectionIDs!);
+    }
+
     [Theory]
     [InlineData(true, false, true)]
     [InlineData(false, true, true)]

--- a/S1API.Tests/Entities/MugshotCapturePolicyTests.cs
+++ b/S1API.Tests/Entities/MugshotCapturePolicyTests.cs
@@ -1,0 +1,29 @@
+using S1API.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class MugshotCapturePolicyTests
+{
+    [Theory]
+    [InlineData(500, 4096, 0.60f, 0.90f, true)]
+    [InlineData(500, 4096, 0.60f, 0.80f, false)]
+    [InlineData(200, 4096, 0.60f, 0.90f, false)]
+    [InlineData(500, 4096, 0.30f, 0.90f, false)]
+    [InlineData(500, 4096, 0.60f, 0.40f, false)]
+    [InlineData(500, 0, 0.60f, 0.80f, false)]
+    public void PortraitCoverageRequiresSubstantialVisibleBounds(
+        int visibleSamples,
+        int totalSamples,
+        float contentWidth,
+        float contentHeight,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPCAppearance.IsPortraitCoverageSufficient(
+                visibleSamples,
+                totalSamples,
+                contentWidth,
+                contentHeight));
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -4483,13 +4483,23 @@ namespace S1API.Entities
                         NPCRelationshipGraphPolicy.BuildUndirectedConnectionIds(
                             entry.Wrapper.ID,
                             declarations);
-                    if (connectionIds.Count == 0)
+                    if (connectionIds.Count == 0
+                        && !entry.Identity!.HasConfiguredConnections())
                         continue;
 
                     var builder = new NPCRelationshipDataBuilder();
                     builder.WithConnectionsById(connectionIds);
+                    var relationData = entry.Wrapper.S1NPC.RelationData;
+                    if (relationData == null)
+                    {
+                        Logger.Warning(
+                            $"[Relationship Data] RelationData is null for " +
+                            $"'{entry.Wrapper.GetSafeNpcId()}'; skipping connection reconciliation.");
+                        continue;
+                    }
+
                     builder.ApplyTo(
-                        entry.Wrapper.S1NPC.RelationData,
+                        relationData,
                         entry.Wrapper.S1NPC,
                         preserveUnlockState: true);
                 }

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -683,8 +683,10 @@ namespace S1API.Entities
 
         private static void RepairDealerPrefabReferences(GameObject prefabRoot, S1Economy.Dealer dealer)
         {
-            dealer.HomeEvent ??=
-                prefabRoot.GetComponentInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true);
+            dealer.HomeEvent ??= prefabRoot
+                .GetComponentsInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true)
+                .FirstOrDefault(action =>
+                    NPCPrefabBuilder.IsDealerHomeEventName(action?.gameObject?.name));
 
             S1Dialogue.DialogueController_Dealer controller =
                 prefabRoot.GetComponentInChildren<S1Dialogue.DialogueController_Dealer>(true);
@@ -1349,6 +1351,7 @@ namespace S1API.Entities
 
                 // Add to All list
                 All.Add(wrapper);
+                ReconcileAllCustomNpcRelationshipConnections();
 
                 return wrapper;
             }
@@ -1372,6 +1375,14 @@ namespace S1API.Entities
                 wrapper.Appearance = new NPCAppearance(wrapper, runtimeAvatar);
                 wrapper.RestoreRuntimeAvatarAppearance();
 
+                try
+                {
+                    var registry = S1NPCs.NPCManager.NPCRegistry;
+                    if (registry != null && !registry.Contains(baseNpc))
+                        registry.Add(baseNpc);
+                }
+                catch { }
+
                 var identity = baseNpc.gameObject?.GetComponent<NPCPrefabIdentity>();
                 if (identity != null)
                 {
@@ -1383,14 +1394,6 @@ namespace S1API.Entities
 
                 wrapper.RefreshMessagingIcons();
                 wrapper._relationshipDataAppliedFromPrefab = identity != null && baseNpc.RelationData != null;
-
-                try
-                {
-                    var registry = S1NPCs.NPCManager.NPCRegistry;
-                    if (registry != null && !registry.Contains(baseNpc))
-                        registry.Add(baseNpc);
-                }
-                catch { }
             }
             catch (Exception ex)
             {
@@ -2335,6 +2338,7 @@ namespace S1API.Entities
                 _hasExplicitIcon = value != null;
                 NPCDataAccess.ApplyIcon(S1NPC, value);
                 RefreshMessagingIcons();
+                Internal.Patches.ContactsAppPatches.RefreshContactIcon(S1NPC);
             }
         }
 
@@ -2345,6 +2349,7 @@ namespace S1API.Entities
 
             NPCDataAccess.ApplyIcon(S1NPC, icon);
             RefreshMessagingIcons();
+            Internal.Patches.ContactsAppPatches.RefreshContactIcon(S1NPC);
         }
 
         /// <summary>
@@ -4400,6 +4405,7 @@ namespace S1API.Entities
                 // Check if all custom NPCs are now ready (finalized)
                 // This sets the CustomNpcsReady flag once all custom NPCs have been spawned and finalized
                 FinalizedCustomNpcTypes.Add(GetType());
+                ReconcileAllCustomNpcRelationshipConnections();
                 CheckAndSetCustomNpcsReady();
             }
             catch (Exception ex)
@@ -4437,6 +4443,62 @@ namespace S1API.Entities
             catch (Exception ex)
             {
                 Logger.Warning($"[NPC] Failed to check CustomNpcsReady status: {ex.Message}");
+            }
+        }
+
+        internal static void ReconcileAllCustomNpcRelationshipConnections()
+        {
+            var configuredNpcs = All
+                .Where(wrapper => wrapper?.S1NPC != null && wrapper.IsCustomNPC)
+                .Select(wrapper => new
+                {
+                    Wrapper = wrapper,
+                    Identity = wrapper.gameObject?.GetComponent<NPCPrefabIdentity>()
+                })
+                .Where(entry => entry.Identity != null && !string.IsNullOrWhiteSpace(entry.Wrapper.ID))
+                .ToArray();
+
+            var declarations =
+                new global::System.Collections.Generic.Dictionary<
+                    string,
+                    global::System.Collections.Generic.IReadOnlyList<string>>(
+                    StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in configuredNpcs)
+            {
+                if (!declarations.TryAdd(
+                        entry.Wrapper.ID,
+                        entry.Identity!.GetConfiguredConnectionIds()))
+                {
+                    Logger.Warning(
+                        $"[Relationship Data] Duplicate custom NPC ID '{entry.Wrapper.ID}' " +
+                        "prevents deterministic connection reconciliation for that duplicate.");
+                }
+            }
+
+            foreach (var entry in configuredNpcs)
+            {
+                try
+                {
+                    global::System.Collections.Generic.IReadOnlyList<string> connectionIds =
+                        NPCRelationshipGraphPolicy.BuildUndirectedConnectionIds(
+                            entry.Wrapper.ID,
+                            declarations);
+                    if (connectionIds.Count == 0)
+                        continue;
+
+                    var builder = new NPCRelationshipDataBuilder();
+                    builder.WithConnectionsById(connectionIds);
+                    builder.ApplyTo(
+                        entry.Wrapper.S1NPC.RelationData,
+                        entry.Wrapper.S1NPC,
+                        preserveUnlockState: true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(
+                        $"[Relationship Data] Could not reconcile connections for " +
+                        $"'{entry.Wrapper.GetSafeNpcId()}': {ex.Message}");
+                }
             }
         }
 

--- a/S1API/Entities/NPCAppearance.cs
+++ b/S1API/Entities/NPCAppearance.cs
@@ -115,6 +115,45 @@ namespace S1API.Entities
 
         private static IEnumerator ProcessMugshotQueue()
         {
+            while (true)
+            {
+                IEnumerator processor = ProcessMugshotQueueCore();
+                bool restart = false;
+
+                while (true)
+                {
+                    bool hasNext;
+                    object? current = null;
+                    try
+                    {
+                        hasNext = processor.MoveNext();
+                        if (hasNext)
+                            current = processor.Current;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error($"[Mugshot] Capture job failed: {ex}");
+                        restart = CompleteActiveMugshot();
+                        if (!restart)
+                            AbortQueuedMugshots();
+                        break;
+                    }
+
+                    if (!hasNext)
+                        yield break;
+
+                    yield return current;
+                }
+
+                if (!restart)
+                    yield break;
+
+                yield return null;
+            }
+        }
+
+        private static IEnumerator ProcessMugshotQueueCore()
+        {
             var generator = S1AvatarFramework.MugshotGenerator.Instance;
             var mugshotRig = generator != null ? generator.MugshotRig : null;
             var iconGenerator = generator != null ? generator.Generator : null;
@@ -194,6 +233,8 @@ namespace S1API.Entities
                     continue;
                 }
 
+                _activeMugshot = next;
+
                 // Use a per-capture clone so subsequent appearance edits don't mutate the in-flight mugshot
                 var mugshotSettings = ScriptableObject.Instantiate(next._customAvatarSettings);
                 mugshotSettings.Height = 1f;
@@ -213,6 +254,60 @@ namespace S1API.Entities
                 Transform? rightPupil = eyes != null && eyes.rightEye != null ? eyes.rightEye.PupilContainer : null;
                 Quaternion previousLeftPupilRotation = leftPupil != null ? leftPupil.localRotation : Quaternion.identity;
                 Quaternion previousRightPupilRotation = rightPupil != null ? rightPupil.localRotation : Quaternion.identity;
+
+                _restoreActiveMugshotRig = () =>
+                {
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (defaultSettings != null)
+                                mugshotRig.LoadAvatarSettings(defaultSettings);
+                        },
+                        "default appearance");
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (mugshotRig.Animation != null)
+                                mugshotRig.Animation.AllowCulling = previousAllowCulling;
+                        },
+                        "animation culling");
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (lookController != null)
+                            {
+                                lookController.ResetIKWeight();
+                                lookController.enabled = previousLookControllerEnabled;
+                            }
+                        },
+                        "look controller");
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (animator != null)
+                                animator.speed = previousAnimatorSpeed;
+                        },
+                        "animator speed");
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (eyes != null)
+                                eyes.BlinkingEnabled = previousBlinkingEnabled;
+                        },
+                        "blinking");
+                    TryRestoreRigState(
+                        () =>
+                        {
+                            if (leftPupil != null)
+                                leftPupil.localRotation = previousLeftPupilRotation;
+                            if (rightPupil != null)
+                                rightPupil.localRotation = previousRightPupilRotation;
+                        },
+                        "pupil rotation");
+                    TryRestoreRigState(
+                        () => mugshotRig.gameObject.SetActive(false),
+                        "rig visibility");
+                };
 
                 if (mugshotRig.Animation != null)
                     mugshotRig.Animation.AllowCulling = false;
@@ -344,29 +439,7 @@ namespace S1API.Entities
                     _logger.Error($"[Mugshot] {next.NPC.FirstName}: no complete portrait was captured; keeping the existing icon");
                 }
 
-                next.MarkMugshotCompleted();
-
-                next.ApplyToAvatar(next._runtimeAvatar);
-
-                // Reset rig and deactivate
-                if (defaultSettings != null)
-                    mugshotRig.LoadAvatarSettings(defaultSettings);
-                if (mugshotRig.Animation != null)
-                    mugshotRig.Animation.AllowCulling = previousAllowCulling;
-                if (lookController != null)
-                {
-                    lookController.ResetIKWeight();
-                    lookController.enabled = previousLookControllerEnabled;
-                }
-                if (animator != null)
-                    animator.speed = previousAnimatorSpeed;
-                if (eyes != null)
-                    eyes.BlinkingEnabled = previousBlinkingEnabled;
-                if (leftPupil != null)
-                    leftPupil.localRotation = previousLeftPupilRotation;
-                if (rightPupil != null)
-                    rightPupil.localRotation = previousRightPupilRotation;
-                mugshotRig.gameObject.SetActive(false);
+                CompleteActiveMugshot();
 
                 // Small delay between jobs to let the mugshot rig fully reset
                 yield return new WaitForSeconds(0.1f);
@@ -379,6 +452,61 @@ namespace S1API.Entities
             {
                 _mugshotQueued = false;
                 _mugshotCompleted = true;
+            }
+        }
+
+        private static bool CompleteActiveMugshot()
+        {
+            NPCAppearance? active = _activeMugshot;
+            if (active == null)
+                return false;
+
+            try
+            {
+                active.ApplyToAvatar(active._runtimeAvatar);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[Mugshot] Failed to restore the runtime avatar: {ex.Message}");
+            }
+
+            try
+            {
+                _restoreActiveMugshotRig?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[Mugshot] Failed to restore shared rig state: {ex.Message}");
+            }
+            finally
+            {
+                active.MarkMugshotCompleted();
+                _activeMugshot = null;
+                _restoreActiveMugshotRig = null;
+            }
+
+            return true;
+        }
+
+        private static void AbortQueuedMugshots()
+        {
+            lock (_mugshotQueueLock)
+            {
+                while (_mugshotQueue.Count > 0)
+                    _mugshotQueue.Dequeue().MarkMugshotCompleted();
+                _isProcessingMugshots = false;
+            }
+        }
+
+        private static void TryRestoreRigState(Action restore, string stateName)
+        {
+            try
+            {
+                restore();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"[Mugshot] Failed to restore {stateName}: {ex.Message}");
             }
         }
 
@@ -823,6 +951,8 @@ namespace S1API.Entities
         private static readonly Queue<NPCAppearance> _mugshotQueue = new Queue<NPCAppearance>();
         private static bool _isProcessingMugshots = false;
         private static bool _hasQueuedMugshots = false;
+        private static NPCAppearance? _activeMugshot;
+        private static Action? _restoreActiveMugshotRig;
 
         /// <summary>
         /// INTERNAL: Resets mugshot queue state on scene change so warmup runs fresh on reload.
@@ -835,6 +965,8 @@ namespace S1API.Entities
                 _mugshotQueue.Clear();
                 _isProcessingMugshots = false;
                 _hasQueuedMugshots = false;
+                _activeMugshot = null;
+                _restoreActiveMugshotRig = null;
             }
         }
 

--- a/S1API/Entities/NPCAppearance.cs
+++ b/S1API/Entities/NPCAppearance.cs
@@ -39,6 +39,8 @@ namespace S1API.Entities
     public class NPCAppearance
     {
         private static readonly Log _logger = new Log("NPCAppearance");
+        private bool _mugshotQueued;
+        private bool _mugshotCompleted;
 
         #region Internal Members
 
@@ -88,15 +90,19 @@ namespace S1API.Entities
         internal void GenerateMugshot()
         {
             if (NPC.HasExplicitIcon)
+            {
+                _mugshotCompleted = true;
                 return;
-
-            // Enqueue serialized mugshot generation to avoid shared rig race conditions
-            var generator = S1AvatarFramework.MugshotGenerator.Instance;
-            if (generator == null || generator.MugshotRig == null)
-                return;
+            }
 
             lock (_mugshotQueueLock)
             {
+                if (_mugshotQueued || _mugshotCompleted)
+                    return;
+
+                // Queue even before MugshotGenerator is ready. The processor waits for the
+                // native rig, avoiding a permanent shared Contacts icon on early OnCreated calls.
+                _mugshotQueued = true;
                 _mugshotQueue.Enqueue(this);
                 _hasQueuedMugshots = true;
                 if (!_isProcessingMugshots)
@@ -170,7 +176,10 @@ namespace S1API.Entities
                 }
 
                 if (next.NPC.HasExplicitIcon)
+                {
+                    next.MarkMugshotCompleted();
                     continue;
+                }
 
                 // Refresh references in case they became stale
                 generator = S1AvatarFramework.MugshotGenerator.Instance;
@@ -185,12 +194,35 @@ namespace S1API.Entities
                     continue;
                 }
 
-                S1AvatarFramework.Avatar previousAvatar = next.NPC.S1NPC.Avatar;
-                global::S1API.Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(next.NPC.S1NPC, "Avatar", mugshotRig);
-
                 // Use a per-capture clone so subsequent appearance edits don't mutate the in-flight mugshot
                 var mugshotSettings = ScriptableObject.Instantiate(next._customAvatarSettings);
                 mugshotSettings.Height = 1f;
+
+                // The mugshot rig is shared scene state. Keep it detached from the live NPC:
+                // since the NPC rewrite, assigning it to NPC.Avatar lets runtime LOD/look logic
+                // alter the rig while this coroutine yields, producing impostor captures and
+                // player-directed eyes.
+                bool previousAllowCulling = mugshotRig.Animation != null && mugshotRig.Animation.AllowCulling;
+                var lookController = mugshotRig.LookController;
+                bool previousLookControllerEnabled = lookController != null && lookController.enabled;
+                var animator = mugshotRig.Animation != null ? mugshotRig.Animation.animator : null;
+                float previousAnimatorSpeed = animator != null ? animator.speed : 1f;
+                var eyes = mugshotRig.Eyes;
+                bool previousBlinkingEnabled = eyes != null && eyes.BlinkingEnabled;
+                Transform? leftPupil = eyes != null && eyes.leftEye != null ? eyes.leftEye.PupilContainer : null;
+                Transform? rightPupil = eyes != null && eyes.rightEye != null ? eyes.rightEye.PupilContainer : null;
+                Quaternion previousLeftPupilRotation = leftPupil != null ? leftPupil.localRotation : Quaternion.identity;
+                Quaternion previousRightPupilRotation = rightPupil != null ? rightPupil.localRotation : Quaternion.identity;
+
+                if (mugshotRig.Animation != null)
+                    mugshotRig.Animation.AllowCulling = false;
+                if (lookController != null)
+                {
+                    lookController.OverrideIKWeight(0f);
+                    lookController.enabled = false;
+                }
+                if (eyes != null)
+                    eyes.BlinkingEnabled = false;
 
                 // === Content-validated capture with retry ===
                 // On cold start the rig's renderers may not be ready, producing completely
@@ -203,6 +235,7 @@ namespace S1API.Entities
                 const float contentBrightnessFloor = 0.01f;
                 Texture2D? generatedMugshot = null;
                 bool hasContent = false;
+                bool poseReset = false;
 
                 for (int attempt = 0; attempt <= maxRetries; attempt++)
                 {
@@ -212,12 +245,24 @@ namespace S1API.Entities
                     mugshotRig.gameObject.SetActive(true);
 
                     // Disable distance culling so the mugshot rig never hides while the player camera is far away
-                    bool previousAllowCulling = mugshotRig.Animation != null && mugshotRig.Animation.AllowCulling;
-                    if (mugshotRig.Animation != null)
-                        mugshotRig.Animation.AllowCulling = false;
                     mugshotRig.SetVisible(true);
                     mugshotRig.Impostor.DisableImpostor();
 
+                    if (animator != null)
+                    {
+                        animator.speed = previousAnimatorSpeed;
+                        if (!poseReset)
+                        {
+                            animator.Rebind();
+                            animator.Update(0f);
+                            poseReset = true;
+                        }
+                        animator.speed = 0f;
+                    }
+
+                    // Rebind before applying appearance data. Rebinding afterwards can restore
+                    // the prefab's animated scale/shape and produce a visibly shorter, wider
+                    // portrait even though the mugshot settings specify Height = 1.
                     mugshotRig.LoadAvatarSettings(mugshotSettings);
                     SetLayerRecursively(mugshotRig.gameObject, LayerMask.NameToLayer("IconGeneration"));
 
@@ -230,6 +275,24 @@ namespace S1API.Entities
                     yield return null;
                     yield return new WaitForEndOfFrame();
 
+                    // Live scene systems can toggle visibility late in the frame. Reassert the
+                    // portrait-only state immediately before reading pixels.
+                    mugshotRig.SetVisible(true);
+                    mugshotRig.Impostor.DisableImpostor();
+                    // IconGenerator uses a fixed camera; it does not normalize model scale.
+                    // Keep the preview rig at the base game's canonical mugshot height even if
+                    // an Animator or scene callback changed the shared transform while yielding.
+                    mugshotRig.transform.localScale = Vector3.one;
+                    if (eyes != null)
+                        eyes.SetEyesOpen(true);
+                    if (leftPupil != null)
+                        leftPupil.localRotation = Quaternion.identity;
+                    if (rightPupil != null)
+                        rightPupil.localRotation = Quaternion.identity;
+                    // Neutral pupil rotations produce a straight-ahead portrait. EyeController's
+                    // runtime target is player-driven and the thumbnail camera is deliberately
+                    // offset, either of which makes the eyes visibly track to one side.
+
                     generatedMugshot = null;
                     try
                     {
@@ -240,27 +303,10 @@ namespace S1API.Entities
                         _logger.Error($"Direct GetTexture failed: {ex.Message}");
                     }
 
-                    // Check if capture has actual content (not black/empty)
-                    hasContent = false;
-                    if (generatedMugshot != null && generatedMugshot.width > 0 && generatedMugshot.height > 0)
-                    {
-                        int cx = generatedMugshot.width / 2;
-                        int cy = generatedMugshot.height / 2;
-                        Color centerPx = generatedMugshot.GetPixel(cx, cy);
-                        Color topPx = generatedMugshot.GetPixel(cx, (int)(generatedMugshot.height * 0.85f));
-                        Color botPx = generatedMugshot.GetPixel(cx, (int)(generatedMugshot.height * 0.15f));
-                        Color leftPx = generatedMugshot.GetPixel((int)(generatedMugshot.width * 0.25f), cy);
-                        Color rightPx = generatedMugshot.GetPixel((int)(generatedMugshot.width * 0.75f), cy);
-
-                        float maxBrightness = 0f;
-                        Color[] samples = { centerPx, topPx, botPx, leftPx, rightPx };
-                        foreach (var s in samples)
-                        {
-                            float b = s.r + s.g + s.b;
-                            if (b > maxBrightness) maxBrightness = b;
-                        }
-                        hasContent = maxBrightness > contentBrightnessFloor;
-                    }
+                    // Reject empty frames and partially initialized meshes. The previous five-
+                    // pixel brightness check accepted a stray impostor or a single clothing mesh
+                    // as a valid portrait.
+                    hasContent = HasPortraitContent(generatedMugshot, contentBrightnessFloor);
 
                     if (hasContent)
                         break;
@@ -268,15 +314,15 @@ namespace S1API.Entities
                     // No content — deactivate and retry
                     if (defaultSettings != null)
                         mugshotRig.LoadAvatarSettings(defaultSettings);
-                    if (mugshotRig.Animation != null)
-                        mugshotRig.Animation.AllowCulling = previousAllowCulling;
+                    if (animator != null)
+                        animator.speed = previousAnimatorSpeed;
                     mugshotRig.gameObject.SetActive(false);
 
                     if (attempt == maxRetries)
                         _logger.Warning($"[Mugshot] {next.NPC.FirstName}: no content after {maxRetries + 1} attempts, using last capture");
                 }
 
-                if (generatedMugshot != null)
+                if (generatedMugshot != null && hasContent)
                 {
                     try
                     {
@@ -293,23 +339,102 @@ namespace S1API.Entities
                         _logger.Error($"Failed to finalize mugshot: {ex.Message}");
                     }
                 }
+                else
+                {
+                    _logger.Error($"[Mugshot] {next.NPC.FirstName}: no complete portrait was captured; keeping the existing icon");
+                }
 
-                // Restore avatar reference
-                global::S1API.Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(next.NPC.S1NPC, "Avatar", previousAvatar ?? next._runtimeAvatar);
+                next.MarkMugshotCompleted();
+
                 next.ApplyToAvatar(next._runtimeAvatar);
 
                 // Reset rig and deactivate
-                bool finalAllowCulling = mugshotRig.Animation != null && mugshotRig.Animation.AllowCulling;
                 if (defaultSettings != null)
                     mugshotRig.LoadAvatarSettings(defaultSettings);
                 if (mugshotRig.Animation != null)
-                    mugshotRig.Animation.AllowCulling = finalAllowCulling;
+                    mugshotRig.Animation.AllowCulling = previousAllowCulling;
+                if (lookController != null)
+                {
+                    lookController.ResetIKWeight();
+                    lookController.enabled = previousLookControllerEnabled;
+                }
+                if (animator != null)
+                    animator.speed = previousAnimatorSpeed;
+                if (eyes != null)
+                    eyes.BlinkingEnabled = previousBlinkingEnabled;
+                if (leftPupil != null)
+                    leftPupil.localRotation = previousLeftPupilRotation;
+                if (rightPupil != null)
+                    rightPupil.localRotation = previousRightPupilRotation;
                 mugshotRig.gameObject.SetActive(false);
 
                 // Small delay between jobs to let the mugshot rig fully reset
                 yield return new WaitForSeconds(0.1f);
             }
         }
+
+        private void MarkMugshotCompleted()
+        {
+            lock (_mugshotQueueLock)
+            {
+                _mugshotQueued = false;
+                _mugshotCompleted = true;
+            }
+        }
+
+        internal bool MugshotReady => IsMugshotReady(NPC.HasExplicitIcon, _mugshotCompleted);
+
+        internal static bool IsMugshotReady(bool hasExplicitIcon, bool generationCompleted) =>
+            hasExplicitIcon || generationCompleted;
+
+        private static bool HasPortraitContent(Texture2D? texture, float brightnessFloor)
+        {
+            if (texture == null || texture.width <= 0 || texture.height <= 0)
+                return false;
+
+            int stepX = Math.Max(1, texture.width / 64);
+            int stepY = Math.Max(1, texture.height / 64);
+            int sampled = 0;
+            int visible = 0;
+            int minX = texture.width;
+            int minY = texture.height;
+            int maxX = -1;
+            int maxY = -1;
+
+            for (int y = 0; y < texture.height; y += stepY)
+            {
+                for (int x = 0; x < texture.width; x += stepX)
+                {
+                    sampled++;
+                    Color pixel = texture.GetPixel(x, y);
+                    if (pixel.a <= 0.05f || pixel.r + pixel.g + pixel.b <= brightnessFloor)
+                        continue;
+
+                    visible++;
+                    minX = Math.Min(minX, x);
+                    minY = Math.Min(minY, y);
+                    maxX = Math.Max(maxX, x);
+                    maxY = Math.Max(maxY, y);
+                }
+            }
+
+            if (maxX < minX || maxY < minY)
+                return false;
+
+            float contentWidth = (maxX - minX + stepX) / (float)texture.width;
+            float contentHeight = (maxY - minY + stepY) / (float)texture.height;
+            return IsPortraitCoverageSufficient(visible, sampled, contentWidth, contentHeight);
+        }
+
+        internal static bool IsPortraitCoverageSufficient(
+            int visibleSamples,
+            int totalSamples,
+            float contentWidth,
+            float contentHeight) =>
+            totalSamples > 0 &&
+            visibleSamples >= totalSamples * 0.1f &&
+            contentWidth >= 0.4f &&
+            contentHeight >= 0.82f;
 
         /// <summary>
         /// INTERNAL: Applies the currently configured avatar settings to a runtime avatar instance.

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -763,7 +763,14 @@ namespace S1API.Entities
                             behaviour = go.AddComponent<S1NPCsBehaviour.DealerAttendDealBehaviour>();
                             go.SetActive(false);
                         }
+                        behaviour.Name = "Attend deal";
+                        behaviour.Priority = NPCPrefabBuilder.DealerAttendDealPriority;
                         attendDealField?.SetValue(dealer, behaviour);
+                    }
+                    else
+                    {
+                        existingBehaviour.Name = "Attend deal";
+                        existingBehaviour.Priority = NPCPrefabBuilder.DealerAttendDealPriority;
                     }
                 }
                 catch { /* ignore */ }
@@ -777,19 +784,25 @@ namespace S1API.Entities
                     var homeEventField = typeof(S1Economy.Dealer).GetProperty("HomeEvent", BindingFlags.Public | BindingFlags.Instance);
 #endif
                     var homeEvent = homeEventField?.GetValue(dealer) as S1NPCsSchedules.NPCEvent_StayInBuilding;
-                    if (homeEvent == null)
+                    if (homeEvent == null
+                        || !NPCPrefabBuilder.IsDealerHomeEventName(homeEvent.gameObject?.name))
                     {
                         var sched = NPC.gameObject.GetComponentInChildren<S1NPCs.NPCScheduleManager>(true);
                         if (sched != null)
                         {
-                            homeEvent = NPC.gameObject.GetComponentInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true);
+                            homeEvent = NPC.gameObject
+                                .GetComponentsInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true)
+                                .FirstOrDefault(action =>
+                                    NPCPrefabBuilder.IsDealerHomeEventName(action?.gameObject?.name));
                             if (homeEvent == null)
                             {
-                                var go = new GameObject("HomeEvent");
+                                var go = new GameObject(NPCPrefabBuilder.DealerHomeEventName);
                                 go.transform.SetParent(sched.transform, false);
                                 homeEvent = go.AddComponent<S1NPCsSchedules.NPCEvent_StayInBuilding>();
                                 go.SetActive(false);
                             }
+                            Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(homeEvent, "npc", dealer);
+                            Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(homeEvent, "schedule", sched);
                             homeEventField?.SetValue(dealer, homeEvent);
                         }
                     }

--- a/S1API/Entities/NPCPrefabBuilder.cs
+++ b/S1API/Entities/NPCPrefabBuilder.cs
@@ -35,6 +35,7 @@ using S1API.Entities.Voices;
 using S1API.Entities.Relation;
 using S1API.Entities.Appearances.Base;
 using System.Collections.Generic;
+using System.Linq;
 using S1API.Internal.Entities;
 using S1API.Internal.Utils;
 using S1API.Logging;
@@ -363,19 +364,38 @@ namespace S1API.Entities
             }
             var baseNpcForDealer = prefabRoot.GetComponent<S1NPCs.NPC>();
             SetBehaviourRefs(attendDeal, npcBehaviour, baseNpcForDealer);
+            attendDeal.Name = "Attend deal";
+            attendDeal.Priority = DealerAttendDealPriority;
 
-            // Ensure NPCEvent_StayInBuilding exists for home behavior
-            var stayInBuilding = prefabRoot.GetComponentInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true);
-            if (stayInBuilding != null) return this;
+            // Keep the dealer's HomeEvent separate from mod-defined schedule actions. Dealer.OnTick
+            // toggles this object directly, so reusing an arbitrary StayInBuilding action makes the
+            // schedule and contract behaviour fight over the same doorway.
+            var stayInBuilding = prefabRoot
+                .GetComponentsInChildren<S1NPCsSchedules.NPCEvent_StayInBuilding>(true)
+                .FirstOrDefault(action => IsDealerHomeEventName(action?.gameObject?.name));
+            if (stayInBuilding == null)
             {
-                var go = new GameObject("StayInBuilding");
+                var go = new GameObject(DealerHomeEventName);
                 go.transform.SetParent(mgr.transform, false);
                 stayInBuilding = go.AddComponent<S1NPCsSchedules.NPCEvent_StayInBuilding>();
                 go.SetActive(false);
             }
 
+            ReflectionUtils.TrySetFieldOrProperty(stayInBuilding, "npc", baseNpcForDealer);
+            ReflectionUtils.TrySetFieldOrProperty(stayInBuilding, "schedule", mgr);
+            if (baseNpcForDealer != null
+                && CrossType.Is(baseNpcForDealer, out S1Economy.Dealer dealer))
+                dealer.HomeEvent = stayInBuilding;
+
             return this;
         }
+
+        internal const int DealerAttendDealPriority = 5;
+        internal const string DealerHomeEventName = "DealerHomeEvent";
+
+        internal static bool IsDealerHomeEventName(string? name) =>
+            string.Equals(name, DealerHomeEventName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "HomeEvent", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Selects a supported base-game voice while preserving the prefab's inherited pitch.

--- a/S1API/Entities/NPCPrefabBuilder.cs
+++ b/S1API/Entities/NPCPrefabBuilder.cs
@@ -58,6 +58,13 @@ namespace S1API.Entities
         private readonly GameObject prefabRoot;
         private readonly Type ownerType;
 
+        internal const int DealerAttendDealPriority = 5;
+        internal const string DealerHomeEventName = "DealerHomeEvent";
+
+        internal static bool IsDealerHomeEventName(string? name) =>
+            string.Equals(name, DealerHomeEventName, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(name, "HomeEvent", StringComparison.OrdinalIgnoreCase);
+
         internal NPCPrefabBuilder(GameObject prefabRoot, Type ownerType)
         {
             this.prefabRoot = prefabRoot;
@@ -389,13 +396,6 @@ namespace S1API.Entities
 
             return this;
         }
-
-        internal const int DealerAttendDealPriority = 5;
-        internal const string DealerHomeEventName = "DealerHomeEvent";
-
-        internal static bool IsDealerHomeEventName(string? name) =>
-            string.Equals(name, DealerHomeEventName, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(name, "HomeEvent", StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Selects a supported base-game voice while preserving the prefab's inherited pitch.

--- a/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
+++ b/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
@@ -82,24 +82,30 @@ namespace S1API.Entities.Relation
         public NPCRelationshipDataBuilder WithConnectionsById(IEnumerable<string> ids)
         {
             _connectionIDs.Clear();
-            if (ids == null)
-            {
-                return this;
-            }
-            
-            int addedCount = 0;
-            foreach (var id in ids)
-            {
-                if (string.IsNullOrEmpty(id))
-                    continue;
-                if (!_connectionIDs.Contains(id, StringComparer.OrdinalIgnoreCase))
-                {
-                    _connectionIDs.Add(id);
-                    addedCount++;
-                }
-            }
-            
+            _connectionIDs.AddRange(NormalizeConnectionIds(ids));
+
             return this;
+        }
+
+        internal static IReadOnlyList<string> NormalizeConnectionIds(IEnumerable<string>? ids)
+        {
+            if (ids == null)
+                return Array.Empty<string>();
+
+            var normalized = new List<string>();
+            foreach (string? id in ids)
+            {
+                string value = id?.Trim() ?? string.Empty;
+                if (value.Length == 0
+                    || normalized.Contains(value, StringComparer.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                normalized.Add(value);
+            }
+
+            return normalized;
         }
 
         /// <summary>

--- a/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
+++ b/S1API/Entities/Relation/NPCRelationshipDataBuilder.cs
@@ -28,6 +28,7 @@ namespace S1API.Entities.Relation
         private bool? _unlocked;
         private NPCRelationship.UnlockType? _unlockType;
         private readonly List<string> _connectionIDs = new List<string>();
+        private bool _connectionsConfigured;
 
         /// <summary>
         /// Sets the relationship delta in [0, 5].
@@ -81,6 +82,7 @@ namespace S1API.Entities.Relation
         /// </summary>
         public NPCRelationshipDataBuilder WithConnectionsById(IEnumerable<string> ids)
         {
+            _connectionsConfigured = true;
             _connectionIDs.Clear();
             _connectionIDs.AddRange(NormalizeConnectionIds(ids));
 
@@ -160,6 +162,7 @@ namespace S1API.Entities.Relation
         /// </summary>
         public NPCRelationshipDataBuilder WithConnections(params System.Type?[]? npcTypes)
         {
+            _connectionsConfigured = true;
             _connectionIDs.Clear();
             if (npcTypes == null || npcTypes.Length == 0)
             {
@@ -227,7 +230,8 @@ namespace S1API.Entities.Relation
                 RelationDelta = _relationDelta,
                 Unlocked = _unlocked,
                 UnlockType = _unlockType,
-                ConnectionIDs = _connectionIDs.Count > 0 ? new List<string>(_connectionIDs) : null
+                ConnectionsConfigured = _connectionsConfigured,
+                ConnectionIDs = new List<string>(_connectionIDs)
             };
         }
 
@@ -251,7 +255,7 @@ namespace S1API.Entities.Relation
 
             try
             {
-                if (_connectionIDs.Count > 0)
+                if (_connectionsConfigured)
                 {
                     var registry = S1NPCs.NPCManager.NPCRegistry;
                     var targetList = relationData.Connections;
@@ -362,6 +366,7 @@ namespace S1API.Entities.Relation
             public float? RelationDelta;
             public bool? Unlocked;
             public NPCRelationship.UnlockType? UnlockType;
+            public bool ConnectionsConfigured;
             public List<string>? ConnectionIDs;
         }
     }

--- a/S1API/Internal/Entities/NPCDataAccess.cs
+++ b/S1API/Internal/Entities/NPCDataAccess.cs
@@ -218,14 +218,21 @@ namespace S1API.Internal.Entities
             if (dealer == null || data == null)
                 return false;
 
-            if (GetOriginalData(dealer) is not S1NPCFramework.DealerNPCData dealerData)
+            S1NPCFramework.NPCData? originalData = GetOriginalData(dealer);
+            if (originalData == null
+                || !CrossType.Is(originalData, out S1NPCFramework.DealerNPCData dealerData))
                 return false;
 
-            dealerData.SigningFee = data.SigningFee;
-            dealerData.SalesCutPercentage = data.Cut;
-            dealerData.DealerType = (S1Economy.EDealerType)(int)data.DealerType;
-            if (!string.IsNullOrWhiteSpace(data.HomeName))
-                dealerData.HomeName = data.HomeName;
+            ApplyDealerDefaults(dealerData, data);
+
+            S1NPCFramework.NPCData? currentData = GetCurrentData(dealer);
+            if (currentData != null
+                && CrossType.Is(currentData, out S1NPCFramework.DealerNPCData currentDealerData)
+                && !ReferenceEquals(currentDealerData, dealerData))
+            {
+                ApplyDealerDefaults(currentDealerData, data);
+            }
+
             return true;
         }
 
@@ -265,8 +272,19 @@ namespace S1API.Internal.Entities
             if (CrossType.Is(data, out S1NPCFramework.SupplierNPCData _))
                 EnsureSupplierDialogueDatabase(data, required: true);
 
-            if (data is S1NPCFramework.DealerNPCData dealerData)
-                PopulateDealerDialogueDefaults(dealerData);
+            if (CrossType.Is(data, out S1NPCFramework.DealerNPCData _))
+                EnsureDealerDialogueDefaults(npc, logFailure: false);
+        }
+
+        private static void ApplyDealerDefaults(
+            S1NPCFramework.DealerNPCData dealerData,
+            DealerDataBuilder.DealerConfigData data)
+        {
+            dealerData.SigningFee = data.SigningFee;
+            dealerData.SalesCutPercentage = data.Cut;
+            dealerData.DealerType = (S1Economy.EDealerType)(int)data.DealerType;
+            if (!string.IsNullOrWhiteSpace(data.HomeName))
+                dealerData.HomeName = data.HomeName;
         }
 
         private static void ApplySupplierDefaults(
@@ -588,33 +606,334 @@ namespace S1API.Internal.Entities
             }
         }
 
-        private static void PopulateDealerDialogueDefaults(S1NPCFramework.DealerNPCData dealerData)
+        internal static bool EnsureDealerDialogueDefaults(S1NPCs.NPC npc, bool logFailure = true)
         {
-            if (dealerData.RecruitDialogue != null
-                && dealerData.CollectCashDialogue != null
-                && dealerData.AssignCustomersDialogue != null)
+            if (npc == null)
+                return false;
+
+            var targets = new List<S1NPCFramework.DealerNPCData>();
+            AddDealerDataTarget(targets, GetOriginalData(npc));
+            AddDealerDataTarget(targets, GetCurrentData(npc));
+            if (npc is S1Economy.Dealer dealer && dealer.DealerData != null)
+                targets.Add(dealer.DealerData);
+
+            bool ready = targets.Count > 0;
+            foreach (S1NPCFramework.DealerNPCData target in targets)
+                ready &= PopulateDealerDialogueDefaults(target);
+
+            if (!ready && logFailure)
             {
-                return;
+                Logger.Error(
+                    $"Dealer '{GetId(npc)}' has no complete native dealer dialogue template. " +
+                    "Recruitment, cash collection, or customer assignment dialogue may be unavailable.");
+            }
+
+            return ready;
+        }
+
+        private static void AddDealerDataTarget(
+            ICollection<S1NPCFramework.DealerNPCData> targets,
+            S1NPCFramework.NPCData? data)
+        {
+            if (data != null
+                && CrossType.Is(data, out S1NPCFramework.DealerNPCData dealerData))
+            {
+                targets.Add(dealerData);
+            }
+        }
+
+        internal static bool HasCompleteDealerDialogueSet(
+            bool hasRecruitDialogue,
+            bool hasCollectCashDialogue,
+            bool hasAssignCustomersDialogue) =>
+            hasRecruitDialogue && hasCollectCashDialogue && hasAssignCustomersDialogue;
+
+        internal const string DealerRecruitDialogueName = "Supplier_Recruitment";
+        internal const string DealerCollectCashDialogueName = "Dealer_CollectCash";
+        internal const string DealerAssignCustomersDialogueName = "Dealer_AssignCustomers";
+
+        private static S1Dialogue.DialogueContainer? _fallbackRecruitDialogue;
+        private static S1Dialogue.DialogueContainer? _fallbackCollectCashDialogue;
+        private static S1Dialogue.DialogueContainer? _fallbackAssignCustomersDialogue;
+
+        private static bool PopulateDealerDialogueDefaults(S1NPCFramework.DealerNPCData dealerData)
+        {
+            if (HasCompleteDealerDialogueSet(
+                    dealerData.RecruitDialogue != null,
+                    dealerData.CollectCashDialogue != null,
+                    dealerData.AssignCustomersDialogue != null))
+                return true;
+
+            // DealerNPCDataObject assets are no longer reliably enumerated in 0.4.6, but the
+            // loaded native Dealer components still expose their complete current/original data.
+            foreach (S1Economy.Dealer donorDealer in
+                     Resources.FindObjectsOfTypeAll<S1Economy.Dealer>())
+            {
+                if (donorDealer == null)
+                    continue;
+
+                S1NPCFramework.DealerNPCData? source = donorDealer.DealerData;
+                if (source == null)
+                    TryGetDealerData(GetOriginalData(donorDealer), out source);
+                if (!TryCopyDealerDialogueDefaults(dealerData, source))
+                    continue;
+
+                return true;
             }
 
             S1NPCFramework.DealerNPCDataObject[] donors =
                 Resources.FindObjectsOfTypeAll<S1NPCFramework.DealerNPCDataObject>();
             foreach (S1NPCFramework.DealerNPCDataObject donor in donors)
             {
-                if (donor == null || donor.GetOriginalData() is not S1NPCFramework.DealerNPCData source)
+                if (donor == null)
                     continue;
 
-                dealerData.RecruitDialogue ??= source.RecruitDialogue;
-                dealerData.CollectCashDialogue ??= source.CollectCashDialogue;
-                dealerData.AssignCustomersDialogue ??= source.AssignCustomersDialogue;
+                TryGetDealerData(donor.GetOriginalData(), out S1NPCFramework.DealerNPCData? source);
+                if (source == null)
+                    TryGetDealerData(donor.GetRuntimeData(), out source);
+                if (!TryCopyDealerDialogueDefaults(dealerData, source))
+                    continue;
 
-                if (dealerData.RecruitDialogue != null
-                    && dealerData.CollectCashDialogue != null
-                    && dealerData.AssignCustomersDialogue != null)
-                {
-                    return;
-                }
+                return true;
             }
+
+            // 0.4.6 no longer guarantees that native DealerNPCDataObject assets are surfaced by
+            // FindObjectsOfTypeAll. Their referenced DialogueContainer assets are still loaded for
+            // base-game dealers, so resolve the same three vanilla assets by stable asset name.
+            S1Dialogue.DialogueContainer[] dialogues =
+                Resources.FindObjectsOfTypeAll<S1Dialogue.DialogueContainer>();
+            dealerData.RecruitDialogue ??=
+                FindDialogueContainer(dialogues, DealerRecruitDialogueName);
+            dealerData.CollectCashDialogue ??=
+                FindDialogueContainer(dialogues, DealerCollectCashDialogueName);
+            dealerData.AssignCustomersDialogue ??=
+                FindDialogueContainer(dialogues, DealerAssignCustomersDialogueName);
+
+            // On 0.4.6 the three containers can be absent from Unity's loaded-object set until a
+            // native dealer has already initialized. Custom NPCs spawn earlier than that in some
+            // saves, so preserve the native dialogue graph as an always-available final fallback.
+            dealerData.RecruitDialogue ??= GetFallbackRecruitDialogue();
+            dealerData.CollectCashDialogue ??= GetFallbackCollectCashDialogue();
+            dealerData.AssignCustomersDialogue ??= GetFallbackAssignCustomersDialogue();
+
+            bool ready = HasCompleteDealerDialogueSet(
+                dealerData.RecruitDialogue != null,
+                dealerData.CollectCashDialogue != null,
+                dealerData.AssignCustomersDialogue != null);
+            if (!ready)
+            {
+                Logger.Error(
+                    "[S1API][DealerDialogue] Failed to persist fallback containers on DealerNPCData. " +
+                    $"RecruitManagedNull={ReferenceEquals(dealerData.RecruitDialogue, null)}, " +
+                    $"CollectManagedNull={ReferenceEquals(dealerData.CollectCashDialogue, null)}, " +
+                    $"AssignManagedNull={ReferenceEquals(dealerData.AssignCustomersDialogue, null)}, " +
+                    $"FallbackRecruitManagedNull={ReferenceEquals(_fallbackRecruitDialogue, null)}, " +
+                    $"FallbackCollectManagedNull={ReferenceEquals(_fallbackCollectCashDialogue, null)}, " +
+                    $"FallbackAssignManagedNull={ReferenceEquals(_fallbackAssignCustomersDialogue, null)}.");
+            }
+
+            return ready;
+        }
+
+        private static bool TryGetDealerData(
+            S1NPCFramework.NPCData? data,
+            out S1NPCFramework.DealerNPCData? dealerData)
+        {
+            if (data != null
+                && CrossType.Is(data, out S1NPCFramework.DealerNPCData typedData))
+            {
+                dealerData = typedData;
+                return true;
+            }
+
+            dealerData = null;
+            return false;
+        }
+
+        private static bool TryCopyDealerDialogueDefaults(
+            S1NPCFramework.DealerNPCData target,
+            S1NPCFramework.DealerNPCData? source)
+        {
+            if (source == null
+                || !HasCompleteDealerDialogueSet(
+                    source.RecruitDialogue != null,
+                    source.CollectCashDialogue != null,
+                    source.AssignCustomersDialogue != null))
+            {
+                return false;
+            }
+
+            target.RecruitDialogue ??= source.RecruitDialogue;
+            target.CollectCashDialogue ??= source.CollectCashDialogue;
+            target.AssignCustomersDialogue ??= source.AssignCustomersDialogue;
+            return HasCompleteDealerDialogueSet(
+                target.RecruitDialogue != null,
+                target.CollectCashDialogue != null,
+                target.AssignCustomersDialogue != null);
+        }
+
+        private static S1Dialogue.DialogueContainer? FindDialogueContainer(
+            IEnumerable<S1Dialogue.DialogueContainer> dialogues,
+            string name) =>
+            dialogues.FirstOrDefault(dialogue =>
+                dialogue != null
+                && string.Equals(dialogue.name, name, StringComparison.Ordinal));
+
+        private static S1Dialogue.DialogueContainer GetFallbackRecruitDialogue()
+        {
+            if (_fallbackRecruitDialogue != null)
+                return _fallbackRecruitDialogue;
+
+            const string entryGuid = "e53bd440-29c4-4dce-a5cd-7415dcda83f8";
+            const string confirmGuid = "4854545e-b2f9-4cba-9703-94e68c058352";
+            const string exitGuid = "1575094b-13a3-4d54-9c06-136b571f8c51";
+            const string acceptedGuid = "dbffb23a-034f-4d0f-9815-36cc247335b6";
+
+            S1Dialogue.DialogueContainer dialogue = CreateDialogueContainer(
+                DealerRecruitDialogueName);
+            AddDialogueNode(
+                dialogue,
+                CreateDialogueNode(
+                    entryGuid,
+                    "Alright, I'll be a dealer for you but there is a <SIGNING_FEE> signing fee, " +
+                    "and I'll take a <CUT> cut of each sale. We got a deal?",
+                    "ENTRY",
+                    new Vector2(416f, 458f),
+                    CreateDialogueChoices(
+                        CreateDialogueChoice(confirmGuid, "Deal (<SIGNING_FEE>)", "CONFIRM"),
+                        CreateDialogueChoice(exitGuid, "Nevermind", string.Empty))));
+            AddDialogueNode(
+                dialogue,
+                CreateDialogueNode(
+                    acceptedGuid,
+                    "Thank you. Bring me some product and assign some customers to me, and I'll get to work.",
+                    string.Empty,
+                    new Vector2(1313f, 566f),
+                    CreateDialogueChoices()));
+            AddNodeLink(dialogue, entryGuid, confirmGuid, acceptedGuid);
+
+            _fallbackRecruitDialogue = dialogue;
+            return dialogue;
+        }
+
+        private static S1Dialogue.DialogueContainer GetFallbackCollectCashDialogue()
+        {
+            if (_fallbackCollectCashDialogue != null)
+                return _fallbackCollectCashDialogue;
+
+            S1Dialogue.DialogueContainer dialogue = CreateDialogueContainer(
+                DealerCollectCashDialogueName);
+            AddDialogueNode(
+                dialogue,
+                CreateDialogueNode(
+                    "4057413b-2c8a-411d-a9a0-d8e606558846",
+                    "No worries, here you are.",
+                    "ENTRY",
+                    new Vector2(765f, 412f),
+                    CreateDialogueChoices()));
+
+            _fallbackCollectCashDialogue = dialogue;
+            return dialogue;
+        }
+
+        private static S1Dialogue.DialogueContainer GetFallbackAssignCustomersDialogue()
+        {
+            if (_fallbackAssignCustomersDialogue != null)
+                return _fallbackAssignCustomersDialogue;
+
+            S1Dialogue.DialogueContainer dialogue = CreateDialogueContainer(
+                DealerAssignCustomersDialogueName);
+            AddDialogueNode(
+                dialogue,
+                CreateDialogueNode(
+                    "56a2eae5-0e64-4ca1-b296-148df22793f9",
+                    "You can assign customers to me with the dealer management app on your phone.",
+                    "ENTRY",
+                    new Vector2(622f, 287f),
+                    CreateDialogueChoices()));
+
+            _fallbackAssignCustomersDialogue = dialogue;
+            return dialogue;
+        }
+
+        private static S1Dialogue.DialogueContainer CreateDialogueContainer(string name)
+        {
+            S1Dialogue.DialogueContainer dialogue =
+                ScriptableObject.CreateInstance<S1Dialogue.DialogueContainer>();
+            if (dialogue == null)
+                throw new InvalidOperationException($"Failed to create dealer dialogue '{name}'.");
+
+            dialogue.name = name;
+            dialogue.hideFlags = HideFlags.DontUnloadUnusedAsset;
+            return dialogue;
+        }
+
+        private static S1Dialogue.DialogueNodeData CreateDialogueNode(
+            string guid,
+            string text,
+            string label,
+            Vector2 position,
+#if IL2CPPMELON
+            Il2CppReferenceArray<S1Dialogue.DialogueChoiceData> choices)
+#else
+            S1Dialogue.DialogueChoiceData[] choices)
+#endif
+        {
+            return new S1Dialogue.DialogueNodeData
+            {
+                Guid = guid,
+                DialogueText = text,
+                DialogueNodeLabel = label,
+                Position = position,
+                choices = choices,
+                VoiceLine = (S1VoiceOver.EVOLineType)0
+            };
+        }
+
+        private static S1Dialogue.DialogueChoiceData CreateDialogueChoice(
+            string guid,
+            string text,
+            string label) =>
+            new S1Dialogue.DialogueChoiceData
+            {
+                Guid = guid,
+                ChoiceText = text,
+                ChoiceLabel = label,
+                ShowWorldspaceDialogue = true
+            };
+
+#if IL2CPPMELON
+        private static Il2CppReferenceArray<S1Dialogue.DialogueChoiceData> CreateDialogueChoices(
+            params S1Dialogue.DialogueChoiceData[] choices)
+        {
+            var result = new Il2CppReferenceArray<S1Dialogue.DialogueChoiceData>(choices.Length);
+            for (int i = 0; i < choices.Length; i++)
+                result[i] = choices[i];
+            return result;
+        }
+#else
+        private static S1Dialogue.DialogueChoiceData[] CreateDialogueChoices(
+            params S1Dialogue.DialogueChoiceData[] choices) => choices;
+#endif
+
+        private static void AddDialogueNode(
+            S1Dialogue.DialogueContainer dialogue,
+            S1Dialogue.DialogueNodeData node) =>
+            dialogue.DialogueNodeData.Add(node);
+
+        private static void AddNodeLink(
+            S1Dialogue.DialogueContainer dialogue,
+            string baseNodeGuid,
+            string baseChoiceGuid,
+            string targetNodeGuid)
+        {
+            dialogue.NodeLinks.Add(
+                new S1Dialogue.NodeLinkData
+                {
+                    BaseDialogueOrBranchNodeGuid = baseNodeGuid,
+                    BaseChoiceOrOptionGUID = baseChoiceGuid,
+                    TargetNodeGuid = targetNodeGuid
+                });
         }
     }
 }

--- a/S1API/Internal/Entities/NPCDataAccess.cs
+++ b/S1API/Internal/Entities/NPCDataAccess.cs
@@ -614,7 +614,8 @@ namespace S1API.Internal.Entities
             var targets = new List<S1NPCFramework.DealerNPCData>();
             AddDealerDataTarget(targets, GetOriginalData(npc));
             AddDealerDataTarget(targets, GetCurrentData(npc));
-            if (npc is S1Economy.Dealer dealer && dealer.DealerData != null)
+            if (CrossType.Is(npc, out S1Economy.Dealer dealer)
+                && dealer.DealerData != null)
                 targets.Add(dealer.DealerData);
 
             bool ready = targets.Count > 0;
@@ -648,6 +649,7 @@ namespace S1API.Internal.Entities
             bool hasAssignCustomersDialogue) =>
             hasRecruitDialogue && hasCollectCashDialogue && hasAssignCustomersDialogue;
 
+        // Despite the dealer context, this is the stable name of the vanilla recruitment asset.
         internal const string DealerRecruitDialogueName = "Supplier_Recruitment";
         internal const string DealerCollectCashDialogueName = "Dealer_CollectCash";
         internal const string DealerAssignCustomersDialogueName = "Dealer_AssignCustomers";
@@ -655,6 +657,9 @@ namespace S1API.Internal.Entities
         private static S1Dialogue.DialogueContainer? _fallbackRecruitDialogue;
         private static S1Dialogue.DialogueContainer? _fallbackCollectCashDialogue;
         private static S1Dialogue.DialogueContainer? _fallbackAssignCustomersDialogue;
+        private static S1Dialogue.DialogueContainer? _cachedRecruitDialogue;
+        private static S1Dialogue.DialogueContainer? _cachedCollectCashDialogue;
+        private static S1Dialogue.DialogueContainer? _cachedAssignCustomersDialogue;
 
         private static bool PopulateDealerDialogueDefaults(S1NPCFramework.DealerNPCData dealerData)
         {
@@ -662,6 +667,12 @@ namespace S1API.Internal.Entities
                     dealerData.RecruitDialogue != null,
                     dealerData.CollectCashDialogue != null,
                     dealerData.AssignCustomersDialogue != null))
+            {
+                CacheDealerDialogueDefaults(dealerData);
+                return true;
+            }
+
+            if (TryCopyCachedDealerDialogueDefaults(dealerData))
                 return true;
 
             // DealerNPCDataObject assets are no longer reliably enumerated in 0.4.6, but the
@@ -678,6 +689,7 @@ namespace S1API.Internal.Entities
                 if (!TryCopyDealerDialogueDefaults(dealerData, source))
                     continue;
 
+                CacheDealerDialogueDefaults(source!);
                 return true;
             }
 
@@ -694,6 +706,7 @@ namespace S1API.Internal.Entities
                 if (!TryCopyDealerDialogueDefaults(dealerData, source))
                     continue;
 
+                CacheDealerDialogueDefaults(source!);
                 return true;
             }
 
@@ -702,19 +715,25 @@ namespace S1API.Internal.Entities
             // base-game dealers, so resolve the same three vanilla assets by stable asset name.
             S1Dialogue.DialogueContainer[] dialogues =
                 Resources.FindObjectsOfTypeAll<S1Dialogue.DialogueContainer>();
-            dealerData.RecruitDialogue ??=
-                FindDialogueContainer(dialogues, DealerRecruitDialogueName);
-            dealerData.CollectCashDialogue ??=
-                FindDialogueContainer(dialogues, DealerCollectCashDialogueName);
-            dealerData.AssignCustomersDialogue ??=
-                FindDialogueContainer(dialogues, DealerAssignCustomersDialogueName);
+            if (dealerData.RecruitDialogue == null)
+                dealerData.RecruitDialogue =
+                    FindDialogueContainer(dialogues, DealerRecruitDialogueName);
+            if (dealerData.CollectCashDialogue == null)
+                dealerData.CollectCashDialogue =
+                    FindDialogueContainer(dialogues, DealerCollectCashDialogueName);
+            if (dealerData.AssignCustomersDialogue == null)
+                dealerData.AssignCustomersDialogue =
+                    FindDialogueContainer(dialogues, DealerAssignCustomersDialogueName);
 
             // On 0.4.6 the three containers can be absent from Unity's loaded-object set until a
             // native dealer has already initialized. Custom NPCs spawn earlier than that in some
             // saves, so preserve the native dialogue graph as an always-available final fallback.
-            dealerData.RecruitDialogue ??= GetFallbackRecruitDialogue();
-            dealerData.CollectCashDialogue ??= GetFallbackCollectCashDialogue();
-            dealerData.AssignCustomersDialogue ??= GetFallbackAssignCustomersDialogue();
+            if (dealerData.RecruitDialogue == null)
+                dealerData.RecruitDialogue = GetFallbackRecruitDialogue();
+            if (dealerData.CollectCashDialogue == null)
+                dealerData.CollectCashDialogue = GetFallbackCollectCashDialogue();
+            if (dealerData.AssignCustomersDialogue == null)
+                dealerData.AssignCustomersDialogue = GetFallbackAssignCustomersDialogue();
 
             bool ready = HasCompleteDealerDialogueSet(
                 dealerData.RecruitDialogue != null,
@@ -731,8 +750,52 @@ namespace S1API.Internal.Entities
                     $"FallbackCollectManagedNull={ReferenceEquals(_fallbackCollectCashDialogue, null)}, " +
                     $"FallbackAssignManagedNull={ReferenceEquals(_fallbackAssignCustomersDialogue, null)}.");
             }
+            else
+            {
+                CacheDealerDialogueDefaults(dealerData);
+            }
 
             return ready;
+        }
+
+        private static bool TryCopyCachedDealerDialogueDefaults(
+            S1NPCFramework.DealerNPCData target)
+        {
+            if (!HasCompleteDealerDialogueSet(
+                    _cachedRecruitDialogue != null,
+                    _cachedCollectCashDialogue != null,
+                    _cachedAssignCustomersDialogue != null))
+            {
+                return false;
+            }
+
+            if (target.RecruitDialogue == null)
+                target.RecruitDialogue = _cachedRecruitDialogue;
+            if (target.CollectCashDialogue == null)
+                target.CollectCashDialogue = _cachedCollectCashDialogue;
+            if (target.AssignCustomersDialogue == null)
+                target.AssignCustomersDialogue = _cachedAssignCustomersDialogue;
+
+            return HasCompleteDealerDialogueSet(
+                target.RecruitDialogue != null,
+                target.CollectCashDialogue != null,
+                target.AssignCustomersDialogue != null);
+        }
+
+        private static void CacheDealerDialogueDefaults(
+            S1NPCFramework.DealerNPCData source)
+        {
+            if (!HasCompleteDealerDialogueSet(
+                    source.RecruitDialogue != null,
+                    source.CollectCashDialogue != null,
+                    source.AssignCustomersDialogue != null))
+            {
+                return;
+            }
+
+            _cachedRecruitDialogue = source.RecruitDialogue;
+            _cachedCollectCashDialogue = source.CollectCashDialogue;
+            _cachedAssignCustomersDialogue = source.AssignCustomersDialogue;
         }
 
         private static bool TryGetDealerData(
@@ -763,9 +826,12 @@ namespace S1API.Internal.Entities
                 return false;
             }
 
-            target.RecruitDialogue ??= source.RecruitDialogue;
-            target.CollectCashDialogue ??= source.CollectCashDialogue;
-            target.AssignCustomersDialogue ??= source.AssignCustomersDialogue;
+            if (target.RecruitDialogue == null)
+                target.RecruitDialogue = source.RecruitDialogue;
+            if (target.CollectCashDialogue == null)
+                target.CollectCashDialogue = source.CollectCashDialogue;
+            if (target.AssignCustomersDialogue == null)
+                target.AssignCustomersDialogue = source.AssignCustomersDialogue;
             return HasCompleteDealerDialogueSet(
                 target.RecruitDialogue != null,
                 target.CollectCashDialogue != null,
@@ -886,7 +952,7 @@ namespace S1API.Internal.Entities
                 DialogueNodeLabel = label,
                 Position = position,
                 choices = choices,
-                VoiceLine = (S1VoiceOver.EVOLineType)0
+                VoiceLine = S1VoiceOver.EVOLineType.None
             };
         }
 
@@ -918,8 +984,20 @@ namespace S1API.Internal.Entities
 
         private static void AddDialogueNode(
             S1Dialogue.DialogueContainer dialogue,
-            S1Dialogue.DialogueNodeData node) =>
+            S1Dialogue.DialogueNodeData node)
+        {
+            if (dialogue.DialogueNodeData == null)
+            {
+#if IL2CPPMELON
+                dialogue.DialogueNodeData =
+                    new Il2CppSystem.Collections.Generic.List<S1Dialogue.DialogueNodeData>();
+#else
+                dialogue.DialogueNodeData = new List<S1Dialogue.DialogueNodeData>();
+#endif
+            }
+
             dialogue.DialogueNodeData.Add(node);
+        }
 
         private static void AddNodeLink(
             S1Dialogue.DialogueContainer dialogue,
@@ -927,6 +1005,16 @@ namespace S1API.Internal.Entities
             string baseChoiceGuid,
             string targetNodeGuid)
         {
+            if (dialogue.NodeLinks == null)
+            {
+#if IL2CPPMELON
+                dialogue.NodeLinks =
+                    new Il2CppSystem.Collections.Generic.List<S1Dialogue.NodeLinkData>();
+#else
+                dialogue.NodeLinks = new List<S1Dialogue.NodeLinkData>();
+#endif
+            }
+
             dialogue.NodeLinks.Add(
                 new S1Dialogue.NodeLinkData
                 {

--- a/S1API/Internal/Entities/NPCPrefabIdentity.cs
+++ b/S1API/Internal/Entities/NPCPrefabIdentity.cs
@@ -941,6 +941,17 @@ namespace S1API.Internal.Entities
             }
         }
 
+#if IL2CPPMELON
+        [HideFromIl2Cpp]
+#endif
+        internal IReadOnlyList<string> GetConfiguredConnectionIds()
+        {
+            EnsureRelationshipDataFromRegistry();
+            return _connectionIds == null
+                ? Array.Empty<string>()
+                : new List<string>(_connectionIds);
+        }
+
         internal bool ApplyAppearanceTo(S1NPCs.NPC npc, S1AvatarFramework.Avatar avatar)
         {
             if (npc == null || avatar == null)

--- a/S1API/Internal/Entities/NPCPrefabIdentity.cs
+++ b/S1API/Internal/Entities/NPCPrefabIdentity.cs
@@ -47,6 +47,7 @@ namespace S1API.Internal.Entities
         private string? _dealerHomeBuildingName;
         private string? _prefabName;
         private List<string>? _connectionIds;
+        private bool _hasConfiguredConnections;
         private string? _voiceId;
         private bool _hasVoicePitch;
         private float _voicePitch;
@@ -60,6 +61,7 @@ namespace S1API.Internal.Entities
         [SerializeField] private string? _dealerHomeBuildingName;
         [SerializeField] private string? _prefabName;
         [SerializeField] private List<string>? _connectionIds;
+        [SerializeField] private bool _hasConfiguredConnections;
         [SerializeField] private string? _voiceId;
         [SerializeField] private bool _hasVoicePitch;
         [SerializeField] private float _voicePitch;
@@ -174,6 +176,7 @@ namespace S1API.Internal.Entities
             internal float? RelationDelta;
             internal bool? Unlocked;
             internal int? UnlockType; // Stored as int (0=Recommendation, 1=DirectApproach) to avoid enum dependency
+            internal bool HasConfiguredConnections;
             internal List<string>? ConnectionIDs;
             internal string? PrefabName;
             internal string? VoiceId;
@@ -227,8 +230,9 @@ namespace S1API.Internal.Entities
                 float? relationDelta = snapshot?.RelationDelta;
                 bool? unlocked = snapshot?.Unlocked;
                 NPCRelationship.UnlockType? unlockType = snapshot?.UnlockType;
-                List<string>? connectionIDs = snapshot?.ConnectionIDs != null && snapshot.ConnectionIDs.Count > 0
-                    ? new List<string>(snapshot.ConnectionIDs)
+                bool hasConfiguredConnections = snapshot?.ConnectionsConfigured == true;
+                List<string>? connectionIDs = hasConfiguredConnections
+                    ? new List<string>(snapshot?.ConnectionIDs ?? new List<string>())
                     : null;
 
                 // Get or create identity data entry
@@ -245,8 +249,11 @@ namespace S1API.Internal.Entities
                     updatedData.Unlocked = unlocked;
                 if (unlockType.HasValue)
                     updatedData.UnlockType = (int?)unlockType.Value;
-                if (connectionIDs != null && connectionIDs.Count > 0)
-                    updatedData.ConnectionIDs = new List<string>(connectionIDs);
+                if (hasConfiguredConnections)
+                {
+                    updatedData.HasConfiguredConnections = true;
+                    updatedData.ConnectionIDs = new List<string>(connectionIDs!);
+                }
 
                 _registry[normalizedName] = updatedData;
             }
@@ -318,17 +325,18 @@ namespace S1API.Internal.Entities
                 }
                 
                 // ALWAYS preserve connection IDs from registry if they exist (they come from RegisterRelationshipDataToStaticCache)
-                if (existingData.ConnectionIDs != null && existingData.ConnectionIDs.Count > 0)
+                if (existingData.HasConfiguredConnections)
                 {
-                    connectionIDs = new List<string>(existingData.ConnectionIDs);
+                    connectionIDs = new List<string>(
+                        existingData.ConnectionIDs ?? new List<string>());
                 }
             }
             
             // Only use component field if registry doesn't have connection IDs
             // (Component field is typically empty during prefab configuration, but check it as fallback)
-            if ((connectionIDs == null || connectionIDs.Count == 0) && _connectionIds != null && _connectionIds.Count > 0)
+            if (connectionIDs == null && _hasConfiguredConnections)
             {
-                connectionIDs = new List<string>(_connectionIds);
+                connectionIDs = new List<string>(_connectionIds ?? new List<string>());
             }
 
             var identityData = new IdentityData
@@ -343,6 +351,7 @@ namespace S1API.Internal.Entities
                 RelationDelta = relationDelta,
                 Unlocked = unlocked,
                 UnlockType = unlockType,
+                HasConfiguredConnections = connectionIDs != null,
                 ConnectionIDs = connectionIDs,
                 PrefabName = normalizedName,
                 VoiceId = VoiceId,
@@ -453,6 +462,7 @@ namespace S1API.Internal.Entities
                 this.RelationDelta = dataRef.RelationDelta;
                 this.Unlocked = dataRef.Unlocked;
                 this.UnlockType = dataRef.UnlockType.HasValue ? (NPCRelationship.UnlockType?)dataRef.UnlockType.Value : null;
+                _hasConfiguredConnections = dataRef.HasConfiguredConnections;
                 _connectionIds = dataRef.ConnectionIDs != null ? new List<string>(dataRef.ConnectionIDs) : null;
                 PrefabName = dataRef.PrefabName ?? PrefabName;
                 if (string.IsNullOrEmpty(VoiceId) && !string.IsNullOrEmpty(dataRef.VoiceId))
@@ -608,10 +618,9 @@ namespace S1API.Internal.Entities
                 if (UnlockType.HasValue)
                     builder.SetUnlockType(UnlockType.Value);
 
-                if (_connectionIds != null && _connectionIds.Count > 0)
-                {
-                    builder.WithConnectionsById(_connectionIds);
-                }
+                if (_hasConfiguredConnections)
+                    builder.WithConnectionsById(
+                        (IEnumerable<string>?)_connectionIds ?? Array.Empty<string>());
 
                 builder.ApplyTo(relationData, npc, preserveUnlockState);
             }
@@ -926,13 +935,14 @@ namespace S1API.Internal.Entities
                 return;
 
             EnsureRelationshipDataFromRegistry();
-            if (_connectionIds == null || _connectionIds.Count == 0)
+            if (!_hasConfiguredConnections)
                 return;
 
             try
             {
                 var builder = new NPCRelationshipDataBuilder();
-                builder.WithConnectionsById(_connectionIds);
+                builder.WithConnectionsById(
+                    (IEnumerable<string>?)_connectionIds ?? Array.Empty<string>());
                 builder.ApplyTo(npc.RelationData, npc, preserveUnlockState: true);
             }
             catch (Exception ex)
@@ -950,6 +960,12 @@ namespace S1API.Internal.Entities
             return _connectionIds == null
                 ? Array.Empty<string>()
                 : new List<string>(_connectionIds);
+        }
+
+        internal bool HasConfiguredConnections()
+        {
+            EnsureRelationshipDataFromRegistry();
+            return _hasConfiguredConnections;
         }
 
         internal bool ApplyAppearanceTo(S1NPCs.NPC npc, S1AvatarFramework.Avatar avatar)

--- a/S1API/Internal/Entities/NPCRelationshipGraphPolicy.cs
+++ b/S1API/Internal/Entities/NPCRelationshipGraphPolicy.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace S1API.Internal.Entities
+{
+    internal static class NPCRelationshipGraphPolicy
+    {
+        internal static IReadOnlyList<string> BuildUndirectedConnectionIds(
+            string ownerId,
+            IReadOnlyDictionary<string, IReadOnlyList<string>> declarations)
+        {
+            if (string.IsNullOrWhiteSpace(ownerId) || declarations == null)
+                return Array.Empty<string>();
+
+            var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (declarations.TryGetValue(ownerId, out IReadOnlyList<string>? outgoing))
+            {
+                foreach (string id in outgoing)
+                {
+                    if (!string.IsNullOrWhiteSpace(id)
+                        && !string.Equals(id, ownerId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Add(id);
+                    }
+                }
+            }
+
+            foreach (KeyValuePair<string, IReadOnlyList<string>> declaration in declarations)
+            {
+                if (string.Equals(declaration.Key, ownerId, StringComparison.OrdinalIgnoreCase)
+                    || declaration.Value == null
+                    || !declaration.Value.Contains(ownerId, StringComparer.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                result.Add(declaration.Key);
+            }
+
+            return result.OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToArray();
+        }
+    }
+}

--- a/S1API/Internal/Patches/ContactsAppPatches.cs
+++ b/S1API/Internal/Patches/ContactsAppPatches.cs
@@ -71,6 +71,32 @@ namespace S1API.Internal.Patches
             _hasCustomNpcTypesCache = null;
         }
 
+        internal static void RefreshContactIcon(S1NPCs.NPC npc)
+        {
+            if (npc == null || string.IsNullOrWhiteSpace(npc.ID))
+                return;
+
+            try
+            {
+                foreach (S1Relations.RelationCircle circle in
+                         Object.FindObjectsOfType<S1Relations.RelationCircle>(true))
+                {
+                    if (!string.Equals(
+                            GetAssignedNpcId(circle),
+                            npc.ID,
+                            global::System.StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    SetAssignedNpc(circle, npc);
+                    circle.AssignNPC(npc);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Logger.Warning($"Could not refresh Contacts icon for NPC '{npc.ID}': {ex.Message}");
+            }
+        }
+
         /// <summary>
         /// Checks if any custom NPC types exist (excluding S1API internal types).
         /// Caches the result to avoid repeated reflection calls.
@@ -166,9 +192,10 @@ namespace S1API.Internal.Patches
             yield return null;
             yield return null;
 
-            // Wait for mugshots to be generated before creating circles
-            // This ensures HeadshotImg.sprite gets the correct mugshot, not the default icon
-            yield return new WaitUntil((Func<bool>)(() => NPCAppearance.MugshotsProcessingComplete));
+            // Wait per NPC rather than using only the global queue. Explicit-icon NPC sets
+            // never enqueue a mugshot, while early-generated NPCs may enqueue before the rig exists.
+            yield return new WaitUntil((Func<bool>)(() =>
+                customNPCs.All(npc => npc.Appearance.MugshotReady)));
 
             // Add circles after native Start so they are not processed as serialized native circles.
             AddRelationCircles(contactsApp);
@@ -207,7 +234,12 @@ namespace S1API.Internal.Patches
                 var existing = regionUI.Container.GetComponentsInChildren<S1Relations.RelationCircle>(true)
                     .FirstOrDefault(c => GetAssignedNpcId(c) == npc.S1NPC.ID);
                 if (existing != null)
+                {
+                    SetAssignedNpc(existing, npc.S1NPC);
+                    existing.AssignNPC(npc.S1NPC);
+                    ApplyRoleIndicators(existing, npc.GetType());
                     continue;
+                }
 
                 // Find a base game template - exclude circles we've already created
                 var allCirclesInRegion = regionUI.Container.GetComponentsInChildren<S1Relations.RelationCircle>(true);

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -946,6 +946,26 @@ namespace S1API.Internal.Patches
             return true;
         }
 
+        [HarmonyPatch(typeof(S1Economy.Dealer), "SetUpDialogue")]
+        [HarmonyPrefix]
+        [HarmonyPriority(Priority.First)]
+        private static void Dealer_SetUpDialogue_Prefix(S1Economy.Dealer __instance)
+        {
+            if (!IsS1ApiCustomNpcComponent(__instance))
+                return;
+
+            try
+            {
+                NPCDataAccess.EnsureDealerDialogueDefaults(__instance);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(
+                    $"Dealer_SetUpDialogue_Prefix: Failed to repair dealer dialogue for " +
+                    $"'{__instance?.ID ?? "<unknown>"}': {ex.Message}");
+            }
+        }
+
         internal static bool IsS1ApiCustomNpcComponent(Component component)
         {
             if (component == null)

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -49,6 +49,7 @@
         <Reference Include="$(Il2CppAssembliesPath)\Il2Cppmscorlib.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.CoreModule.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.AnimationModule.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.UI.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.InputLegacyModule.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.IMGUIModule.dll" />
@@ -79,6 +80,9 @@
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
             <HintPath>$(MonoAssembliesPath)/UnityEngine.CoreModule.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.AnimationModule">
+            <HintPath>$(MonoAssembliesPath)/UnityEngine.AnimationModule.dll</HintPath>
         </Reference>
         <Reference Include="FishNet.Runtime">
             <HintPath>$(MonoAssembliesPath)/FishNet.Runtime.dll</HintPath>


### PR DESCRIPTION
## Summary

- restore custom dealer recruitment by populating the native dealer dialogue data used by the confirmation callback
- reconcile custom NPC relationship connections after spawning and refresh generated portraits in existing Contacts entries
- give dealers an independent home event and native deal priority so consumer schedules cannot drive them into building loops
- isolate and normalize the shared mugshot rig so portraits remain distinct, correctly framed, and forward-facing

## Root cause

The 0.4.6 NPC rewrite removed the prefab and lifecycle assumptions used by the older custom-NPC path. In particular, IL2CPP could expose dealer data through a base native wrapper, causing ordinary C# casts to skip dealer configuration and dialogue setup. Dealer home behavior could also reuse a consumer schedule's `StayInBuilding` action, allowing native dealer ticks and the schedule to repeatedly command the same door action.

The portrait pipeline still temporarily coupled the shared mugshot rig to live NPC state. New LOD, look/IK, animation, and Contacts timing could therefore capture impostors, duplicate an earlier icon, steer pupils away from the camera, or reset the rig to an undersized prefab pose.

## Implementation

- use native-aware dealer-data resolution and provide faithful runtime dialogue fallbacks when no loaded native donor exists
- synchronize runtime/original dealer data before native dialogue setup
- create a dedicated dealer home action and preserve the base game's behavior priorities
- normalize and reconcile declared relationship IDs into a symmetric runtime graph
- queue mugshots until the native generator exists, track completion per NPC, and update already-created Contacts UI entries
- detach the preview rig from live NPCs, freeze look/IK and blinking, reset the animator before applying appearance data, enforce canonical scale, and restore shared rig state after capture
- reject incomplete or underframed portrait textures instead of assigning them

## Compatibility

- preserves the existing public NPC/dealer API and save/network payloads
- builds and runs through the native-aware seams on both MonoMelon and Il2CppMelon

## Documentation

- no public documentation changes are required; this PR repairs internal lifecycle behavior without changing modder-facing signatures
## Validation

- Mono focused dealer/mugshot policies: 21/21 passed
- IL2CPP focused dealer/mugshot policies: 21/21 passed
- Mono disposable-save smoke: recruitment `CONFIRM` callback, connections, dedicated home event, behavior priorities, and distinct portraits passed
- IL2CPP disposable-save smoke: the same lifecycle checks passed
- final visual export on both runtimes: 5 portraits, 5 distinct textures, measured content-height range 456-474 px
- all ten generated 512x512 PNGs were opened and visually inspected for proportions, gaze, clipping, and impostor artifacts
- `CustomNPCTest` built successfully for Mono and IL2CPP
- `git diff --check` passed

The disposable saves, probe assemblies, logs, and proprietary game artifacts were kept out of the repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable custom NPC dealer dialogue, including fallback dialogue when native assets are unavailable.
  * Improved dealer home-event setup and deal-priority behavior.
  * Added stronger relationship synchronization between custom NPCs, including preserved unlock states.
  * Improved contact icons and role indicators for NPCs.

* **Bug Fixes**
  * Mugshot generation now handles queued requests, validates image quality, and preserves existing icons when captures fail.
  * Improved relationship ID cleanup and duplicate handling.
  * NPC readiness now waits for each individual mugshot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->