### PR TITLE
fix(tests): prevent IL2CPP wrapper finalizer crashes

### DIFF
--- a/S1API.Tests/Items/RuntimeItemDefinitionRegistryTests.cs
+++ b/S1API.Tests/Items/RuntimeItemDefinitionRegistryTests.cs
@@ -4,7 +4,6 @@ using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using S1ItemFramework = ScheduleOne.ItemFramework;
 #endif
 
-using System.Runtime.CompilerServices;
 using S1API.Internal.Items;
 
 namespace S1API.Tests.Items;
@@ -63,7 +62,7 @@ public sealed class RuntimeItemDefinitionRegistryTests : IDisposable
     private static S1ItemFramework.ItemDefinition CreateDefinition()
     {
         return (S1ItemFramework.ItemDefinition)
-            RuntimeHelpers.GetUninitializedObject(
+            TestObjectFactory.CreateUninitialized(
                 typeof(S1ItemFramework.StorableItemDefinition));
     }
 

--- a/S1API.Tests/Products/CustomProductDefinitionBuilderContractTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionBuilderContractTests.cs
@@ -4,7 +4,6 @@ using NativeProductDefinition = Il2CppScheduleOne.Product.ProductDefinition;
 using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
 #endif
 
-using System.Runtime.CompilerServices;
 using S1API.Products;
 
 namespace S1API.Tests.Products;
@@ -185,10 +184,7 @@ public sealed class CustomProductDefinitionBuilderContractTests
 
     private static ProductDefinition CreateUninitializedTemplate()
     {
-        var native =
-            (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
-                typeof(NativeProductDefinition));
-        GC.SuppressFinalize(native);
+        var native = TestObjectFactory.CreateUninitialized<NativeProductDefinition>();
         return new ProductDefinition(native);
     }
 }

--- a/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
+++ b/S1API.Tests/Products/CustomProductDefinitionRegistryTests.cs
@@ -6,7 +6,6 @@ using NativePackagingDefinition = ScheduleOne.Product.Packaging.PackagingDefinit
 using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
 #endif
 
-using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using S1API.Items;
 using S1API.Products;
@@ -494,9 +493,7 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
         string productId = CreateProductId();
         NativeProductDefinition definition = CreateDefinition();
         var nativePackaging =
-            (NativePackagingDefinition)RuntimeHelpers.GetUninitializedObject(
-                typeof(NativePackagingDefinition));
-        GC.SuppressFinalize(nativePackaging);
+            TestObjectFactory.CreateUninitialized<NativePackagingDefinition>();
         var packaging = new PackagingDefinition(nativePackaging);
         CustomProductDefinitionMetadata metadata =
             CreateMetadata(productId, new[] { packaging });
