### PR TITLE
chore(release): publish S1API 3.1.10

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -11,7 +11,7 @@ using S1API.Internal.Rendering;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.9", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.10", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.9</Version>
+        <Version>3.1.10</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- bump the S1API project package version to 3.1.10
- align the MelonInfo assembly metadata with 3.1.10
- prepare the stable release branch from the current `origin/stable` commit

## Compatibility

- public and protected API shape: unchanged by this release commit
- durable IDs, save formats, and network payloads: unchanged by this release commit
- runtime behavior: unchanged by this release commit

## Validation

- MonoMelon solution build: passed, 0 warnings
- MonoMelon tests: 474/474 passed
- Il2CppMelon solution build: passed, 0 warnings
- Il2CppMelon tests: 356 passed before the local test host aborted because native `GameAssembly` is unavailable; hosted CI remains the full IL2CPP gate
- generated NuGet package version: 3.1.10
- git diff --check: passed