### PR TITLE
fix(npc): respect customer property and follow boundaries

### DIFF
--- a/S1API.Tests/Entities/CustomNpcRequestProductPolicyTests.cs
+++ b/S1API.Tests/Entities/CustomNpcRequestProductPolicyTests.cs
@@ -1,0 +1,114 @@
+using System.Reflection;
+using NumericsVector3 = System.Numerics.Vector3;
+using UnityEngine;
+
+namespace S1API.Tests.Entities;
+
+public sealed class CustomNpcRequestProductPolicyTests
+{
+    [Fact]
+    public void BaseEmployeeNavigation_ExcludesPropertyInteriorOnly()
+    {
+        const int baseEmployeeMask = 57;
+        const int propertyInteriorArea = 5;
+
+        int normalizedMask = global::S1API.Entities.NPC.ExcludeNavMeshArea(
+            baseEmployeeMask,
+            propertyInteriorArea);
+
+        int civilianMask = global::S1API.Entities.NPC.IncludeNavMeshArea(normalizedMask, 7);
+
+        Assert.Equal(153, civilianMask);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(32)]
+    public void BaseEmployeeNavigation_IgnoresInvalidAreaIndices(int areaIndex)
+    {
+        Assert.Equal(57, global::S1API.Entities.NPC.ExcludeNavMeshArea(57, areaIndex));
+    }
+
+    [Fact]
+    public void FollowDestination_KeepsCustomNpcOutsidePlayerSpace()
+    {
+        bool overridden = global::S1API.Internal.Patches.NPCPatches.TryCalculateCustomNpcFollowDestination(
+            isCustomNpc: true,
+            isFollowingPlayer: true,
+            playerPosition: NumericsVector3.Zero,
+            npcPosition: new NumericsVector3(4f, 0f, 0f),
+            fallbackDirection: -NumericsVector3.UnitZ,
+            out NumericsVector3 destination);
+
+        Assert.True(overridden);
+        Assert.Equal(new NumericsVector3(2.5f, 0f, 0f), destination);
+    }
+
+    [Fact]
+    public void FollowDestination_UsesFallbackWhenNpcOverlapsPlayer()
+    {
+        bool overridden = global::S1API.Internal.Patches.NPCPatches.TryCalculateCustomNpcFollowDestination(
+            isCustomNpc: true,
+            isFollowingPlayer: true,
+            playerPosition: NumericsVector3.Zero,
+            npcPosition: NumericsVector3.Zero,
+            fallbackDirection: -NumericsVector3.UnitZ,
+            out NumericsVector3 destination);
+
+        Assert.True(overridden);
+        Assert.Equal(new NumericsVector3(0f, 0f, -2.5f), destination);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void FollowDestination_PreservesNativeBehaviourOutsideCustomFollowPhase(
+        bool isCustomNpc,
+        bool isFollowingPlayer)
+    {
+        bool overridden = global::S1API.Internal.Patches.NPCPatches.TryCalculateCustomNpcFollowDestination(
+            isCustomNpc,
+            isFollowingPlayer,
+            NumericsVector3.Zero,
+            NumericsVector3.UnitX,
+            -NumericsVector3.UnitZ,
+            out _);
+
+        Assert.False(overridden);
+    }
+
+    [Fact]
+    public void DestinationPatchLookup_UsesTheByValueVectorSignature()
+    {
+        MethodBase? method = global::S1API.Internal.Patches.NPCPatches
+            .FindNpcMovementDestinationMethod(typeof(NpcMovementFixture));
+
+        Assert.NotNull(method);
+        Assert.Equal(nameof(NpcMovementFixture.SetDestination), method!.Name);
+        Assert.False(method.GetParameters()[0].ParameterType.IsByRef);
+    }
+
+    [Fact]
+    public void DestinationPatch_AvoidsIl2CppOutParameterMethods()
+    {
+        Type? patchType = typeof(global::S1API.Internal.Patches.NPCPatches).GetNestedType(
+            "RequestProductMovementDestinationPatch",
+            BindingFlags.NonPublic);
+        MethodInfo? prefix = patchType?.GetMethod(
+            "Prefix",
+            BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(prefix);
+        Assert.Contains(
+            prefix!.GetCustomAttributesData(),
+            attribute => attribute.AttributeType.FullName == "HarmonyLib.HarmonyPrefix");
+        Assert.Null(patchType!.GetMethod("Postfix", BindingFlags.Static | BindingFlags.NonPublic));
+    }
+
+    private sealed class NpcMovementFixture
+    {
+        public void SetDestination(Vector3 destination) { }
+
+        public void SetDestination(Vector3 destination, Action<bool> callback) { }
+    }
+}

--- a/S1API.Tests/Entities/CustomNpcRequestProductPolicyTests.cs
+++ b/S1API.Tests/Entities/CustomNpcRequestProductPolicyTests.cs
@@ -29,6 +29,14 @@ public sealed class CustomNpcRequestProductPolicyTests
         Assert.Equal(57, global::S1API.Entities.NPC.ExcludeNavMeshArea(57, areaIndex));
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(32)]
+    public void BaseEmployeeNavigation_IncludeIgnoresInvalidAreaIndices(int areaIndex)
+    {
+        Assert.Equal(57, global::S1API.Entities.NPC.IncludeNavMeshArea(57, areaIndex));
+    }
+
     [Fact]
     public void FollowDestination_KeepsCustomNpcOutsidePlayerSpace()
     {
@@ -57,6 +65,84 @@ public sealed class CustomNpcRequestProductPolicyTests
 
         Assert.True(overridden);
         Assert.Equal(new NumericsVector3(0f, 0f, -2.5f), destination);
+    }
+
+    [Fact]
+    public void FollowDestination_UsesNegativeZWhenNpcAndFallbackDirectionsAreZero()
+    {
+        bool overridden = global::S1API.Internal.Patches.NPCPatches.TryCalculateCustomNpcFollowDestination(
+            isCustomNpc: true,
+            isFollowingPlayer: true,
+            playerPosition: NumericsVector3.Zero,
+            npcPosition: NumericsVector3.Zero,
+            fallbackDirection: NumericsVector3.Zero,
+            out NumericsVector3 destination);
+
+        Assert.True(overridden);
+        Assert.Equal(new NumericsVector3(0f, 0f, -2.5f), destination);
+    }
+
+    [Fact]
+    public void PropertyApproachDestination_UsesOwnedPropertyExteriorSpawnForCustomInitialApproach()
+    {
+        var propertyExteriorSpawn = new NumericsVector3(-67f, 0.7f, 81.5f);
+
+        bool overridden = global::S1API.Internal.Patches.NPCPatches
+            .TryCalculateCustomNpcPropertyApproachDestination(
+                isCustomNpc: true,
+                isInitialApproach: true,
+                playerInsideOwnedProperty: true,
+                propertyExteriorSpawn,
+                out NumericsVector3 destination);
+
+        Assert.True(overridden);
+        Assert.Equal(propertyExteriorSpawn, destination);
+    }
+
+    [Theory]
+    [InlineData(false, true, true, true)]
+    [InlineData(true, false, true, true)]
+    [InlineData(true, true, false, true)]
+    [InlineData(true, true, true, false)]
+    public void PropertyApproachDestination_PreservesNativeDestinationOutsideCustomOwnedPropertyApproach(
+        bool isCustomNpc,
+        bool isInitialApproach,
+        bool playerInsideOwnedProperty,
+        bool hasExteriorSpawnPoint)
+    {
+        NumericsVector3? propertyExteriorSpawn = hasExteriorSpawnPoint
+            ? new NumericsVector3(-67f, 0.7f, 81.5f)
+            : null;
+
+        bool overridden = global::S1API.Internal.Patches.NPCPatches
+            .TryCalculateCustomNpcPropertyApproachDestination(
+                isCustomNpc,
+                isInitialApproach,
+                playerInsideOwnedProperty,
+                propertyExteriorSpawn,
+                out _);
+
+        Assert.False(overridden);
+    }
+
+    [Theory]
+    [InlineData(float.NaN, 0f, 0f)]
+    [InlineData(float.PositiveInfinity, 0f, 0f)]
+    [InlineData(10001f, 0f, 0f)]
+    public void PropertyApproachDestination_RejectsInvalidExteriorSpawn(
+        float x,
+        float y,
+        float z)
+    {
+        bool overridden = global::S1API.Internal.Patches.NPCPatches
+            .TryCalculateCustomNpcPropertyApproachDestination(
+                isCustomNpc: true,
+                isInitialApproach: true,
+                playerInsideOwnedProperty: true,
+                new NumericsVector3(x, y, z),
+                out _);
+
+        Assert.False(overridden);
     }
 
     [Theory]

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -147,6 +147,8 @@ namespace S1API.Entities
         private const string CivilianNpcPrefabName = "CivilianNPC";
         private const string BaseNpcPrefabName = "BaseNPC";
         private const string BaseEmployeePrefabName = "BaseEmployee";
+        private const string PropertyInteriorNavMeshAreaName = "PropertyInterior";
+        private const string LadderNavMeshAreaName = "Ladder";
         private static readonly bool LogBetaNpcPrefabDiagnostics = false;
         private static readonly string[] BaseNpcMembersToCopy =
         {
@@ -472,6 +474,7 @@ namespace S1API.Entities
             if (sourceNpc == null && existingPlainNpc != null)
             {
                 RepairNpcPrefabReferences(prefabRoot, existingPlainNpc);
+                NormalizeBaseEmployeeNavigation(prefabRoot, rootRole);
                 if (rootRole == NpcRootRole.Dealer)
                     EnsureDealerComponentOnPrefab(prefabRoot);
                 else if (rootRole == NpcRootRole.Supplier)
@@ -540,6 +543,7 @@ namespace S1API.Entities
                 LogBaseEmployeeComponentState("after employee cleanup", prefabRoot);
                 RewireChildNpcReferences(prefabRoot, replacementNpc);
                 RepairNpcPrefabReferences(prefabRoot, replacementNpc);
+                NormalizeBaseEmployeeNavigation(prefabRoot, rootRole);
                 LogBaseEmployeeNormalization();
             }
             catch (Exception ex)
@@ -616,6 +620,42 @@ namespace S1API.Entities
         {
             return prefabRoot.GetComponent<UnityEngine.AI.NavMeshAgent>()
                    ?? prefabRoot.AddComponent<UnityEngine.AI.NavMeshAgent>();
+        }
+
+        private static void NormalizeBaseEmployeeNavigation(GameObject prefabRoot, NpcRootRole rootRole)
+        {
+            if (prefabRoot == null || rootRole != NpcRootRole.Plain)
+                return;
+
+            var movement = prefabRoot.GetComponent<S1NPCs.NPCMovement>()
+                           ?? prefabRoot.GetComponentInChildren<S1NPCs.NPCMovement>(true);
+            UnityEngine.AI.NavMeshAgent agent = EnsureRootNavMeshAgent(prefabRoot);
+            int propertyInteriorArea = UnityEngine.AI.NavMesh.GetAreaFromName(PropertyInteriorNavMeshAreaName);
+            int ladderArea = UnityEngine.AI.NavMesh.GetAreaFromName(LadderNavMeshAreaName);
+            agent.areaMask = IncludeNavMeshArea(
+                ExcludeNavMeshArea(agent.areaMask, propertyInteriorArea),
+                ladderArea);
+            agent.obstacleAvoidanceType = UnityEngine.AI.ObstacleAvoidanceType.MedQualityObstacleAvoidance;
+
+            if (movement != null)
+            {
+                movement.SetAgentType(S1NPCs.NPCMovement.EAgentType.Humanoid);
+                movement.DefaultObstacleAvoidanceType = UnityEngine.AI.ObstacleAvoidanceType.HighQualityObstacleAvoidance;
+            }
+        }
+
+        internal static int ExcludeNavMeshArea(int areaMask, int areaIndex)
+        {
+            return areaIndex is >= 0 and < 32
+                ? areaMask & ~(1 << areaIndex)
+                : areaMask;
+        }
+
+        internal static int IncludeNavMeshArea(int areaMask, int areaIndex)
+        {
+            return areaIndex is >= 0 and < 32
+                ? areaMask | (1 << areaIndex)
+                : areaMask;
         }
 
         private static S1Economy.Dealer? EnsureDealerComponentOnPrefab(GameObject prefabRoot)

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -644,19 +644,15 @@ namespace S1API.Entities
             }
         }
 
