### PR TITLE
feat(items): expose clothing metadata catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ and document the migration impact in the PR.
 `S1API.Tests/` is the only test implementation that should be committed to this repository. Keep runtime and in-game smoke mods, launchers, harnesses, disposable saves or installs, logs, screenshots, and generated evidence local and ignored, including everything under `tests/Smoke/`. Do not add `.gitignore` exceptions for smoke-test sources. Record the scenario, commands, runtime matrix, and observed pass/fail evidence in the PR description without committing the smoke implementation or game-derived artifacts.
 
 ## Commit & Pull Request Guidelines
-Write imperative, single-purpose commits; lightweight prefixes such as `fix:` or `feat:` appear in history and are encouraged. Target PRs at `bleeding-edge`, include a short change narrative, reproduction or validation notes, and link any external issue. Screenshots or logs are helpful for UI or networking work. Never modify CI workflows without prior discussion.
+Write imperative, single-purpose commits; lightweight prefixes such as `fix:` or `feat:` appear in history and are encouraged. Target regular-game PRs at `stable` and beta-game PRs at `beta`. Include a short change narrative, reproduction or validation notes, and link any external issue. Screenshots or logs are helpful for UI or networking work. Never modify CI workflows without prior discussion.
 
 ## Release & Versioning Workflow
 Always follow [`VERSIONING.md`](VERSIONING.md) for any release, hotfix, tagging, branch-planning, or version-bump work. Treat it as the authoritative release policy.

--- a/S1API.Tests/Items/ClothingMetadataCatalogCollection.cs
+++ b/S1API.Tests/Items/ClothingMetadataCatalogCollection.cs
@@ -1,0 +1,7 @@
+namespace S1API.Tests.Items;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ClothingMetadataCatalogCollection
+{
+    public const string Name = "Clothing metadata catalog";
+}