@@ -585,9 +582,7 @@ public sealed class CustomProductDefinitionRegistryTests : IDisposable
     private static NativeProductDefinition CreateDefinition(
         string? productId = null)
     {
-        var definition = (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
-            typeof(NativeProductDefinition));
-        GC.SuppressFinalize(definition);
+        var definition = TestObjectFactory.CreateUninitialized<NativeProductDefinition>();
 #if MONOMELON
         if (productId != null)
             definition.ID = productId;

--- a/S1API.Tests/Products/ProductDefinitionWrapperTests.cs
+++ b/S1API.Tests/Products/ProductDefinitionWrapperTests.cs
@@ -1,7 +1,6 @@
 #if IL2CPPMELON
 using NativeProductDefinition = Il2CppScheduleOne.Product.ProductDefinition;
 #elif MONOMELON
-using System.Runtime.CompilerServices;
 using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
 #endif
 
@@ -57,7 +56,8 @@ public sealed class ProductDefinitionWrapperTests
         Type nativeDefinitionType,
         Type expectedWrapperType)
     {
-        var nativeDefinition = (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(nativeDefinitionType);
+        var nativeDefinition = (NativeProductDefinition)
+            TestObjectFactory.CreateUninitialized(nativeDefinitionType);
 
         var wrappedFromNative = ProductDefinitionWrapper.Wrap(nativeDefinition);
         var wrappedFromExistingWrapper = ProductDefinitionWrapper.Wrap(new ProductDefinition(nativeDefinition));
@@ -69,8 +69,7 @@ public sealed class ProductDefinitionWrapperTests
     [Fact]
     public void ExistingGenericWrapperRemainsTheFallbackInstance()
     {
-        var nativeDefinition = (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
-            typeof(NativeProductDefinition));
+        var nativeDefinition = TestObjectFactory.CreateUninitialized<NativeProductDefinition>();
         var existingWrapper = new ProductDefinition(nativeDefinition);
 
         var wrapped = ProductDefinitionWrapper.Wrap(existingWrapper);

--- a/S1API.Tests/Products/ProductEffectCallbackTests.cs
+++ b/S1API.Tests/Products/ProductEffectCallbackTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using S1API.Entities;
 using S1API.Entities.NPCs;
 using S1API.Products;
@@ -61,7 +60,7 @@ public sealed class ProductEffectCallbackTests : IDisposable
     [Fact]
     public void NpcClearCallbackInvokesAndCanAllowNativeFallthrough()
     {
-        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+        var npc = (NPC)TestObjectFactory.CreateUninitialized(typeof(DanSamwell));
         var clearCount = 0;
 
         ProductManager.SetNpcEffectClearCallback("test_npc_clear", _ => clearCount++, allowDefaultEffect: true);
@@ -75,7 +74,7 @@ public sealed class ProductEffectCallbackTests : IDisposable
     public void MissingClearCallbackUsesNativeFallthrough()
     {
         var player = CreatePlayer();
-        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+        var npc = (NPC)TestObjectFactory.CreateUninitialized(typeof(DanSamwell));
 
         Assert.False(ProductManager.TryInvokeEffectClearCallback("missing", player, out var playerAllowDefault));
         Assert.False(ProductManager.TryInvokeNpcEffectClearCallback("missing", npc, out var npcAllowDefault));
@@ -106,7 +105,7 @@ public sealed class ProductEffectCallbackTests : IDisposable
     public void ResetClearCallbacksRemovesPlayerAndNpcRegistrations()
     {
         var player = CreatePlayer();
-        var npc = (NPC)RuntimeHelpers.GetUninitializedObject(typeof(DanSamwell));
+        var npc = (NPC)TestObjectFactory.CreateUninitialized(typeof(DanSamwell));
 
         ProductManager.SetEffectClearCallback("test_reset_player", _ => { });
         ProductManager.SetNpcEffectClearCallback("test_reset_npc", _ => { });
@@ -169,5 +168,5 @@ public sealed class ProductEffectCallbackTests : IDisposable
     }
 
     private static Player CreatePlayer() =>
-        (Player)RuntimeHelpers.GetUninitializedObject(typeof(Player));
+        TestObjectFactory.CreateUninitialized<Player>();
 }

--- a/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
+++ b/S1API.Tests/Products/ProductKindMetadataRegistryTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using S1API.Products;
 using UnityEngine;
@@ -282,8 +281,7 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
         Assert.True(ProductKindIconLifetime.IsNullOrDestroyed(null));
 
 #if MONOMELON
-        Sprite destroyedIcon =
-            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+        Sprite destroyedIcon = TestObjectFactory.CreateUninitialized<Sprite>();
         Assert.True(ProductKindIconLifetime.IsNullOrDestroyed(destroyedIcon));
         Assert.Throws<ArgumentNullException>(
             () => new ProductKindMetadataBuilder(kind)
@@ -405,8 +403,7 @@ public sealed class ProductKindMetadataRegistryTests : IDisposable
 
     private static Sprite CreateSprite()
     {
-        var sprite =
-            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+        var sprite = TestObjectFactory.CreateUninitialized<Sprite>();
 #if MONOMELON
         SetCachedPointer(sprite, new IntPtr(1));
 #endif

--- a/S1API.Tests/Products/ProductManagerUiRuntimeContractTests.cs
+++ b/S1API.Tests/Products/ProductManagerUiRuntimeContractTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using UnityEngine;
 
@@ -74,8 +73,7 @@ public sealed class ProductManagerUiRuntimeContractTests : IDisposable
     [Fact]
     public void LiveSectionIconUsesTheRegisteredSpriteAndNeutralTint()
     {
-        Sprite sprite =
-            (Sprite)RuntimeHelpers.GetUninitializedObject(typeof(Sprite));
+        Sprite sprite = TestObjectFactory.CreateUninitialized<Sprite>();
 #if MONOMELON
         typeof(UnityEngine.Object)
             .GetField(

--- a/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentFallbackTests.cs
@@ -5,7 +5,6 @@ using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
 #endif
 
 using System;
-using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using S1API.Products;
 using Xunit;
@@ -92,11 +91,7 @@ public sealed class ProductPackagingContentFallbackTests : IDisposable
 
     private static NativeProductDefinition CreateDefinition()
     {
-        var definition =
-            (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
-                typeof(NativeProductDefinition));
-        GC.SuppressFinalize(definition);
-        return definition;
+        return TestObjectFactory.CreateUninitialized<NativeProductDefinition>();
     }
 
     private sealed class FakeProductRuntime :

--- a/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
+++ b/S1API.Tests/Products/ProductPackagingContentProfileTests.cs
@@ -1,5 +1,4 @@
 using S1API.Products;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace S1API.Tests.Products;
@@ -204,8 +203,6 @@ public sealed class ProductPackagingContentProfileTests
 
     private static ProductPresentationTransform CreatePlacementWithoutUnityRuntime()
     {
-        return
-            (ProductPresentationTransform)RuntimeHelpers.GetUninitializedObject(
-                typeof(ProductPresentationTransform));
+        return TestObjectFactory.CreateUninitialized<ProductPresentationTransform>();
     }
 }

--- a/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
+++ b/S1API.Tests/Products/ProductPresentationProfileRegistryTests.cs
@@ -4,7 +4,6 @@ using NativeProductDefinition = Il2CppScheduleOne.Product.ProductDefinition;
 using NativeProductDefinition = ScheduleOne.Product.ProductDefinition;
 #endif
 
-using System.Runtime.CompilerServices;
 using S1API.Internal.Products;
 using S1API.Products;
 
@@ -282,11 +281,7 @@ public sealed class ProductPresentationProfileRegistryTests : IDisposable
 
     private static NativeProductDefinition CreateDefinition()
     {
-        var definition =
-            (NativeProductDefinition)RuntimeHelpers.GetUninitializedObject(
-                typeof(NativeProductDefinition));
-        GC.SuppressFinalize(definition);
-        return definition;
+        return TestObjectFactory.CreateUninitialized<NativeProductDefinition>();
     }
 
     private static string CreateId()

--- a/S1API.Tests/TestObjectFactory.cs
+++ b/S1API.Tests/TestObjectFactory.cs
@@ -1,0 +1,19 @@
+using System.Runtime.CompilerServices;
+
+namespace S1API.Tests;
+
+internal static class TestObjectFactory
+{
+    public static T CreateUninitialized<T>() where T : class =>
+        (T)CreateUninitialized(typeof(T));
+
+    public static object CreateUninitialized(Type type)
+    {
+        object instance = RuntimeHelpers.GetUninitializedObject(type);
+
+        // IL2CPP wrappers finalize through GameAssembly, which is unavailable in
+        // the standalone test host. These fixtures never own a native object.
+        GC.SuppressFinalize(instance);
+        return instance;
+    }
+}


### PR DESCRIPTION
## Summary

- centralize creation of deliberately uninitialized test fixtures
- suppress finalization for native wrapper fixtures that never own IL2CPP objects
- retain compile-time and reflection coverage against MelonLoader-generated IL2CPP assemblies

## Root cause

The standalone IL2CPP test host completed the managed tests, then crashed during garbage collection. `Il2CppObjectBase.Finalize()` attempted to release a native handle through `GameAssembly`, which is unavailable outside the game process. The affected fixtures were created without constructors and never owned native handles, so their finalizers should not run.

## Testing

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 515 passed
- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 504 passed
- `git diff --check`

## Compatibility

No public or protected API symbols, durable IDs, runtime behavior, save data, or network payloads changed. The change is limited to test fixture lifetime management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized creation of uninitialized test objects across product, item, presentation, and callback test coverage.
  * Improved test-host compatibility by safely suppressing finalization for standalone test objects.
  * Removed redundant test setup code and unused imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->