-        internal static int ExcludeNavMeshArea(int areaMask, int areaIndex)
-        {
-            return areaIndex is >= 0 and < 32
+        internal static int ExcludeNavMeshArea(int areaMask, int areaIndex) =>
+            areaIndex is >= 0 and < 32
                 ? areaMask & ~(1 << areaIndex)
                 : areaMask;
-        }
 
-        internal static int IncludeNavMeshArea(int areaMask, int areaIndex)
-        {
-            return areaIndex is >= 0 and < 32
+        internal static int IncludeNavMeshArea(int areaMask, int areaIndex) =>
+            areaIndex is >= 0 and < 32
                 ? areaMask | (1 << areaIndex)
                 : areaMask;
-        }
 
         private static S1Economy.Dealer? EnsureDealerComponentOnPrefab(GameObject prefabRoot)
         {

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -13,6 +13,7 @@ using S1Datas = Il2CppScheduleOne.Persistence.Datas;
 using S1Items = Il2CppScheduleOne.ItemFramework;
 using S1GameTime = Il2CppScheduleOne.GameTime;
 using S1Quests = Il2CppScheduleOne.Quests;
+using S1Properties = Il2CppScheduleOne.Property;
 using Il2CppFishNet;
 using Il2CppFishNet.Object;
 using Il2CppScheduleOne.DevUtilities;
@@ -35,6 +36,7 @@ using S1Datas = ScheduleOne.Persistence.Datas;
 using S1Items = ScheduleOne.ItemFramework;
 using S1GameTime = ScheduleOne.GameTime;
 using S1Quests = ScheduleOne.Quests;
+using S1Properties = ScheduleOne.Property;
 #endif
 
 using System;
@@ -185,6 +187,72 @@ namespace S1API.Internal.Patches
             return true;
         }
 