--- a/S1API.Tests/Items/ClothingMetadataCatalogTests.cs
+++ b/S1API.Tests/Items/ClothingMetadataCatalogTests.cs
@@ -1,0 +1,154 @@
+using S1API.Items.Clothing;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+[Collection(ClothingMetadataCatalogCollection.Name)]
+public sealed class ClothingMetadataCatalogTests : IDisposable
+{
+    private readonly FakeClothingMetadataProvider _provider = new();
+
+    public ClothingMetadataCatalogTests()
+    {
+        ClothingMetadataCatalog.ResetForTesting(_provider);
+    }
+
+    public void Dispose()
+    {
+        ClothingMetadataCatalog.RestoreProviderForTesting();
+    }
+
+    [Fact]
+    public void LookupsExposeS1ApiOwnedMetadata()
+    {
+        Color actualColor = CreateColor(0.2f, 0.4f, 0.6f);
+        Color labelColor = CreateColor(1f, 1f, 1f);
+        var slotMetadata = new ClothingSlotMetadata(
+            ClothingSlot.Head,
+            "Headwear",
+            null);
+        var colorMetadata = new ClothingColorMetadata(
+            ClothingColor.Blue,
+            "Blue",
+            actualColor,
+            labelColor);
+        _provider.Slots[ClothingSlot.Head] = slotMetadata;
+        _provider.Colors[ClothingColor.Blue] = colorMetadata;
+
+        Assert.Same(slotMetadata, ClothingMetadataCatalog.GetSlot(ClothingSlot.Head));
+        Assert.True(
+            ClothingMetadataCatalog.TryGetColor(
+                ClothingColor.Blue,
+                out ClothingColorMetadata? resolvedColor));
+        Assert.Same(colorMetadata, resolvedColor);
+        AssertColor(actualColor, resolvedColor!.ActualColor);
+        AssertColor(labelColor, resolvedColor.LabelColor);
+    }
+
+    [Fact]
+    public void CatalogPropertiesReturnOrderedReadOnlySnapshots()
+    {
+        var feet = new ClothingSlotMetadata(ClothingSlot.Feet, "Shoes", null);
+        var head = new ClothingSlotMetadata(ClothingSlot.Head, "Headwear", null);
+        _provider.Slots[ClothingSlot.Head] = head;
+        _provider.Slots[ClothingSlot.Feet] = feet;
+
+        IReadOnlyList<ClothingSlotMetadata> snapshot =
+            ClothingMetadataCatalog.Slots;
+        _provider.Slots.Remove(ClothingSlot.Head);
+
+        Assert.Equal(new[] { feet, head }, snapshot);
+        Assert.Equal(new[] { feet }, ClothingMetadataCatalog.Slots);
+
+        IList<ClothingSlotMetadata> mutableView =
+            Assert.IsAssignableFrom<IList<ClothingSlotMetadata>>(snapshot);
+        Assert.True(mutableView.IsReadOnly);
+        Assert.Throws<NotSupportedException>(() => mutableView.Add(feet));
+    }
+
+    [Fact]
+    public void InvalidValuesDoNotReachNativeProvider()
+    {
+        Assert.False(
+            ClothingMetadataCatalog.TryGetSlot(
+                (ClothingSlot)(-1),
+                out ClothingSlotMetadata? slotMetadata));
+        Assert.False(
+            ClothingMetadataCatalog.TryGetColor(
+                (ClothingColor)999,
+                out ClothingColorMetadata? colorMetadata));
+
+        Assert.Null(slotMetadata);
+        Assert.Null(colorMetadata);
+        Assert.Equal(0, _provider.SlotLookupCount);
+        Assert.Equal(0, _provider.ColorLookupCount);
+    }
+
+    [Fact]
+    public void UnavailableRuntimeReturnsEmptyAndNullResults()
+    {
+        Assert.Empty(ClothingMetadataCatalog.Slots);
+        Assert.Empty(ClothingMetadataCatalog.Colors);
+        Assert.Null(ClothingMetadataCatalog.GetSlot(ClothingSlot.Head));
+        Assert.Null(ClothingMetadataCatalog.GetColor(ClothingColor.Blue));
+    }
+
+    [Fact]
+    public void MetadataPropertiesAreReadOnly()
+    {
+        Assert.All(
+            typeof(ClothingSlotMetadata).GetProperties(),
+            property => Assert.False(property.CanWrite));
+        Assert.All(
+            typeof(ClothingColorMetadata).GetProperties(),
+            property => Assert.False(property.CanWrite));
+    }
+
+    private static Color CreateColor(float red, float green, float blue)
+    {
+        Color color = default;
+        color.r = red;
+        color.g = green;
+        color.b = blue;
+        color.a = 1f;
+        return color;
+    }
+
+    private static void AssertColor(Color expected, Color actual)
+    {
+        Assert.Equal(expected.r, actual.r);
+        Assert.Equal(expected.g, actual.g);
+        Assert.Equal(expected.b, actual.b);
+        Assert.Equal(expected.a, actual.a);
+    }
+
+    private sealed class FakeClothingMetadataProvider :
+        IClothingMetadataProvider
+    {
+        internal Dictionary<ClothingSlot, ClothingSlotMetadata> Slots { get; } =
+            new();
+
+        internal Dictionary<ClothingColor, ClothingColorMetadata> Colors { get; } =
+            new();
+
+        internal int SlotLookupCount { get; private set; }
+
+        internal int ColorLookupCount { get; private set; }
+
+        public bool TryGetSlot(
+            ClothingSlot slot,
+            out ClothingSlotMetadata? metadata)
+        {
+            SlotLookupCount++;
+            return Slots.TryGetValue(slot, out metadata);
+        }
+
+        public bool TryGetColor(
+            ClothingColor color,
+            out ClothingColorMetadata? metadata)
+        {
+            ColorLookupCount++;
+            return Colors.TryGetValue(color, out metadata);
+        }
+    }
+}

--- a/S1API/Items/Clothing/ClothingColorMetadata.cs
+++ b/S1API/Items/Clothing/ClothingColorMetadata.cs
@@ -25,7 +25,7 @@ namespace S1API.Items.Clothing
         public ClothingColor Color { get; }
 
         /// <summary>
-        /// Gets the base game's display name for the color.
+        /// Gets the clothing color enum identifier used by the base game as its label.
         /// </summary>
         public string DisplayName { get; }
 

--- a/S1API/Items/Clothing/ClothingColorMetadata.cs
+++ b/S1API/Items/Clothing/ClothingColorMetadata.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+namespace S1API.Items.Clothing
+{
+    /// <summary>
+    /// Describes a clothing color using the base game's display metadata.
+    /// </summary>
+    public sealed class ClothingColorMetadata
+    {
+        internal ClothingColorMetadata(
+            ClothingColor color,
+            string displayName,
+            Color actualColor,
+            Color labelColor)
+        {
+            Color = color;
+            DisplayName = displayName;
+            ActualColor = actualColor;
+            LabelColor = labelColor;
+        }
+
+        /// <summary>
+        /// Gets the clothing color represented by this metadata.
+        /// </summary>
+        public ClothingColor Color { get; }
+
+        /// <summary>
+        /// Gets the base game's display name for the color.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the color applied to clothing materials.
+        /// </summary>
+        public Color ActualColor { get; }
+
+        /// <summary>
+        /// Gets the contrasting color used to label this color in the base game UI.
+        /// </summary>
+        public Color LabelColor { get; }
+    }
+}

