### PR TITLE
chore(release): publish S1API 3.1.11

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -12,7 +12,7 @@ using S1API.Internal.Weather;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.10", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.11", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.10</Version>
+        <Version>3.1.11</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">

--- a/tools/S1APICoverageAnalyzer/Configuration/ExclusionConfig.cs
+++ b/tools/S1APICoverageAnalyzer/Configuration/ExclusionConfig.cs
@@ -20,9 +20,15 @@ public static class ExclusionConfig
         "ScheduleOne.Tutorials",
         "ScheduleOne.Tools", // Internal tools
         "ScheduleOne.DevUtilities", // Internal dev utilities
+        "ScheduleOne.Development", // Development and experimental tooling
+        "ScheduleOne.Reporting", // Built-in diagnostics and report submission
+        "ScheduleOne.Configuration", // Internal configuration services
         
         // FishNet networking internals
         "ScheduleOne.Networking",
+
+        // Platform integration and authentication internals
+        "ScheduleOne.Platform",
         
         // Audio system (internal implementation, likely not wrapped)
         "ScheduleOne.Audio",
@@ -38,6 +44,7 @@ public static class ExclusionConfig
         "ScheduleOne.Packaging", // Visuals for packaging
         "ScheduleOne.PostProcessing",
         "ScheduleOne.Shaders",
+        "ScheduleOne.Instancing",
         
         // Physics / Math / Core Utils
         "ScheduleOne.GamePhysics",
@@ -49,6 +56,8 @@ public static class ExclusionConfig
         "ScheduleOne.Polling", // Internal polling/feedback
         "ScheduleOne.Dragging",
         "ScheduleOne.Decoration",
+        "ScheduleOne.Map.Infrastructure",
+        "ScheduleOne.Core.Utilities",
         
         // Avatar internals (Animation, Rendering, etc.) - API wraps high level Avatar only
         "ScheduleOne.AvatarFramework.Animation",
@@ -64,6 +73,12 @@ public static class ExclusionConfig
         
         // UI - Entire UI namespace is internal implementation
         "ScheduleOne.UI",
+        "ScheduleOne.Casino.UI",
+        "ScheduleOne.CustomUI",
+
+        // Input implementation
+        "ScheduleOne.Gamepad",
+        "ScheduleOne.GamepadInput",
         
         // Calling internals (CallManager is wrapped, but PayPhone etc are not)
         "ScheduleOne.Calling",
@@ -82,8 +97,7 @@ public static class ExclusionConfig
         
         // Player Tasks (Mini-games internals)
         "ScheduleOne.PlayerTasks",
-        "ScheduleOne.Experimental", // Prototype/tuning data, not stable modding surface
-        "Casino.UI",
+        "ScheduleOne.TV",
         "ScheduleOne.Console",
     ];
     


### PR DESCRIPTION
## Summary

- exclude internal platform/authentication, diagnostics, development, configuration, input, instancing, TV, infrastructure, utility, and UI namespaces from API coverage
- correct ineffective experimental and casino UI namespace exclusions
- bump the S1API project and Melon metadata to 3.1.11
- prepare the required `releases/3.1.11` release branch

## Impact

The coverage analyzer no longer treats implementation-only game systems, including the v0.4.6f12 Steam/FishNet authentication surface, as S1API wrapper obligations. A fresh local analysis reported 393 / 1,128 eligible types (34.84%) with no leaks from the twelve excluded namespace prefixes.

## Compatibility

- public and protected API shape: unchanged
- runtime behavior: unchanged
- durable IDs, save formats, and network payloads: unchanged
- Mono/IL2CPP compatibility: unchanged; this release modifies analyzer configuration and version metadata only

## Validation

- coverage analyzer Release build: passed, 0 warnings
- coverage exclusion leak check: 0 matching eligible types
- MonoMelon solution build: passed, 0 warnings
- MonoMelon tests: 515/515 passed
- Il2CppMelon solution build: passed, 0 warnings
- Il2CppMelon tests: 504/504 passed
- generated NuGet package version: 3.1.11
- git diff --check: passed