+        internal static bool TryCalculateCustomNpcPropertyApproachDestination(
+            bool isCustomNpc,
+            bool isInitialApproach,
+            bool playerInsideOwnedProperty,
+            NumericsVector3? propertyExteriorSpawnPosition,
+            out NumericsVector3 destination)
+        {
+            destination = default;
+            if (!isCustomNpc || !isInitialApproach || !playerInsideOwnedProperty ||
+                propertyExteriorSpawnPosition is not NumericsVector3 spawnPosition ||
+                !IsValidNavigationPosition(spawnPosition))
+            {
+                return false;
+            }
+
+            destination = spawnPosition;
+            return true;
+        }
+
+        private static bool IsValidNavigationPosition(NumericsVector3 position) =>
+            float.IsFinite(position.X) &&
+            float.IsFinite(position.Y) &&
+            float.IsFinite(position.Z) &&
+            position.LengthSquared() <= 100_000_000f;
+
+        private static bool TryGetCustomNpcPropertyApproachDestination(
+            bool isCustomNpc,
+            bool isInitialApproach,
+            Vector3 playerPosition,
+            out Vector3 destination)
+        {
+            destination = default;
+            foreach (S1Properties.Property property in S1Properties.Property.OwnedProperties)
+            {
+                if (property == null || !property.DoBoundsContainPoint(playerPosition))
+                    continue;
+
+                Vector3? spawnPosition = property.SpawnPoint != null
+                    ? property.SpawnPoint.position
+                    : null;
+                NumericsVector3? numericSpawnPosition = spawnPosition.HasValue
+                    ? new NumericsVector3(
+                        spawnPosition.Value.x,
+                        spawnPosition.Value.y,
+                        spawnPosition.Value.z)
+                    : null;
+                if (!TryCalculateCustomNpcPropertyApproachDestination(
+                        isCustomNpc,
+                        isInitialApproach,
+                        playerInsideOwnedProperty: true,
+                        numericSpawnPosition,
+                        out NumericsVector3 calculatedDestination))
+                {
+                    return false;
+                }
+
+                destination = new Vector3(
+                    calculatedDestination.X,
+                    calculatedDestination.Y,
+                    calculatedDestination.Z);
+                return true;
+            }
+
+            return false;
+        }
+
         [HarmonyPatch]
         private static class RequestProductMovementDestinationPatch
         {
@@ -202,6 +270,19 @@ namespace S1API.Internal.Patches
                     return;
 
                 bool isCustomNpc = IsS1ApiCustomNpcComponent(nativeNpc);
+                bool isInitialApproach =
+                    request.Active &&
+                    request.State == S1NPCsBehaviour.RequestProductBehaviour.EState.InitialApproach;
+                if (TryGetCustomNpcPropertyApproachDestination(
+                        isCustomNpc,
+                        isInitialApproach,
+                        targetPlayer.transform.position,
+                        out Vector3 propertyApproachDestination))
+                {
+                    pos = propertyApproachDestination;
+                    return;
+                }
+
                 bool isFollowingPlayer =
                     request.Active &&
                     request.State == S1NPCsBehaviour.RequestProductBehaviour.EState.FollowPlayer;
@@ -216,7 +297,12 @@ namespace S1API.Internal.Patches
                     return;
                 }
 