--- a/S1API/Items/Clothing/ClothingMetadataCatalog.cs
+++ b/S1API/Items/Clothing/ClothingMetadataCatalog.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using UnityEngine;
+#if IL2CPPMELON
+using S1Clothing = Il2CppScheduleOne.Clothing;
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
+#elif MONOMELON
+using S1Clothing = ScheduleOne.Clothing;
+using S1DevUtilities = ScheduleOne.DevUtilities;
+#endif
+
+namespace S1API.Items.Clothing
+{
+    /// <summary>
+    /// Provides read-only access to the base game's clothing slot and color metadata.
+    /// </summary>
+    public static class ClothingMetadataCatalog
+    {
+        private static readonly IReadOnlyList<ClothingSlotMetadata> EmptySlots =
+            new ReadOnlyCollection<ClothingSlotMetadata>(
+                Array.Empty<ClothingSlotMetadata>());
+        private static readonly IReadOnlyList<ClothingColorMetadata> EmptyColors =
+            new ReadOnlyCollection<ClothingColorMetadata>(
+                Array.Empty<ClothingColorMetadata>());
+        private static IClothingMetadataProvider _provider =
+            new NativeClothingMetadataProvider();
+
+        /// <summary>
+        /// Gets a read-only snapshot of all available clothing slot metadata.
+        /// Returns an empty list before the base game's clothing utility is ready.
+        /// </summary>
+        public static IReadOnlyList<ClothingSlotMetadata> Slots =>
+            GetSlots();
+
+        /// <summary>
+        /// Gets a read-only snapshot of all available clothing color metadata.
+        /// Returns an empty list before the base game's clothing utility is ready.
+        /// </summary>
+        public static IReadOnlyList<ClothingColorMetadata> Colors =>
+            GetColors();
+
+        /// <summary>
+        /// Gets metadata for a clothing slot.
+        /// </summary>
+        /// <param name="slot">The clothing slot to look up.</param>
+        /// <returns>
+        /// The slot metadata, or <see langword="null"/> when the slot is unavailable
+        /// or the base game's clothing utility is not ready.
+        /// </returns>
+        public static ClothingSlotMetadata? GetSlot(ClothingSlot slot)
+        {
+            TryGetSlot(slot, out ClothingSlotMetadata? metadata);
+            return metadata;
+        }
+
+        /// <summary>
+        /// Tries to get metadata for a clothing slot.
+        /// </summary>
+        /// <param name="slot">The clothing slot to look up.</param>
+        /// <param name="metadata">The resolved metadata when available.</param>
+        /// <returns><see langword="true"/> when metadata was found.</returns>
+        public static bool TryGetSlot(
+            ClothingSlot slot,
+            out ClothingSlotMetadata? metadata)
+        {
+            if (!Enum.IsDefined(typeof(ClothingSlot), slot))
+            {
+                metadata = null;
+                return false;
+            }
+
+            return _provider.TryGetSlot(slot, out metadata);
+        }
+
+        /// <summary>
+        /// Gets metadata for a clothing color.
+        /// </summary>
+        /// <param name="color">The clothing color to look up.</param>
+        /// <returns>
+        /// The color metadata, or <see langword="null"/> when the color is unavailable
+        /// or the base game's clothing utility is not ready.
+        /// </returns>
+        public static ClothingColorMetadata? GetColor(ClothingColor color)
+        {
+            TryGetColor(color, out ClothingColorMetadata? metadata);
+            return metadata;
+        }
+
+        /// <summary>
+        /// Tries to get metadata for a clothing color.
+        /// </summary>
+        /// <param name="color">The clothing color to look up.</param>
+        /// <param name="metadata">The resolved metadata when available.</param>
+        /// <returns><see langword="true"/> when metadata was found.</returns>
+        public static bool TryGetColor(
+            ClothingColor color,
+            out ClothingColorMetadata? metadata)
+        {
+            if (!Enum.IsDefined(typeof(ClothingColor), color))
+            {
+                metadata = null;
+                return false;
+            }
+
+            return _provider.TryGetColor(color, out metadata);
+        }
+
+        internal static void ResetForTesting(IClothingMetadataProvider provider)
+        {
+            _provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        internal static void RestoreProviderForTesting()
+        {
+            _provider = new NativeClothingMetadataProvider();
+        }
+
+        private static IReadOnlyList<ClothingSlotMetadata> GetSlots()
+        {
+            var metadata = new List<ClothingSlotMetadata>();
+            foreach (ClothingSlot slot in Enum.GetValues(typeof(ClothingSlot)))
+            {
+                if (_provider.TryGetSlot(slot, out ClothingSlotMetadata? entry)
+                    && entry != null)
+                {
+                    metadata.Add(entry);
+                }
+            }
+
+            return metadata.Count == 0
+                ? EmptySlots
+                : new ReadOnlyCollection<ClothingSlotMetadata>(metadata);
+        }
+
+        private static IReadOnlyList<ClothingColorMetadata> GetColors()
+        {
+            var metadata = new List<ClothingColorMetadata>();
+            foreach (ClothingColor color in Enum.GetValues(typeof(ClothingColor)))
+            {
+                if (_provider.TryGetColor(color, out ClothingColorMetadata? entry)
+                    && entry != null)
+                {
+                    metadata.Add(entry);
+                }
+            }
+
+            return metadata.Count == 0
+                ? EmptyColors
+                : new ReadOnlyCollection<ClothingColorMetadata>(metadata);
+        }
+    }
+
+    internal interface IClothingMetadataProvider
+    {
+        bool TryGetSlot(
+            ClothingSlot slot,
+            out ClothingSlotMetadata? metadata);
+
+        bool TryGetColor(
+            ClothingColor color,
+            out ClothingColorMetadata? metadata);
+    }
+
+    internal sealed class NativeClothingMetadataProvider :
+        IClothingMetadataProvider
+    {
+        public bool TryGetSlot(
+            ClothingSlot slot,
+            out ClothingSlotMetadata? metadata)
+        {
+            metadata = null;
+
+            try
+            {
+                if (!S1DevUtilities.Singleton<S1Clothing.ClothingUtility>.InstanceExists)
+                    return false;
+
+                S1Clothing.ClothingUtility.ClothingSlotData? nativeMetadata =
+                    S1DevUtilities.Singleton<S1Clothing.ClothingUtility>
+                        .Instance
+                        .GetSlotData((S1Clothing.EClothingSlot)slot);
+                if (nativeMetadata == null)
+                    return false;
+
+                metadata = new ClothingSlotMetadata(
+                    slot,
+                    nativeMetadata.Name ?? slot.ToString(),
+                    nativeMetadata.Icon);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool TryGetColor(
+            ClothingColor color,
+            out ClothingColorMetadata? metadata)
+        {
+            metadata = null;
+
+            try
+            {
+                if (!S1DevUtilities.Singleton<S1Clothing.ClothingUtility>.InstanceExists)
+                    return false;
+
+                S1Clothing.ClothingUtility.ColorData? nativeMetadata =
+                    S1DevUtilities.Singleton<S1Clothing.ClothingUtility>
+                        .Instance
+                        .GetColorData((S1Clothing.EClothingColor)color);
+                if (nativeMetadata == null)
+                    return false;
+
+                metadata = new ClothingColorMetadata(
+                    color,
+                    color.ToString(),
+                    nativeMetadata.ActualColor,
+                    nativeMetadata.LabelColor);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/S1API/Items/Clothing/ClothingMetadataCatalog.cs
+++ b/S1API/Items/Clothing/ClothingMetadataCatalog.cs
@@ -2,12 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using UnityEngine;
-#if IL2CPPMELON
-using S1Clothing = Il2CppScheduleOne.Clothing;
-using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
-#elif MONOMELON
+#if MONOMELON
 using S1Clothing = ScheduleOne.Clothing;
 using S1DevUtilities = ScheduleOne.DevUtilities;
+#elif IL2CPPMELON
+using S1Clothing = Il2CppScheduleOne.Clothing;
+using S1DevUtilities = Il2CppScheduleOne.DevUtilities;
 #endif
 
 namespace S1API.Items.Clothing

--- a/S1API/Items/Clothing/ClothingSlotMetadata.cs
+++ b/S1API/Items/Clothing/ClothingSlotMetadata.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace S1API.Items.Clothing
+{
+    /// <summary>
+    /// Describes a clothing slot using the base game's display metadata.
+    /// </summary>
+    public sealed class ClothingSlotMetadata
+    {
+        internal ClothingSlotMetadata(
+            ClothingSlot slot,
+            string displayName,
+            Sprite? icon)
+        {
+            Slot = slot;
+            DisplayName = displayName;
+            Icon = icon;
+        }
+
+        /// <summary>
+        /// Gets the clothing slot represented by this metadata.
+        /// </summary>
+        public ClothingSlot Slot { get; }
+
+        /// <summary>
+        /// Gets the base game's display name for the slot.
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// Gets the base game's icon for the slot, if one is configured.
+        /// </summary>
+        public Sprite? Icon { get; }
+    }
+}

--- a/S1API/docs/clothing-items.md
+++ b/S1API/docs/clothing-items.md
@@ -105,6 +105,35 @@ Shop injection should happen after the registry confirms your item exists (e.g.,
 | Feet | Shoes, boots |
 | Wrist | Watches, bracelets |
 
+### Reading the Native Clothing Catalog
+
+Use `ClothingMetadataCatalog` when a menu or tool needs the same clothing slot
+names, icons, and colors as the base game:
+
+```csharp
+using S1API.Items.Clothing;
+using UnityEngine;
+
+foreach (ClothingSlotMetadata slot in ClothingMetadataCatalog.Slots)
+{
+    MelonLogger.Msg($"{slot.Slot}: {slot.DisplayName}");
+    Sprite? icon = slot.Icon;
+}
+
+ClothingColorMetadata? blue =
+    ClothingMetadataCatalog.GetColor(ClothingColor.Blue);
+if (blue != null)
+{
+    Color materialColor = blue.ActualColor;
+    Color labelColor = blue.LabelColor;
+}
+```
+
+The catalog is read-only and returns S1API-owned metadata snapshots rather than
+native `ClothingUtility` objects. Access it after the main scene has initialized;
+before the native clothing utility is ready, `Slots` and `Colors` are empty and
+individual lookups return `null`.
+
 | Application Type (`ClothingApplicationType`) | Purpose |
 | --- | --- |
 | Accessory | 3D meshes (hats, glasses) |


### PR DESCRIPTION
## Summary

- add immutable S1API clothing slot and color metadata snapshots
- expose ordered read-only catalog enumeration plus safe direct and `TryGet` lookups
- return empty/null results until the native clothing utility is available instead of leaking native types or throwing during early lifecycle calls
- document catalog usage and correct the contributor branch guidance (`stable` for the regular game, `beta` for the beta game)

Closes #224

## Implementation

`ClothingMetadataCatalog` adapts the verified Mono and IL2CPP `ClothingUtility` seams behind an internal provider. Slot entries expose the S1API `ClothingSlot`, display name, and icon. Color entries expose the S1API `ClothingColor`, display name, actual material color, and UI label color.

Every enumeration returns a read-only snapshot. Invalid enum values and unavailable native metadata return `false`/`null` without touching the native provider.

## Compatibility

- Source compatibility: unchanged; all public symbols are additive.
- Binary compatibility: unchanged; ApiCompat reports no breaking changes against the exact `origin/stable` assembly.
- Behavioral compatibility: unchanged for existing APIs; the new catalog is opt-in and read-only.
- Save compatibility: unchanged; no persistent representation or identifier changed.
- Network compatibility: unchanged; no payload or synchronization behavior changed.
- Runtime compatibility: the same public surface is built and exercised independently on Mono and IL2CPP.

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — passed, 0 warnings/errors
- full Mono contract suite — 507/507 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` — passed, 0 warnings/errors
- focused IL2CPP clothing metadata suite — 5/5 passed
- remaining IL2CPP suite — 413 tests pass before the existing out-of-game testhost finalizer abort caused by missing `GameAssembly`; the new test class passes independently and does not participate in the abort
- live Mono smoke in a disposable default save — `PASS|Runtime=Mono|Scene=Main|Slots=10|SlotIcons=10|Colors=27`
- live IL2CPP smoke in a disposable default save — `PASS|Runtime=Il2Cpp|Scene=Main|Slots=10|SlotIcons=10|Colors=27`
- DocFX — passed with 4 existing assembly-reference warnings and 0 errors
- public API documentation coverage — 80.79% (3,091/3,826)
- Microsoft ApiCompat 10.0.302 against exact `origin/stable` — no breaking changes

The live probes, copied saves, DLLs, logs, and result files were removed after validation; both game installs were restored byte-for-byte.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clothing metadata catalog for browsing available clothing slots and colors.
  - Added read-only metadata including display names, icons, material colors, and label colors.
  - Added safe lookups that handle unavailable or invalid metadata gracefully.

- **Documentation**
  - Added guidance for enumerating clothing metadata and retrieving icons and colors.
  - Clarified behavior before native clothing initialization.

- **Tests**
  - Added coverage for metadata lookups, snapshots, validation, and unavailable-runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->