-                if (NavMeshUtility.SamplePosition(desiredDestination, out var hit, 15f, -1))
+                var agent = __instance?.Agent;
+                if (agent != null && NavMeshUtility.SamplePosition(
+                        desiredDestination,
+                        out var hit,
+                        15f,
+                        agent.areaMask))
                 {
                     pos = hit.position;
                 }

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -43,6 +43,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using NumericsVector3 = System.Numerics.Vector3;
 using HarmonyLib;
 using MelonLoader;
 using S1API.Entities;
@@ -123,6 +124,108 @@ namespace S1API.Internal.Patches
                         && parameters[1].ParameterType == typeof(int)
                         && parameters[2].ParameterType == typeof(float);
                 });
+        }
+
+        internal static MethodBase? FindNpcMovementDestinationMethod(Type movementType)
+        {
+            return movementType.GetMethod(
+                "SetDestination",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(Vector3) },
+                modifiers: null);
+        }
+
+        internal static bool TryGetCustomNpcFollowDestination(
+            bool isCustomNpc,
+            bool isFollowingPlayer,
+            Vector3 playerPosition,
+            Vector3 npcPosition,
+            Vector3 fallbackDirection,
+            out Vector3 destination)
+        {
+            destination = default;
+            if (!TryCalculateCustomNpcFollowDestination(
+                    isCustomNpc,
+                    isFollowingPlayer,
+                    new NumericsVector3(playerPosition.x, playerPosition.y, playerPosition.z),
+                    new NumericsVector3(npcPosition.x, npcPosition.y, npcPosition.z),
+                    new NumericsVector3(fallbackDirection.x, fallbackDirection.y, fallbackDirection.z),
+                    out NumericsVector3 calculatedDestination))
+            {
+                return false;
+            }
+
+            destination = new Vector3(
+                calculatedDestination.X,
+                calculatedDestination.Y,
+                calculatedDestination.Z);
+            return true;
+        }
+
+        internal static bool TryCalculateCustomNpcFollowDestination(
+            bool isCustomNpc,
+            bool isFollowingPlayer,
+            NumericsVector3 playerPosition,
+            NumericsVector3 npcPosition,
+            NumericsVector3 fallbackDirection,
+            out NumericsVector3 destination)
+        {
+            destination = default;
+            if (!isCustomNpc || !isFollowingPlayer)
+                return false;
+
+            NumericsVector3 direction = npcPosition - playerPosition;
+            if (direction.LengthSquared() <= 0.0001f)
+                direction = fallbackDirection;
+            if (direction.LengthSquared() <= 0.0001f)
+                direction = -NumericsVector3.UnitZ;
+
+            destination = playerPosition + NumericsVector3.Normalize(direction) * 2.5f;
+            return true;
+        }
+
+        [HarmonyPatch]
+        private static class RequestProductMovementDestinationPatch
+        {
+            private static MethodBase? TargetMethod() =>
+                FindNpcMovementDestinationMethod(typeof(S1NPCs.NPCMovement));
+
+            [HarmonyPrefix]
+            private static void Prefix(S1NPCs.NPCMovement __instance, ref Vector3 pos)
+            {
+                S1NPCs.NPC? nativeNpc = __instance?.GetComponent<S1NPCs.NPC>();
+                S1NPCsBehaviour.RequestProductBehaviour? request =
+                    nativeNpc?.Behaviour?.RequestProductBehaviour;
+                var targetPlayer = request?.TargetPlayer;
+                if (nativeNpc == null || request == null || targetPlayer == null)
+                    return;
+
+                bool isCustomNpc = IsS1ApiCustomNpcComponent(nativeNpc);
+                bool isFollowingPlayer =
+                    request.Active &&
+                    request.State == S1NPCsBehaviour.RequestProductBehaviour.EState.FollowPlayer;
+                if (!TryGetCustomNpcFollowDestination(
+                        isCustomNpc,
+                        isFollowingPlayer,
+                        targetPlayer.transform.position,
+                        nativeNpc.transform.position,
+                        -targetPlayer.transform.forward,
+                        out Vector3 desiredDestination))
+                {
+                    return;
+                }
+
+                if (NavMeshUtility.SamplePosition(desiredDestination, out var hit, 15f, -1))
+                {
+                    pos = hit.position;
+                }
+                else
+                {
+                    Logger.Warning(
+                        $"[RequestProduct] Failed to find a spaced follow destination for custom NPC '{nativeNpc.ID}'; preserving the native destination.");
+                }
+            }
         }
 
         internal static S1NPCs.NPC? GetScheduleActionNpc(S1NPCsSchedules.NPCAction action)


### PR DESCRIPTION
## Summary

- normalize plain custom NPCs cloned from `BaseEmployee` to the civilian navigation profile, excluding `PropertyInterior` while retaining ladder traversal
- route a requesting custom customer to the containing owned property's exterior entrance while the player remains inside
- resume native player pursuit and forced dialogue as soon as the player exits the property
- keep custom customers at a 2.5-unit follow radius and sample that destination with the NPC agent's allowed NavMesh areas
- preserve all native NPC movement and request-product behavior

## Root cause

The 0.4.6 migration from `CivilianNPC` to `BaseEmployee` left plain custom NPCs with the employee NavMesh area mask, allowing them to traverse owned-property interiors. Removing `PropertyInterior` prevents the invasion, but also exposed a second native edge: `NPCMovement.GetClosestReachablePoint` samples only 3, 6, and 9 metres around the player's requested position. A player deep inside a disconnected property interior can therefore produce no reachable point unless the global native closest-point cache was already seeded nearby.

For custom customers in `RequestProductBehaviour.InitialApproach`, S1API now resolves the owned property containing the target player and uses its configured exterior `SpawnPoint`. The NPC approaches and waits at the entrance while the player is inside. Once the player exits, the patch stops overriding the destination and the native request-product state machine handles pursuit and forced dialogue. During `FollowPlayer`, S1API retains native-equivalent spacing instead of targeting the player's exact position.

The patch remains on the initialized by-value `NPCMovement.SetDestination(Vector3)` boundary. It does not patch `RequestProductBehaviour.GetNewDestination(out Vector3)`, whose IL2CPP wrapper passes the out slot through `Unsafe.AsPointer(ref dest)` and was shown to corrupt or clear Harmony-observed values.

## Validation

### Contract tests

- Mono focused request-product policy tests: 20/20 passed
- IL2CPP focused request-product policy tests: 20/20 passed
- Mono full suite: 502/502 passed
- IL2CPP standalone suite: 382 tests passed before the known finalizer abort caused by unavailable `GameAssembly` outside the game host

### In-game existing-save automation

Loaded an isolated copy of `SaveGame_2`, teleported the player to the motel room's actual `InteriorSpawnPoint`, triggered the native `Customer.RequestProduct(Player)` path, and required all of the following before passing:

- a destination within 2 seconds and movement intent within 4 seconds
- movement from the native request-product warp point toward the property entrance
- no entry into the motel property while the player remained inside
- forced dialogue only after the player was moved outside
- successful transition to `FollowPlayer` without running away or crowding the player

Final custom-customer results:

- Mono: PASS; approach travel 68.425, doorway distance 8.476, forced dialogue true, follow distance 3.242
- IL2CPP: PASS; approach travel 68.920, doorway distance 8.098, forced dialogue true, follow distance 3.243

Successful vanilla controls on the same motel scenario established the parity envelope:

- Mono: approach travel 69.320, doorway distance 7.317, follow distance 3.248
- IL2CPP: approach travel 68.007, doorway distance 8.511, follow distance 3.242

The final S1API and manual F8/F9 diagnostic mod builds were also deployed to both local Mono and IL2CPP installs for manual verification.

## Review follow-up

- added invalid-index coverage for both area-mask helpers
- added explicit zero-direction follow fallback coverage
- changed follow NavMesh sampling from all areas to the active NPC agent's area mask
- converted the simple area-mask helpers to expression-bodied members

Closes #218
