### PR TITLE
feat(items): add custom furniture API

### DIFF
--- a/S1API.Tests/Items/BuildableGhostApiCompatibilityTests.cs
+++ b/S1API.Tests/Items/BuildableGhostApiCompatibilityTests.cs
@@ -16,8 +16,11 @@ public sealed class BuildableGhostApiCompatibilityTests
 
         Assert.NotNull(method);
         Assert.Equal(typeof(BuildableItemDefinitionBuilder), method!.ReturnType);
-        Assert.True(method.GetParameters()[1].HasDefaultValue);
-        Assert.Equal(false, method.GetParameters()[1].DefaultValue);
+        ParameterInfo[] parameters = method.GetParameters();
+        Assert.Equal("visualFactory", parameters[0].Name);
+        Assert.Equal("replaceExistingVisual", parameters[1].Name);
+        Assert.True(parameters[1].HasDefaultValue);
+        Assert.Equal(false, parameters[1].DefaultValue);
     }
 
     [Fact]

--- a/S1API.Tests/Items/BuildableGhostApiCompatibilityTests.cs
+++ b/S1API.Tests/Items/BuildableGhostApiCompatibilityTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using S1API.Items.Buildable;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+public sealed class BuildableGhostApiCompatibilityTests
+{
+    [Fact]
+    public void BuildableBuilderExposesOptInGhostVisualFactory()
+    {
+        MethodInfo? method = typeof(BuildableItemDefinitionBuilder).GetMethod(
+            nameof(BuildableItemDefinitionBuilder.WithGhostVisual),
+            new[] { typeof(Func<Transform, GameObject>), typeof(bool) });
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(BuildableItemDefinitionBuilder), method!.ReturnType);
+        Assert.True(method.GetParameters()[1].HasDefaultValue);
+        Assert.Equal(false, method.GetParameters()[1].DefaultValue);
+    }
+
+    [Fact]
+    public void GhostVisualFactoryRejectsNull()
+    {
+        var builder = (BuildableItemDefinitionBuilder)RuntimeHelpers.GetUninitializedObject(
+            typeof(BuildableItemDefinitionBuilder));
+
+        Assert.Throws<ArgumentNullException>(() => builder.WithGhostVisual(null!));
+    }
+}

--- a/S1API.Tests/Items/FurnitureApiCompatibilityTests.cs
+++ b/S1API.Tests/Items/FurnitureApiCompatibilityTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using S1API.Internal.Building;
 using S1API.Items.Buildable;
 using UnityEngine;
 
@@ -62,6 +63,42 @@ public sealed class FurnitureApiCompatibilityTests
         FurnitureDefinitionBuilder builder = FurnitureCreator.CreateBuilder();
         Assert.Throws<ArgumentOutOfRangeException>(
             () => builder.WithSurfacePlacement(surfaceTypes));
+    }
+
+    [Fact]
+    public void ModelAndIconRejectNull()
+    {
+        FurnitureDefinitionBuilder builder = FurnitureCreator.CreateBuilder();
+
+        Assert.Throws<ArgumentNullException>(() => builder.WithModel(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.WithIcon(null!));
+    }
+
+    [Fact]
+    public void DefaultBuildSoundIsWood()
+    {
+        Assert.Equal(BuildSoundType.Wood, FurnitureBuildSoundMapper.Default);
+    }
+
+    [Theory]
+    [InlineData(BuildSoundType.Cardboard, 0)]
+    [InlineData(BuildSoundType.Wood, 1)]
+    [InlineData(BuildSoundType.Metal, 2)]
+    [InlineData(BuildSoundType.Plastic, 2)]
+    public void BuildSoundsMapToNativeValues(BuildSoundType soundType, int nativeValue)
+    {
+        Assert.Equal(
+            nativeValue,
+            Convert.ToInt32(FurnitureBuildSoundMapper.ToNative(soundType)));
+    }
+
+    [Fact]
+    public void BuildSoundRejectsUnknownValue()
+    {
+        FurnitureDefinitionBuilder builder = FurnitureCreator.CreateBuilder();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithBuildSound((BuildSoundType)int.MaxValue));
     }
 
     private static void AssertFluent(string name, params Type[] parameterTypes)

--- a/S1API.Tests/Items/FurnitureApiCompatibilityTests.cs
+++ b/S1API.Tests/Items/FurnitureApiCompatibilityTests.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using S1API.Items.Buildable;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+public sealed class FurnitureApiCompatibilityTests
+{
+    [Fact]
+    public void FurnitureBuilderExposesRuntimeAgnosticFluentSurface()
+    {
+        MethodInfo? createBuilder = typeof(FurnitureCreator).GetMethod(
+            nameof(FurnitureCreator.CreateBuilder),
+            Type.EmptyTypes);
+
+        Assert.NotNull(createBuilder);
+        Assert.Equal(typeof(FurnitureDefinitionBuilder), createBuilder!.ReturnType);
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithBasicInfo), typeof(string), typeof(string), typeof(string));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithModel), typeof(GameObject));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithPlacement), typeof(FurniturePlacementMode));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithFootprint), typeof(int), typeof(int));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithSurfacePlacement), typeof(FurnitureSurfaceType), typeof(bool));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithBuildSound), typeof(BuildSoundType));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithPricing), typeof(float), typeof(float));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithStackLimit), typeof(int));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithIcon), typeof(Sprite));
+        AssertFluent(nameof(FurnitureDefinitionBuilder.WithGeneratedIcon), typeof(int));
+
+        MethodInfo? build = typeof(FurnitureDefinitionBuilder).GetMethod(
+            nameof(FurnitureDefinitionBuilder.Build),
+            Type.EmptyTypes);
+        Assert.NotNull(build);
+        Assert.Equal(typeof(BuildableItemDefinition), build!.ReturnType);
+    }
+
+    [Fact]
+    public void PlacementEnumsExposeOnlySupportedNativeFamilies()
+    {
+        Assert.Equal(
+            new[] { FurniturePlacementMode.Grid, FurniturePlacementMode.Surface },
+            Enum.GetValues<FurniturePlacementMode>());
+        Assert.Equal(
+            FurnitureSurfaceType.Wall | FurnitureSurfaceType.Roof,
+            FurnitureSurfaceType.All);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(-1, 1)]
+    public void FootprintRejectsNonPositiveDimensions(int width, int depth)
+    {
+        FurnitureDefinitionBuilder builder = FurnitureCreator.CreateBuilder();
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.WithFootprint(width, depth));
+    }
+
+    [Theory]
+    [InlineData(FurnitureSurfaceType.None)]
+    [InlineData((FurnitureSurfaceType)8)]
+    public void SurfacePlacementRejectsEmptyOrUnknownFlags(FurnitureSurfaceType surfaceTypes)
+    {
+        FurnitureDefinitionBuilder builder = FurnitureCreator.CreateBuilder();
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithSurfacePlacement(surfaceTypes));
+    }
+
+    private static void AssertFluent(string name, params Type[] parameterTypes)
+    {
+        MethodInfo? method = typeof(FurnitureDefinitionBuilder).GetMethod(name, parameterTypes);
+        Assert.NotNull(method);
+        Assert.Equal(typeof(FurnitureDefinitionBuilder), method!.ReturnType);
+    }
+}

--- a/S1API.Tests/Items/FurnitureApiCompileFixture.cs
+++ b/S1API.Tests/Items/FurnitureApiCompileFixture.cs
@@ -1,0 +1,20 @@
+using S1API.Items.Buildable;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+internal static class FurnitureApiCompileFixture
+{
+    internal static FurnitureDefinitionBuilder Configure(GameObject model, Sprite icon)
+    {
+        return FurnitureCreator.CreateBuilder()
+            .WithBasicInfo("example.mod:sofa-chair", "Sofa Chair", "A compact chair.")
+            .WithModel(model)
+            .WithPlacement(FurniturePlacementMode.Grid)
+            .WithFootprint(2, 2)
+            .WithBuildSound(BuildSoundType.Wood)
+            .WithPricing(175f)
+            .WithStackLimit(4)
+            .WithIcon(icon);
+    }
+}

--- a/S1API.Tests/Items/FurnitureNativeCompositionContractTests.cs
+++ b/S1API.Tests/Items/FurnitureNativeCompositionContractTests.cs
@@ -15,8 +15,8 @@ public sealed class FurnitureNativeCompositionContractTests
     public void ComposerDoesNotExposeProceduralGridWithoutGenericNativeTemplate()
     {
         Assert.DoesNotContain(
-            "Procedural",
-            Enum.GetNames<global::S1API.Items.Buildable.FurniturePlacementMode>());
+            Enum.GetNames<global::S1API.Items.Buildable.FurniturePlacementMode>(),
+            name => name.StartsWith("Procedural", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/S1API.Tests/Items/FurnitureNativeCompositionContractTests.cs
+++ b/S1API.Tests/Items/FurnitureNativeCompositionContractTests.cs
@@ -1,0 +1,28 @@
+using S1API.Internal.Building;
+
+namespace S1API.Tests.Items;
+
+public sealed class FurnitureNativeCompositionContractTests
+{
+    [Fact]
+    public void ComposerUsesVerifiedNativeGridAndSurfaceTemplates()
+    {
+        Assert.Equal("grandfatherclock", FurnitureTemplateCatalog.GridItemId);
+        Assert.Equal("wallclock", FurnitureTemplateCatalog.SurfaceItemId);
+    }
+
+    [Fact]
+    public void ComposerDoesNotExposeProceduralGridWithoutGenericNativeTemplate()
+    {
+        Assert.DoesNotContain(
+            "Procedural",
+            Enum.GetNames<global::S1API.Items.Buildable.FurniturePlacementMode>());
+    }
+
+    [Fact]
+    public void ComposerAndGhostRuntimeShareAStableVisualMarker()
+    {
+        Assert.Equal("FurnitureVisual", BuildableGhostRuntime.FurnitureVisualName);
+        Assert.Equal("FurnitureGhostVisual", BuildableGhostRuntime.FurnitureGhostVisualName);
+    }
+}

--- a/S1API/Building/BuildEvents.cs
+++ b/S1API/Building/BuildEvents.cs
@@ -30,18 +30,25 @@ namespace S1API.Building
         /// <remarks>
         /// Subscribers receive a BuildEventArgs containing the item and GameObject.
         /// The GameObject can be modified to change appearance or behavior.
+        /// <see cref="BuildEventArgs.Storage"/> is null for items that are not storage containers.
         /// </remarks>
         public static event Action<BuildEventArgs>? OnGridItemCreated;
 
         /// <summary>
         /// Event raised after a surface item (table-top item) is created.
         /// </summary>
+        /// <remarks>
+        /// <see cref="BuildEventArgs.Storage"/> is null for items that are not storage containers.
+        /// </remarks>
         public static event Action<BuildEventArgs>? OnSurfaceItemCreated;
 
         /// <summary>
         /// Event raised after a buildable item component is initialized.
         /// This event fires for all buildable items and can be used for additional setup.
         /// </summary>
+        /// <remarks>
+        /// <see cref="BuildEventArgs.Storage"/> is null for items that are not storage containers.
+        /// </remarks>
         public static event Action<BuildEventArgs>? OnBuildableItemInitialized;
 
         /// <summary>

--- a/S1API/Internal/Building/BuildableGhostRuntime.cs
+++ b/S1API/Internal/Building/BuildableGhostRuntime.cs
@@ -77,6 +77,7 @@ namespace S1API.Internal.Building
         {
             Renderer[] existingRenderers = ghostRoot.GetComponentsInChildren<Renderer>(true);
             bool[] previousStates = new bool[existingRenderers.Length];
+            GameObject? createdVisual = null;
 
             try
             {
@@ -89,8 +90,11 @@ namespace S1API.Internal.Building
                     }
                 }
 
-                GameObject visual = visualFactory(ghostRoot.transform) ??
+                GameObject visual = visualFactory(ghostRoot.transform);
+                if (visual == null)
                     throw new InvalidOperationException("The buildable ghost visual factory returned null.");
+
+                createdVisual = visual;
                 if (!visual.transform.IsChildOf(ghostRoot.transform))
                     visual.transform.SetParent(ghostRoot.transform, false);
 
@@ -99,6 +103,9 @@ namespace S1API.Internal.Building
             }
             catch
             {
+                if (createdVisual != null)
+                    UnityEngine.Object.Destroy(createdVisual);
+
                 if (replaceExistingVisual)
                 {
                     for (int index = 0; index < existingRenderers.Length; index++)

--- a/S1API/Internal/Building/BuildableGhostRuntime.cs
+++ b/S1API/Internal/Building/BuildableGhostRuntime.cs
@@ -1,0 +1,131 @@
+#if (IL2CPPMELON)
+using S1Building = Il2CppScheduleOne.Building;
+#elif MONOMELON
+using S1Building = ScheduleOne.Building;
+#endif
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Internal.Building
+{
+    /// <summary>
+    /// Applies opt-in S1API visual configuration after the native placement system creates a ghost.
+    /// </summary>
+    internal static class BuildableGhostRuntime
+    {
+        internal const string FurnitureVisualName = "FurnitureVisual";
+        internal const string FurnitureGhostVisualName = "FurnitureGhostVisual";
+
+        private static readonly Dictionary<string, Action<GameObject>> Configurators =
+            new Dictionary<string, Action<GameObject>>(StringComparer.OrdinalIgnoreCase);
+
+        internal static void RegisterVisual(
+            string itemId,
+            Func<Transform, GameObject> visualFactory,
+            bool replaceExistingVisual)
+        {
+            if (string.IsNullOrWhiteSpace(itemId))
+                throw new ArgumentException("Buildable item ID cannot be null or whitespace.", nameof(itemId));
+            if (visualFactory == null)
+                throw new ArgumentNullException(nameof(visualFactory));
+
+            Configurators[itemId] = ghostRoot =>
+                CreateVisual(ghostRoot, visualFactory, replaceExistingVisual);
+        }
+
+        internal static void RegisterVisualSource(
+            string itemId,
+            GameObject visualSource,
+            string ghostVisualName,
+            bool replaceExistingVisual)
+        {
+            if (visualSource == null)
+                throw new ArgumentNullException(nameof(visualSource));
+            if (string.IsNullOrWhiteSpace(ghostVisualName))
+                throw new ArgumentException("Ghost visual name cannot be null or whitespace.", nameof(ghostVisualName));
+
+            RegisterVisual(
+                itemId,
+                parent =>
+                {
+                    GameObject visual = UnityEngine.Object.Instantiate(
+                        visualSource,
+                        parent,
+                        false);
+                    visual.name = ghostVisualName;
+                    return visual;
+                },
+                replaceExistingVisual);
+        }
+
+        internal static bool TryConfigure(string? itemId, GameObject? ghostRoot)
+        {
+            if (string.IsNullOrWhiteSpace(itemId) || ghostRoot == null)
+                return false;
+            if (!Configurators.TryGetValue(itemId, out Action<GameObject>? configure))
+                return false;
+
+            configure(ghostRoot);
+            return true;
+        }
+
+        private static void CreateVisual(
+            GameObject ghostRoot,
+            Func<Transform, GameObject> visualFactory,
+            bool replaceExistingVisual)
+        {
+            Renderer[] existingRenderers = ghostRoot.GetComponentsInChildren<Renderer>(true);
+            bool[] previousStates = new bool[existingRenderers.Length];
+
+            try
+            {
+                if (replaceExistingVisual)
+                {
+                    for (int index = 0; index < existingRenderers.Length; index++)
+                    {
+                        previousStates[index] = existingRenderers[index].enabled;
+                        existingRenderers[index].enabled = false;
+                    }
+                }
+
+                GameObject visual = visualFactory(ghostRoot.transform) ??
+                    throw new InvalidOperationException("The buildable ghost visual factory returned null.");
+                if (!visual.transform.IsChildOf(ghostRoot.transform))
+                    visual.transform.SetParent(ghostRoot.transform, false);
+
+                visual.SetActive(true);
+                PrepareVisualForGhost(visual);
+            }
+            catch
+            {
+                if (replaceExistingVisual)
+                {
+                    for (int index = 0; index < existingRenderers.Length; index++)
+                    {
+                        if (existingRenderers[index] != null)
+                            existingRenderers[index].enabled = previousStates[index];
+                    }
+                }
+
+                throw;
+            }
+        }
+
+        private static void PrepareVisualForGhost(GameObject visual)
+        {
+            S1Building.BuildManager? buildManager = S1Building.BuildManager.Instance;
+            if (buildManager == null)
+                throw new InvalidOperationException("The native build manager is unavailable while creating a placement ghost.");
+
+            // Native ghost preparation runs before S1API adds this visual. Apply the same
+            // non-interactive runtime contract to the late-added hierarchy.
+            buildManager.DisableColliders(visual);
+            buildManager.DisableNavigation(visual);
+            buildManager.DisableNetworking(visual);
+            buildManager.DisableCanvases(visual);
+            buildManager.DisableLights(visual);
+        }
+
+    }
+}

--- a/S1API/Internal/Building/FurnitureBuildSoundMapper.cs
+++ b/S1API/Internal/Building/FurnitureBuildSoundMapper.cs
@@ -1,0 +1,31 @@
+#if (IL2CPPMELON)
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+#elif MONOMELON
+using S1ItemFramework = ScheduleOne.ItemFramework;
+#endif
+using System;
+using S1API.Items.Buildable;
+
+namespace S1API.Internal.Building
+{
+    /// <summary>
+    /// Maps the public furniture sound choices without changing the legacy buildable builder's ordinal behavior.
+    /// </summary>
+    internal static class FurnitureBuildSoundMapper
+    {
+        internal const BuildSoundType Default = BuildSoundType.Wood;
+
+        internal static S1ItemFramework.BuildableItemDefinition.EBuildSoundType ToNative(
+            BuildSoundType soundType)
+        {
+            return soundType switch
+            {
+                BuildSoundType.Wood => S1ItemFramework.BuildableItemDefinition.EBuildSoundType.Wood,
+                BuildSoundType.Metal => S1ItemFramework.BuildableItemDefinition.EBuildSoundType.Metal,
+                BuildSoundType.Plastic => S1ItemFramework.BuildableItemDefinition.EBuildSoundType.Metal,
+                BuildSoundType.Cardboard => S1ItemFramework.BuildableItemDefinition.EBuildSoundType.Cardboard,
+                _ => throw new ArgumentOutOfRangeException(nameof(soundType)),
+            };
+        }
+    }
+}

--- a/S1API/Internal/Building/FurnitureComposition.cs
+++ b/S1API/Internal/Building/FurnitureComposition.cs
@@ -1,0 +1,33 @@
+#if (IL2CPPMELON)
+using S1EntityFramework = Il2CppScheduleOne.EntityFramework;
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Storage = Il2CppScheduleOne.Storage;
+#elif MONOMELON
+using S1EntityFramework = ScheduleOne.EntityFramework;
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Storage = ScheduleOne.Storage;
+#endif
+using S1API.Items;
+
+namespace S1API.Internal.Building
+{
+    internal sealed class FurnitureComposition
+    {
+        internal FurnitureComposition(
+            S1ItemFramework.BuildableItemDefinition templateDefinition,
+            S1EntityFramework.BuildableItem builtItem,
+            S1Storage.StoredItem storedItem,
+            Equippable equippable)
+        {
+            TemplateDefinition = templateDefinition;
+            BuiltItem = builtItem;
+            StoredItem = storedItem;
+            Equippable = equippable;
+        }
+
+        internal S1ItemFramework.BuildableItemDefinition TemplateDefinition { get; }
+        internal S1EntityFramework.BuildableItem BuiltItem { get; }
+        internal S1Storage.StoredItem StoredItem { get; }
+        internal Equippable Equippable { get; }
+    }
+}

--- a/S1API/Internal/Building/FurnitureIconRuntime.cs
+++ b/S1API/Internal/Building/FurnitureIconRuntime.cs
@@ -1,0 +1,117 @@
+using System.Collections;
+using System.Collections.Generic;
+using MelonLoader;
+using S1API.Items.Buildable;
+using S1API.Logging;
+using S1API.Rendering;
+using UnityEngine;
+
+namespace S1API.Internal.Building
+{
+    /// <summary>
+    /// Defers furniture thumbnail rendering until the gameplay scene provides the native icon rig.
+    /// Definitions remain available during pre-load so native save restoration can resolve them.
+    /// </summary>
+    internal static class FurnitureIconRuntime
+    {
+        private static readonly Log Logger = new Log("FurnitureIconRuntime");
+        private static readonly object Gate = new object();
+        private static readonly Queue<Request> Pending = new Queue<Request>();
+        private static bool _processing;
+
+        internal static void Queue(
+            BuildableItemDefinition definition,
+            Transform model,
+            int resolution)
+        {
+            bool startProcessor = false;
+            lock (Gate)
+            {
+                Pending.Enqueue(new Request(definition, model, resolution));
+                if (!_processing)
+                {
+                    _processing = true;
+                    startProcessor = true;
+                }
+            }
+
+            if (startProcessor)
+                MelonCoroutines.Start(ProcessQueue());
+        }
+
+        private static IEnumerator ProcessQueue()
+        {
+            while (true)
+            {
+                Request request;
+                lock (Gate)
+                {
+                    if (Pending.Count == 0)
+                    {
+                        _processing = false;
+                        yield break;
+                    }
+
+                    request = Pending.Dequeue();
+                }
+
+                const int readinessFrames = 600;
+                int readinessFrame = 0;
+                while (!IconFactory.IsItemIconGeneratorReady && readinessFrame < readinessFrames)
+                {
+                    readinessFrame++;
+                    yield return null;
+                }
+
+                if (!IconFactory.IsItemIconGeneratorReady)
+                {
+                    Logger.Warning(
+                        $"Could not generate furniture icon for '{request.Definition.ID}': " +
+                        "the native item-icon rendering rig did not become ready.");
+                    continue;
+                }
+
+                yield return new WaitForEndOfFrame();
+                GameObject iconModel = Object.Instantiate(request.Model.gameObject);
+                iconModel.name = $"{request.Model.name}_IconPreview";
+                Sprite? icon;
+                try
+                {
+                    icon = IconFactory.GenerateIconSprite(
+                        iconModel.transform,
+                        request.Resolution);
+                }
+                finally
+                {
+                    Object.Destroy(iconModel);
+                }
+                if (icon == null)
+                {
+                    Logger.Warning(
+                        $"Could not generate furniture icon for '{request.Definition.ID}': " +
+                        "the native renderer returned no sprite.");
+                    continue;
+                }
+
+                request.Definition.Icon = icon;
+            }
+        }
+
+        private sealed class Request
+        {
+            internal Request(
+                BuildableItemDefinition definition,
+                Transform model,
+                int resolution)
+            {
+                Definition = definition;
+                Model = model;
+                Resolution = resolution;
+            }
+
+            internal BuildableItemDefinition Definition { get; }
+            internal Transform Model { get; }
+            internal int Resolution { get; }
+        }
+    }
+}

--- a/S1API/Internal/Building/FurnitureIconRuntime.cs
+++ b/S1API/Internal/Building/FurnitureIconRuntime.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using MelonLoader;
 using S1API.Internal.Products;
+using S1API.Internal.Utils;
 using S1API.Items.Buildable;
 using S1API.Logging;
 using S1API.Rendering;
@@ -15,6 +16,7 @@ namespace S1API.Internal.Building
     /// </summary>
     internal static class FurnitureIconRuntime
     {
+        private const int RenderRigWaitFrames = 600;
         private static readonly Log Logger = new Log("FurnitureIconRuntime");
         private static readonly object Gate = new object();
         private static readonly Queue<Request> Pending = new Queue<Request>();
@@ -44,9 +46,8 @@ namespace S1API.Internal.Building
         {
             try
             {
-                const int readinessFrames = 600;
                 int readinessFrame = 0;
-                while (!IconFactory.IsItemIconGeneratorReady && readinessFrame < readinessFrames)
+                while (!IconFactory.IsItemIconGeneratorReady && readinessFrame < RenderRigWaitFrames)
                 {
                     readinessFrame++;
                     yield return null;
@@ -65,8 +66,15 @@ namespace S1API.Internal.Building
                 while (TryDequeue(out Request? request))
                 {
                     IEnumerator requestProcessor = ProcessRequest(request!);
-                    while (requestProcessor.MoveNext())
-                        yield return requestProcessor.Current;
+                    try
+                    {
+                        while (requestProcessor.MoveNext())
+                            yield return requestProcessor.Current;
+                    }
+                    finally
+                    {
+                        (requestProcessor as System.IDisposable)?.Dispose();
+                    }
                 }
             }
             finally
@@ -90,8 +98,22 @@ namespace S1API.Internal.Building
             GameObject? iconModel = null;
             try
             {
-                while (!ProductIconRenderRigArbiter.TryAcquire(renderLease))
+                int acquisitionFrame = 0;
+                bool leaseAcquired = false;
+                while (!(leaseAcquired = ProductIconRenderRigArbiter.TryAcquire(renderLease)) &&
+                       acquisitionFrame < RenderRigWaitFrames)
+                {
+                    acquisitionFrame++;
                     yield return null;
+                }
+
+                if (!leaseAcquired)
+                {
+                    Logger.Warning(
+                        $"Could not generate furniture icon for '{request.Definition.ID}': " +
+                        "the shared item-icon rendering rig remained busy.");
+                    yield break;
+                }
 
                 if (!TryCreatePreview(request, out iconModel, out string failure))
                 {
@@ -161,7 +183,7 @@ namespace S1API.Internal.Building
                     return false;
                 }
 
-                iconModel = Object.Instantiate(request.Model.gameObject);
+                iconModel = InactiveObjectCloner.CloneGameObject(request.Model.gameObject);
                 if (iconModel == null)
                 {
                     failure = "the source model could not be cloned";
@@ -169,6 +191,8 @@ namespace S1API.Internal.Building
                 }
 
                 iconModel.name = $"{request.Model.name}_IconPreview";
+                foreach (Collider collider in iconModel.GetComponentsInChildren<Collider>(true))
+                    collider.enabled = false;
                 iconModel.SetActive(true);
                 failure = string.Empty;
                 return true;

--- a/S1API/Internal/Building/FurnitureIconRuntime.cs
+++ b/S1API/Internal/Building/FurnitureIconRuntime.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using MelonLoader;
+using S1API.Internal.Products;
 using S1API.Items.Buildable;
 using S1API.Logging;
 using S1API.Rendering;
@@ -41,20 +42,8 @@ namespace S1API.Internal.Building
 
         private static IEnumerator ProcessQueue()
         {
-            while (true)
+            try
             {
-                Request request;
-                lock (Gate)
-                {
-                    if (Pending.Count == 0)
-                    {
-                        _processing = false;
-                        yield break;
-                    }
-
-                    request = Pending.Dequeue();
-                }
-
                 const int readinessFrames = 600;
                 int readinessFrame = 0;
                 while (!IconFactory.IsItemIconGeneratorReady && readinessFrame < readinessFrames)
@@ -65,36 +54,208 @@ namespace S1API.Internal.Building
 
                 if (!IconFactory.IsItemIconGeneratorReady)
                 {
+                    int requestCount = DrainPendingRequests();
                     Logger.Warning(
-                        $"Could not generate furniture icon for '{request.Definition.ID}': " +
-                        "the native item-icon rendering rig did not become ready.");
-                    continue;
+                        $"Could not generate {requestCount} furniture icon(s): " +
+                        "the native item-icon rendering rig did not become ready. " +
+                        "The definitions retain their native fallback icons.");
+                    yield break;
                 }
 
+                while (TryDequeue(out Request? request))
+                {
+                    IEnumerator requestProcessor = ProcessRequest(request!);
+                    while (requestProcessor.MoveNext())
+                        yield return requestProcessor.Current;
+                }
+            }
+            finally
+            {
+                FinishProcessing();
+            }
+        }
+
+        private static IEnumerator ProcessRequest(Request request)
+        {
+            if (request.Model == null)
+            {
+                Logger.Warning(
+                    $"Could not generate furniture icon for '{request.Definition.ID}': " +
+                    "the source model was destroyed before capture.");
+                yield break;
+            }
+
+            ProductIconRenderRigArbiter.CaptureLease renderLease =
+                ProductIconRenderRigArbiter.Enqueue();
+            GameObject? iconModel = null;
+            try
+            {
+                while (!ProductIconRenderRigArbiter.TryAcquire(renderLease))
+                    yield return null;
+
+                if (!TryCreatePreview(request, out iconModel, out string failure))
+                {
+                    Logger.Warning(
+                        $"Could not generate furniture icon for '{request.Definition.ID}': {failure}.");
+                    yield break;
+                }
+
+                const int maxRetries = 30;
+                bool generated = false;
+                for (int attempt = 0; attempt <= maxRetries; attempt++)
+                {
+                    // Let the newly activated preview complete Update and render before capture.
+                    yield return null;
+                    yield return new WaitForEndOfFrame();
+
+                    RenderAttemptResult result = TryRender(
+                        request,
+                        iconModel!,
+                        out Sprite? icon,
+                        out failure);
+                    if (result == RenderAttemptResult.Success)
+                    {
+                        request.Definition.Icon = icon!;
+                        generated = true;
+                        break;
+                    }
+
+                    if (result == RenderAttemptResult.Failure)
+                        break;
+                }
+
+                if (!generated)
+                {
+                    Logger.Warning(
+                        $"Could not generate furniture icon for '{request.Definition.ID}': {failure}.");
+                }
+
+                Object.Destroy(iconModel);
+                iconModel = null;
+
+                // Keep the shared rig lease through cleanup and a settled frame so the next
+                // queued subject cannot capture the outgoing preview.
+                yield return null;
                 yield return new WaitForEndOfFrame();
-                GameObject iconModel = Object.Instantiate(request.Model.gameObject);
-                iconModel.name = $"{request.Model.name}_IconPreview";
-                Sprite? icon;
-                try
-                {
-                    icon = IconFactory.GenerateIconSprite(
-                        iconModel.transform,
-                        request.Resolution);
-                }
-                finally
-                {
+            }
+            finally
+            {
+                if (iconModel != null)
                     Object.Destroy(iconModel);
+
+                ProductIconRenderRigArbiter.Release(renderLease);
+            }
+        }
+
+        private static bool TryCreatePreview(
+            Request request,
+            out GameObject? iconModel,
+            out string failure)
+        {
+            iconModel = null;
+            try
+            {
+                if (request.Model == null)
+                {
+                    failure = "the source model was destroyed before capture";
+                    return false;
                 }
+
+                iconModel = Object.Instantiate(request.Model.gameObject);
+                if (iconModel == null)
+                {
+                    failure = "the source model could not be cloned";
+                    return false;
+                }
+
+                iconModel.name = $"{request.Model.name}_IconPreview";
+                iconModel.SetActive(true);
+                failure = string.Empty;
+                return true;
+            }
+            catch (System.Exception exception)
+            {
+                failure = $"preview creation failed: {exception.Message}";
+                if (iconModel != null)
+                    Object.Destroy(iconModel);
+                iconModel = null;
+                return false;
+            }
+        }
+
+        private static RenderAttemptResult TryRender(
+            Request request,
+            GameObject iconModel,
+            out Sprite? icon,
+            out string failure)
+        {
+            icon = null;
+            try
+            {
+                icon = IconFactory.GenerateIconSprite(
+                    iconModel.transform,
+                    request.Resolution);
                 if (icon == null)
                 {
-                    Logger.Warning(
-                        $"Could not generate furniture icon for '{request.Definition.ID}': " +
-                        "the native renderer returned no sprite.");
-                    continue;
+                    failure = "the native renderer returned no visible pixels";
+                    return RenderAttemptResult.Retry;
                 }
 
-                request.Definition.Icon = icon;
+                failure = string.Empty;
+                return RenderAttemptResult.Success;
             }
+            catch (System.Exception exception)
+            {
+                failure = $"rendering failed: {exception.Message}";
+                return RenderAttemptResult.Failure;
+            }
+        }
+
+        private static bool TryDequeue(out Request? request)
+        {
+            lock (Gate)
+            {
+                if (Pending.Count == 0)
+                {
+                    request = null;
+                    return false;
+                }
+
+                request = Pending.Dequeue();
+                return true;
+            }
+        }
+
+        private static int DrainPendingRequests()
+        {
+            lock (Gate)
+            {
+                int requestCount = Pending.Count;
+                Pending.Clear();
+                return requestCount;
+            }
+        }
+
+        private static void FinishProcessing()
+        {
+            bool restart;
+            lock (Gate)
+            {
+                _processing = false;
+                restart = Pending.Count != 0;
+                if (restart)
+                    _processing = true;
+            }
+
+            if (restart)
+                MelonCoroutines.Start(ProcessQueue());
+        }
+
+        private enum RenderAttemptResult
+        {
+            Success,
+            Retry,
+            Failure,
         }
 
         private sealed class Request

--- a/S1API/Internal/Building/FurniturePrefabComposer.cs
+++ b/S1API/Internal/Building/FurniturePrefabComposer.cs
@@ -183,10 +183,11 @@ namespace S1API.Internal.Building
 
             // Grid build points are ground anchors. Moving one to the model center lowers the
             // footprint below the tile detectors, which makes the ghost invisible and invalid.
+            Vector3 boundsCenterWorld = builtItem.transform.TransformPoint(builtItemBounds.center);
             if (placementMode == FurniturePlacementMode.Surface && builtItem.BuildPoint != null)
-                builtItem.BuildPoint.localPosition = builtItemBounds.center;
+                builtItem.BuildPoint.position = boundsCenterWorld;
             if (builtItem.MidAirCenterPoint != null)
-                builtItem.MidAirCenterPoint.localPosition = builtItemBounds.center;
+                builtItem.MidAirCenterPoint.position = boundsCenterWorld;
         }
 
         private static Bounds CalculateCombinedBounds(

--- a/S1API/Internal/Building/FurniturePrefabComposer.cs
+++ b/S1API/Internal/Building/FurniturePrefabComposer.cs
@@ -80,14 +80,17 @@ namespace S1API.Internal.Building
 
             RuntimePrefabCache.Store(builtItem.gameObject);
 
-            var storedRoot = new GameObject($"{id}_StoredItem");
-            storedRoot.SetActive(false);
-            AddModelClone(model, storedRoot.transform, Vector3.zero, BuildableGhostRuntime.FurnitureVisualName);
-            S1Storage.StoredItem storedItem = storedRoot.AddComponent<S1Storage.StoredItem>();
-            RuntimePrefabCache.Store(storedRoot);
-
-            if (template.Equippable == null)
-                throw new InvalidOperationException($"Furniture template '{templateId}' has no native equippable prefab.");
+            S1Storage.StoredItem storedItem = InactiveObjectCloner.CloneComponent(
+                template.StoredItem,
+                parent: null);
+            storedItem.gameObject.name = $"{id}_StoredItem";
+            DisableTemplateRenderers(storedItem.gameObject);
+            AddModelClone(
+                model,
+                storedItem.transform,
+                Vector3.zero,
+                BuildableGhostRuntime.FurnitureVisualName);
+            RuntimePrefabCache.Store(storedItem.gameObject);
 
             return new FurnitureComposition(
                 template,
@@ -107,6 +110,10 @@ namespace S1API.Internal.Building
 
             if (definition.BuiltItem == null)
                 throw new InvalidOperationException($"Native furniture template '{templateId}' has no placed-item prefab.");
+            if (definition.StoredItem == null)
+                throw new InvalidOperationException($"Native furniture template '{templateId}' has no stored-item prefab.");
+            if (definition.Equippable == null)
+                throw new InvalidOperationException($"Native furniture template '{templateId}' has no native equippable prefab.");
 
             return definition;
         }
@@ -141,24 +148,19 @@ namespace S1API.Internal.Building
             if (renderers.Length == 0)
                 throw new ArgumentException("Furniture model must contain at least one Renderer.", nameof(model));
 
-            Bounds worldBounds = renderers[0].bounds;
-            for (int index = 1; index < renderers.Length; index++)
-                worldBounds.Encapsulate(renderers[index].bounds);
-
-            Vector3 localCenter = builtItem.transform.InverseTransformPoint(worldBounds.center);
-            Vector3 localSize = builtItem.transform.InverseTransformVector(worldBounds.size);
-            localSize = new Vector3(Mathf.Abs(localSize.x), Mathf.Abs(localSize.y), Mathf.Abs(localSize.z));
+            Bounds builtItemBounds = CalculateCombinedBounds(renderers, builtItem.transform);
+            Bounds modelBounds = CalculateCombinedBounds(renderers, model.transform);
 
             BoxCollider boundingCollider = builtItem.BoundingCollider;
             if (boundingCollider == null)
                 boundingCollider = builtItem.gameObject.AddComponent<BoxCollider>();
-            boundingCollider.center = localCenter;
-            boundingCollider.size = localSize;
+            boundingCollider.center = builtItemBounds.center;
+            boundingCollider.size = builtItemBounds.size;
             builtItem.BoundingCollider = boundingCollider;
 
             var collision = model.AddComponent<BoxCollider>();
-            collision.center = model.transform.InverseTransformPoint(worldBounds.center);
-            collision.size = model.transform.InverseTransformVector(worldBounds.size);
+            collision.center = modelBounds.center;
+            collision.size = modelBounds.size;
 
             builtItem.GameObjectsToCull = new[] { model };
 #if (IL2CPPMELON)
@@ -182,9 +184,75 @@ namespace S1API.Internal.Building
             // Grid build points are ground anchors. Moving one to the model center lowers the
             // footprint below the tile detectors, which makes the ghost invisible and invalid.
             if (placementMode == FurniturePlacementMode.Surface && builtItem.BuildPoint != null)
-                builtItem.BuildPoint.localPosition = localCenter;
+                builtItem.BuildPoint.localPosition = builtItemBounds.center;
             if (builtItem.MidAirCenterPoint != null)
-                builtItem.MidAirCenterPoint.localPosition = localCenter;
+                builtItem.MidAirCenterPoint.localPosition = builtItemBounds.center;
+        }
+
+        private static Bounds CalculateCombinedBounds(
+            Renderer[] renderers,
+            Transform relativeTo)
+        {
+            Bounds combined = default;
+            bool hasPoint = false;
+
+            foreach (Renderer renderer in renderers)
+            {
+                if (!TryGetRendererLocalBounds(renderer, out Bounds rendererBounds))
+                    continue;
+
+                Vector3 center = rendererBounds.center;
+                Vector3 extents = rendererBounds.extents;
+                for (int corner = 0; corner < 8; corner++)
+                {
+                    var offset = new Vector3(
+                        (corner & 1) == 0 ? -extents.x : extents.x,
+                        (corner & 2) == 0 ? -extents.y : extents.y,
+                        (corner & 4) == 0 ? -extents.z : extents.z);
+                    Vector3 point = relativeTo.InverseTransformPoint(
+                        renderer.transform.TransformPoint(center + offset));
+                    if (!hasPoint)
+                    {
+                        combined = new Bounds(point, Vector3.zero);
+                        hasPoint = true;
+                    }
+                    else
+                    {
+                        combined.Encapsulate(point);
+                    }
+                }
+            }
+
+            if (!hasPoint)
+            {
+                throw new ArgumentException(
+                    "Furniture model must contain a MeshRenderer with a mesh or a SkinnedMeshRenderer.",
+                    nameof(renderers));
+            }
+
+            return combined;
+        }
+
+        private static bool TryGetRendererLocalBounds(
+            Renderer renderer,
+            out Bounds bounds)
+        {
+            MeshFilter? meshFilter = renderer.GetComponent<MeshFilter>();
+            if (meshFilter != null && meshFilter.sharedMesh != null)
+            {
+                bounds = meshFilter.sharedMesh.bounds;
+                return true;
+            }
+
+            SkinnedMeshRenderer? skinnedRenderer = renderer.GetComponent<SkinnedMeshRenderer>();
+            if (skinnedRenderer != null)
+            {
+                bounds = skinnedRenderer.localBounds;
+                return true;
+            }
+
+            bounds = default;
+            return false;
         }
 
         private static void ConfigureGridFootprint(

--- a/S1API/Internal/Building/FurniturePrefabComposer.cs
+++ b/S1API/Internal/Building/FurniturePrefabComposer.cs
@@ -1,0 +1,266 @@
+#if (IL2CPPMELON)
+using S1Building = Il2CppScheduleOne.Building;
+using S1EntityFramework = Il2CppScheduleOne.EntityFramework;
+using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
+using S1Registry = Il2CppScheduleOne.Registry;
+using S1Storage = Il2CppScheduleOne.Storage;
+using S1Tiles = Il2CppScheduleOne.Tiles;
+#elif MONOMELON
+using S1Building = ScheduleOne.Building;
+using S1EntityFramework = ScheduleOne.EntityFramework;
+using S1ItemFramework = ScheduleOne.ItemFramework;
+using S1Registry = ScheduleOne.Registry;
+using S1Storage = ScheduleOne.Storage;
+using S1Tiles = ScheduleOne.Tiles;
+#endif
+using System;
+using S1API.Internal.Utils;
+using S1API.Items;
+using S1API.Items.Buildable;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace S1API.Internal.Building
+{
+    /// <summary>
+    /// Preserves the game's serialized build, save, and networking graph while replacing only
+    /// presentation, bounds, footprint, and surface-placement configuration.
+    /// </summary>
+    internal static class FurniturePrefabComposer
+    {
+        private const float GridTileSize = 0.5f;
+
+        internal static FurnitureComposition Compose(
+            string id,
+            GameObject model,
+            FurniturePlacementMode placementMode,
+            int footprintWidth,
+            int footprintDepth,
+            FurnitureSurfaceType surfaceTypes,
+            bool allowSurfaceRotation)
+        {
+            string templateId = placementMode == FurniturePlacementMode.Grid
+                ? FurnitureTemplateCatalog.GridItemId
+                : FurnitureTemplateCatalog.SurfaceItemId;
+            S1ItemFramework.BuildableItemDefinition template = GetTemplateDefinition(templateId);
+
+            S1EntityFramework.BuildableItem builtItem = InactiveObjectCloner.CloneComponent(
+                template.BuiltItem,
+                parent: null);
+            builtItem.gameObject.name = $"{id}_BuiltItem";
+            DisableTemplateRenderers(builtItem.gameObject);
+
+            Vector3 visualOffset = placementMode == FurniturePlacementMode.Grid
+                ? new Vector3(
+                    (footprintWidth - 1) * GridTileSize * 0.5f,
+                    0f,
+                    (footprintDepth - 1) * GridTileSize * 0.5f)
+                : Vector3.zero;
+            GameObject builtModel = AddModelClone(
+                model,
+                builtItem.transform,
+                visualOffset,
+                BuildableGhostRuntime.FurnitureVisualName);
+            ConfigureBoundsAndCulling(builtItem, builtModel, placementMode);
+
+            if (placementMode == FurniturePlacementMode.Grid)
+            {
+                if (!CrossType.Is(builtItem, out S1EntityFramework.GridItem gridItem))
+                    throw new InvalidOperationException($"Furniture template '{templateId}' is not a native GridItem.");
+
+                ConfigureGridFootprint(gridItem, footprintWidth, footprintDepth);
+            }
+            else
+            {
+                if (!CrossType.Is(builtItem, out S1EntityFramework.SurfaceItem surfaceItem))
+                    throw new InvalidOperationException($"Furniture template '{templateId}' is not a native SurfaceItem.");
+
+                ConfigureSurfacePlacement(surfaceItem, surfaceTypes, allowSurfaceRotation);
+            }
+
+            RuntimePrefabCache.Store(builtItem.gameObject);
+
+            var storedRoot = new GameObject($"{id}_StoredItem");
+            storedRoot.SetActive(false);
+            AddModelClone(model, storedRoot.transform, Vector3.zero, BuildableGhostRuntime.FurnitureVisualName);
+            S1Storage.StoredItem storedItem = storedRoot.AddComponent<S1Storage.StoredItem>();
+            RuntimePrefabCache.Store(storedRoot);
+
+            if (template.Equippable == null)
+                throw new InvalidOperationException($"Furniture template '{templateId}' has no native equippable prefab.");
+
+            return new FurnitureComposition(
+                template,
+                builtItem,
+                storedItem,
+                new Equippable(template.Equippable));
+        }
+
+        private static S1ItemFramework.BuildableItemDefinition GetTemplateDefinition(string templateId)
+        {
+            object? item = S1Registry.GetItem(templateId);
+            if (item == null || !CrossType.Is(item, out S1ItemFramework.BuildableItemDefinition definition))
+            {
+                throw new InvalidOperationException(
+                    $"Native furniture template '{templateId}' is unavailable. Build custom furniture after the item registry is initialized.");
+            }
+
+            if (definition.BuiltItem == null)
+                throw new InvalidOperationException($"Native furniture template '{templateId}' has no placed-item prefab.");
+
+            return definition;
+        }
+
+        private static GameObject AddModelClone(
+            GameObject model,
+            Transform parent,
+            Vector3 localPosition,
+            string name)
+        {
+            GameObject clone = InactiveObjectCloner.CloneGameObject(model);
+            clone.name = name;
+            clone.transform.SetParent(parent, false);
+            clone.transform.localPosition = localPosition;
+            clone.transform.localRotation = Quaternion.identity;
+            clone.SetActive(true);
+            return clone;
+        }
+
+        private static void DisableTemplateRenderers(GameObject root)
+        {
+            foreach (Renderer renderer in root.GetComponentsInChildren<Renderer>(true))
+                renderer.enabled = false;
+        }
+
+        private static void ConfigureBoundsAndCulling(
+            S1EntityFramework.BuildableItem builtItem,
+            GameObject model,
+            FurniturePlacementMode placementMode)
+        {
+            Renderer[] renderers = model.GetComponentsInChildren<Renderer>(true);
+            if (renderers.Length == 0)
+                throw new ArgumentException("Furniture model must contain at least one Renderer.", nameof(model));
+
+            Bounds worldBounds = renderers[0].bounds;
+            for (int index = 1; index < renderers.Length; index++)
+                worldBounds.Encapsulate(renderers[index].bounds);
+
+            Vector3 localCenter = builtItem.transform.InverseTransformPoint(worldBounds.center);
+            Vector3 localSize = builtItem.transform.InverseTransformVector(worldBounds.size);
+            localSize = new Vector3(Mathf.Abs(localSize.x), Mathf.Abs(localSize.y), Mathf.Abs(localSize.z));
+
+            BoxCollider boundingCollider = builtItem.BoundingCollider;
+            if (boundingCollider == null)
+                boundingCollider = builtItem.gameObject.AddComponent<BoxCollider>();
+            boundingCollider.center = localCenter;
+            boundingCollider.size = localSize;
+            builtItem.BoundingCollider = boundingCollider;
+
+            var collision = model.AddComponent<BoxCollider>();
+            collision.center = model.transform.InverseTransformPoint(worldBounds.center);
+            collision.size = model.transform.InverseTransformVector(worldBounds.size);
+
+            builtItem.GameObjectsToCull = new[] { model };
+#if (IL2CPPMELON)
+            builtItem.MeshesToCull = new Il2CppSystem.Collections.Generic.List<MeshRenderer>();
+#else
+            builtItem.MeshesToCull = new System.Collections.Generic.List<MeshRenderer>();
+#endif
+            foreach (MeshRenderer renderer in model.GetComponentsInChildren<MeshRenderer>(true))
+                builtItem.MeshesToCull.Add(renderer);
+
+#if (IL2CPPMELON)
+            var outlineRenderers = new Il2CppSystem.Collections.Generic.List<GameObject>();
+#else
+            var outlineRenderers = new System.Collections.Generic.List<GameObject>();
+#endif
+            foreach (Renderer renderer in renderers)
+                outlineRenderers.Add(renderer.gameObject);
+            if (!ReflectionUtils.TrySetFieldOrProperty(builtItem, "OutlineRenderers", outlineRenderers))
+                throw new InvalidOperationException("Native furniture template does not expose its outline renderer list.");
+
+            // Grid build points are ground anchors. Moving one to the model center lowers the
+            // footprint below the tile detectors, which makes the ghost invisible and invalid.
+            if (placementMode == FurniturePlacementMode.Surface && builtItem.BuildPoint != null)
+                builtItem.BuildPoint.localPosition = localCenter;
+            if (builtItem.MidAirCenterPoint != null)
+                builtItem.MidAirCenterPoint.localPosition = localCenter;
+        }
+
+        private static void ConfigureGridFootprint(
+            S1EntityFramework.GridItem gridItem,
+            int width,
+            int depth)
+        {
+            if (gridItem.CoordinateFootprintTilePairs == null ||
+                gridItem.CoordinateFootprintTilePairs.Count == 0 ||
+                gridItem.CoordinateFootprintTilePairs[0].footprintTile == null)
+            {
+                throw new InvalidOperationException("Native grid furniture template has no footprint tile to clone.");
+            }
+
+            S1Tiles.FootprintTile templateTile = gridItem.CoordinateFootprintTilePairs[0].footprintTile;
+            Transform oldFootprintRoot = templateTile.transform.parent;
+            if (oldFootprintRoot != null && oldFootprintRoot != gridItem.transform)
+                oldFootprintRoot.gameObject.SetActive(false);
+
+            var footprintRoot = new GameObject("FurnitureFootprint");
+            footprintRoot.transform.SetParent(gridItem.transform, false);
+            footprintRoot.SetActive(true);
+
+#if (IL2CPPMELON)
+            var pairs = new Il2CppSystem.Collections.Generic.List<S1Tiles.CoordinateFootprintTilePair>();
+#else
+            var pairs = new System.Collections.Generic.List<S1Tiles.CoordinateFootprintTilePair>();
+#endif
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < depth; y++)
+                {
+                    S1Tiles.FootprintTile tile = InactiveObjectCloner.CloneComponent(
+                        templateTile,
+                        footprintRoot.transform);
+                    tile.name = $"FootprintTile_{x}_{y}";
+                    tile.X = x;
+                    tile.Y = y;
+                    tile.transform.localPosition = new Vector3(x * GridTileSize, 0f, y * GridTileSize);
+                    tile.gameObject.SetActive(true);
+
+#if (IL2CPPMELON)
+                    var pair = new S1Tiles.CoordinateFootprintTilePair();
+                    pair.coord = new S1Tiles.Coordinate(x, y);
+                    pair.footprintTile = tile;
+#else
+                    var pair = new S1Tiles.CoordinateFootprintTilePair
+                    {
+                        coord = new S1Tiles.Coordinate(x, y),
+                        footprintTile = tile,
+                    };
+#endif
+                    pairs.Add(pair);
+                }
+            }
+
+            gridItem.CoordinateFootprintTilePairs = pairs;
+        }
+
+        private static void ConfigureSurfacePlacement(
+            S1EntityFramework.SurfaceItem surfaceItem,
+            FurnitureSurfaceType surfaceTypes,
+            bool allowRotation)
+        {
+#if (IL2CPPMELON)
+            var nativeTypes = new Il2CppSystem.Collections.Generic.List<S1Building.Surface.ESurfaceType>();
+#else
+            var nativeTypes = new System.Collections.Generic.List<S1Building.Surface.ESurfaceType>();
+#endif
+            if ((surfaceTypes & FurnitureSurfaceType.Wall) != 0)
+                nativeTypes.Add(S1Building.Surface.ESurfaceType.Wall);
+            if ((surfaceTypes & FurnitureSurfaceType.Roof) != 0)
+                nativeTypes.Add(S1Building.Surface.ESurfaceType.Roof);
+
+            surfaceItem.ValidSurfaceTypes = nativeTypes;
+            surfaceItem.AllowRotation = allowRotation;
+        }
+    }
+}

--- a/S1API/Internal/Building/FurnitureTemplateCatalog.cs
+++ b/S1API/Internal/Building/FurnitureTemplateCatalog.cs
@@ -1,0 +1,11 @@
+namespace S1API.Internal.Building
+{
+    /// <summary>
+    /// Stable vanilla definitions whose serialized prefab graphs provide the generic placement contract.
+    /// </summary>
+    internal static class FurnitureTemplateCatalog
+    {
+        internal const string GridItemId = "grandfatherclock";
+        internal const string SurfaceItemId = "wallclock";
+    }
+}

--- a/S1API/Internal/Patches/BuildingPatches.cs
+++ b/S1API/Internal/Patches/BuildingPatches.cs
@@ -12,6 +12,7 @@ using S1EntityFramework = ScheduleOne.EntityFramework;
 
 using HarmonyLib;
 using S1API.Building;
+using S1API.Internal.Building;
 using S1API.Items;
 using S1API.Storage;
 using S1API.Logging;
@@ -26,6 +27,51 @@ namespace S1API.Internal.Patches
     internal static class BuildingPatches
     {
         private static readonly Log Logger = new Log("BuildingPatches");
+
+        [HarmonyPatch(typeof(S1Building.BuildStart_Grid), "CreateGhostModel")]
+        [HarmonyPostfix]
+        private static void CreateGridGhostModel_Postfix(
+            S1ItemFramework.BuildableItemDefinition itemDefinition,
+            S1EntityFramework.GridItem __result)
+        {
+            ConfigureGhostVisual(itemDefinition, __result);
+        }
+
+        [HarmonyPatch(typeof(S1Building.BuildStart_Surface), "CreateGhostModel")]
+        [HarmonyPostfix]
+        private static void CreateSurfaceGhostModel_Postfix(
+            S1ItemFramework.BuildableItemDefinition itemDefinition,
+            S1EntityFramework.SurfaceItem __result)
+        {
+            ConfigureGhostVisual(itemDefinition, __result);
+        }
+
+        [HarmonyPatch(typeof(S1Building.BuildStart_ProceduralGrid), "CreateGhostModel")]
+        [HarmonyPostfix]
+        private static void CreateProceduralGridGhostModel_Postfix(
+            S1ItemFramework.BuildableItemDefinition itemDefinition,
+            S1EntityFramework.ProceduralGridItem __result)
+        {
+            ConfigureGhostVisual(itemDefinition, __result);
+        }
+
+        private static void ConfigureGhostVisual(
+            S1ItemFramework.BuildableItemDefinition itemDefinition,
+            S1EntityFramework.BuildableItem ghost)
+        {
+            if (itemDefinition == null || ghost == null)
+                return;
+
+            try
+            {
+                BuildableGhostRuntime.TryConfigure(itemDefinition.ID, ghost.gameObject);
+            }
+            catch (System.Exception ex)
+            {
+                Logger.Error(
+                    $"Failed to configure placement ghost for buildable '{itemDefinition.ID}': {ex}");
+            }
+        }
 
         /// <summary>
         /// Patch for BuildManager.CreateGridItem - raises OnGridItemCreated event.
@@ -49,7 +95,6 @@ namespace S1API.Internal.Patches
                     storageWrapper = new StorageEntity(placeableStorage.StorageEntity, placeableStorage);
                 }
 
-                if (storageWrapper == null) return;
                 var args = new BuildEventArgs(itemInstance, __result.gameObject, storageWrapper);
                 BuildEvents.RaiseGridItemCreated(args);
             }
@@ -81,7 +126,6 @@ namespace S1API.Internal.Patches
                     storageWrapper = new StorageEntity(placeableStorage.StorageEntity, placeableStorage);
                 }
 
-                if (storageWrapper == null) return;
                 var args = new BuildEventArgs(itemInstance, __result.gameObject, storageWrapper);
                 BuildEvents.RaiseSurfaceItemCreated(args);
             }
@@ -113,7 +157,6 @@ namespace S1API.Internal.Patches
                     storageWrapper = new StorageEntity(placeableStorage.StorageEntity, placeableStorage);
                 }
 
-                if (storageWrapper == null) return;
                 var args = new BuildEventArgs(itemInstance, __instance.gameObject, storageWrapper);
                 BuildEvents.RaiseBuildableItemInitialized(args);
             }

--- a/S1API/Items/Buildable/BuildableItemDefinitionBuilder.cs
+++ b/S1API/Items/Buildable/BuildableItemDefinitionBuilder.cs
@@ -1,10 +1,14 @@
 ﻿#if (IL2CPPMELON)
 using S1ItemFramework = Il2CppScheduleOne.ItemFramework;
 using S1CoreItemFramework = Il2CppScheduleOne.Core.Items.Framework;
+using S1EntityFramework = Il2CppScheduleOne.EntityFramework;
 #elif MONOMELON
 using S1ItemFramework = ScheduleOne.ItemFramework;
 using S1CoreItemFramework = ScheduleOne.Core.Items.Framework;
+using S1EntityFramework = ScheduleOne.EntityFramework;
 #endif
+using System;
+using S1API.Internal.Building;
 using S1API.Internal.Utils;
 using S1API.Items.Storable;
 using UnityEngine;
@@ -18,6 +22,9 @@ namespace S1API.Items.Buildable
     public class BuildableItemDefinitionBuilder
         : StorableItemDefinitionBuilderBase<BuildableItemDefinitionBuilder>
     {
+        private Func<Transform, GameObject>? _ghostVisualFactory;
+        private bool _replaceExistingGhostVisual;
+
         private S1ItemFramework.BuildableItemDefinition BuildableDefinition =>
             CrossType.As<S1ItemFramework.BuildableItemDefinition>(Definition);
 
@@ -63,12 +70,40 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>
+        /// Configures an optional visual created whenever the native placement system creates this
+        /// buildable's ghost. The factory runs on Unity's main thread and must return the created
+        /// visual. S1API parents and activates it under the supplied ghost transform.
+        /// </summary>
+        /// <param name="visualFactory">Creates the visual under the supplied placement-ghost transform.</param>
+        /// <param name="replaceExistingVisual">
+        /// Whether S1API should hide renderers inherited from the native buildable before creating the visual.
+        /// </param>
+        /// <returns>The builder instance for fluent chaining.</returns>
+        public BuildableItemDefinitionBuilder WithGhostVisual(
+            Func<Transform, GameObject> visualFactory,
+            bool replaceExistingVisual = false)
+        {
+            _ghostVisualFactory = visualFactory ?? throw new ArgumentNullException(nameof(visualFactory));
+            _replaceExistingGhostVisual = replaceExistingVisual;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the item definition, registers it with the game's registry, and returns a wrapper.
         /// </summary>
         /// <returns>A wrapper around the created buildable item definition.</returns>
         public new BuildableItemDefinition Build()
         {
-            return (BuildableItemDefinition)base.Build();
+            BuildableItemDefinition definition = (BuildableItemDefinition)base.Build();
+            if (_ghostVisualFactory != null)
+            {
+                BuildableGhostRuntime.RegisterVisual(
+                    BuildableDefinition.ID,
+                    _ghostVisualFactory,
+                    _replaceExistingGhostVisual);
+            }
+
+            return definition;
         }
 
         /// <summary>
@@ -78,6 +113,15 @@ namespace S1API.Items.Buildable
         internal new S1ItemFramework.BuildableItemDefinition BuildInternal()
         {
             return BuildableDefinition;
+        }
+
+        /// <summary>
+        /// INTERNAL: Assigns the native placed-item prefab composed by S1API.
+        /// </summary>
+        internal BuildableItemDefinitionBuilder WithBuiltItem(S1EntityFramework.BuildableItem builtItem)
+        {
+            BuildableDefinition.BuiltItem = builtItem;
+            return this;
         }
 
         /// <inheritdoc />

--- a/S1API/Items/Buildable/BuildableItemDefinitionBuilder.cs
+++ b/S1API/Items/Buildable/BuildableItemDefinitionBuilder.cs
@@ -70,6 +70,16 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>
+        /// INTERNAL: Assigns a native build-sound value after a caller-specific compatibility mapping.
+        /// </summary>
+        internal BuildableItemDefinitionBuilder WithNativeBuildSound(
+            S1ItemFramework.BuildableItemDefinition.EBuildSoundType soundType)
+        {
+            BuildableDefinition.BuildSoundType = soundType;
+            return this;
+        }
+
+        /// <summary>
         /// Configures an optional visual created whenever the native placement system creates this
         /// buildable's ghost. The factory runs on Unity's main thread and must return the created
         /// visual. S1API parents and activates it under the supplied ghost transform.

--- a/S1API/Items/Buildable/FurnitureCreator.cs
+++ b/S1API/Items/Buildable/FurnitureCreator.cs
@@ -1,0 +1,16 @@
+namespace S1API.Items.Buildable
+{
+    /// <summary>
+    /// Creates first-class custom furniture backed by the game's native building system.
+    /// </summary>
+    public static class FurnitureCreator
+    {
+        /// <summary>
+        /// Creates a builder for a custom placeable furniture item.
+        /// </summary>
+        public static FurnitureDefinitionBuilder CreateBuilder()
+        {
+            return new FurnitureDefinitionBuilder();
+        }
+    }
+}

--- a/S1API/Items/Buildable/FurnitureCreator.cs
+++ b/S1API/Items/Buildable/FurnitureCreator.cs
@@ -8,6 +8,7 @@ namespace S1API.Items.Buildable
         /// <summary>
         /// Creates a builder for a custom placeable furniture item.
         /// </summary>
+        /// <returns>A new furniture definition builder with grid-placement defaults.</returns>
         public static FurnitureDefinitionBuilder CreateBuilder()
         {
             return new FurnitureDefinitionBuilder();

--- a/S1API/Items/Buildable/FurnitureDefinitionBuilder.cs
+++ b/S1API/Items/Buildable/FurnitureDefinitionBuilder.cs
@@ -18,7 +18,7 @@ namespace S1API.Items.Buildable
         private int _footprintDepth = 1;
         private FurnitureSurfaceType _surfaceTypes = FurnitureSurfaceType.Wall;
         private bool _allowSurfaceRotation = true;
-        private BuildSoundType _buildSound = BuildSoundType.Wood;
+        private BuildSoundType _buildSound = FurnitureBuildSoundMapper.Default;
         private int _stackLimit = 10;
         private float _purchasePrice = 10f;
         private float _resellMultiplier = 0.5f;
@@ -31,6 +31,10 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Sets the stable registry ID and player-facing text.</summary>
+        /// <param name="id">The stable item ID shared by every multiplayer peer.</param>
+        /// <param name="name">The player-facing item name.</param>
+        /// <param name="description">The player-facing item description. An empty description is allowed.</param>
+        /// <returns>This builder for fluent chaining.</returns>
         public FurnitureDefinitionBuilder WithBasicInfo(string id, string name, string description)
         {
             _id = id;
@@ -43,13 +47,22 @@ namespace S1API.Items.Buildable
         /// Sets the model used for the placed object, placement ghost, stored item, and generated icon.
         /// The supplied object is cloned and is never modified by S1API.
         /// </summary>
+        /// <param name="model">The model root to clone. It must contain at least one mesh renderer.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="model"/> is null.</exception>
         public FurnitureDefinitionBuilder WithModel(GameObject model)
         {
-            _model = model != null ? model : throw new ArgumentNullException(nameof(model));
+            if (ReferenceEquals(model, null) || model == null)
+                throw new ArgumentNullException(nameof(model));
+
+            _model = model;
             return this;
         }
 
         /// <summary>Chooses the native placement family.</summary>
+        /// <param name="placementMode">The grid or surface placement family to compose.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown for an undefined placement mode.</exception>
         public FurnitureDefinitionBuilder WithPlacement(FurniturePlacementMode placementMode)
         {
             if (!Enum.IsDefined(typeof(FurniturePlacementMode), placementMode))
@@ -60,6 +73,10 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Sets the floor-grid footprint in 0.5 metre tiles.</summary>
+        /// <param name="width">The positive footprint width in grid tiles.</param>
+        /// <param name="depth">The positive footprint depth in grid tiles.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when either dimension is less than one.</exception>
         public FurnitureDefinitionBuilder WithFootprint(int width, int depth)
         {
             if (width < 1)
@@ -73,6 +90,12 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Configures valid surfaces and rotation for surface-placed furniture.</summary>
+        /// <param name="surfaceTypes">One or more supported wall or roof surface flags.</param>
+        /// <param name="allowRotation">Whether the player can rotate the item during surface placement.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="surfaceTypes"/> is empty or contains an unknown flag.
+        /// </exception>
         public FurnitureDefinitionBuilder WithSurfacePlacement(
             FurnitureSurfaceType surfaceTypes,
             bool allowRotation = true)
@@ -89,13 +112,24 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Sets the sound family used when placement completes.</summary>
+        /// <param name="buildSound">
+        /// The public sound family. Plastic uses the native metal sound because the game has no plastic family.
+        /// </param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown for an undefined sound family.</exception>
         public FurnitureDefinitionBuilder WithBuildSound(BuildSoundType buildSound)
         {
+            if (!Enum.IsDefined(typeof(BuildSoundType), buildSound))
+                throw new ArgumentOutOfRangeException(nameof(buildSound));
+
             _buildSound = buildSound;
             return this;
         }
 
         /// <summary>Sets the purchase and resale values.</summary>
+        /// <param name="basePurchasePrice">The non-negative base purchase price.</param>
+        /// <param name="resellMultiplier">The resale fraction, clamped between zero and one.</param>
+        /// <returns>This builder for fluent chaining.</returns>
         public FurnitureDefinitionBuilder WithPricing(float basePurchasePrice, float resellMultiplier = 0.5f)
         {
             _purchasePrice = Mathf.Max(0f, basePurchasePrice);
@@ -104,6 +138,8 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Sets the inventory stack limit.</summary>
+        /// <param name="stackLimit">The stack limit, clamped between 1 and 999.</param>
+        /// <returns>This builder for fluent chaining.</returns>
         public FurnitureDefinitionBuilder WithStackLimit(int stackLimit)
         {
             _stackLimit = Mathf.Clamp(stackLimit, 1, 999);
@@ -111,9 +147,15 @@ namespace S1API.Items.Buildable
         }
 
         /// <summary>Uses an existing inventory icon.</summary>
+        /// <param name="icon">The icon to assign without using the native render rig.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="icon"/> is null.</exception>
         public FurnitureDefinitionBuilder WithIcon(Sprite icon)
         {
-            _icon = icon != null ? icon : throw new ArgumentNullException(nameof(icon));
+            if (ReferenceEquals(icon, null) || icon == null)
+                throw new ArgumentNullException(nameof(icon));
+
+            _icon = icon;
             _generateIcon = false;
             return this;
         }
@@ -122,6 +164,11 @@ namespace S1API.Items.Buildable
         /// Queues inventory-icon generation from the supplied model. The definition registers immediately,
         /// and S1API replaces its fallback icon when the gameplay rendering rig becomes available.
         /// </summary>
+        /// <param name="resolution">The square icon resolution from 64 through 2048 pixels.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown when <paramref name="resolution"/> is outside the supported range.
+        /// </exception>
         public FurnitureDefinitionBuilder WithGeneratedIcon(int resolution = 512)
         {
             if (resolution < 64 || resolution > 2048)
@@ -138,6 +185,10 @@ namespace S1API.Items.Buildable
         /// Call this after the game's item registry and vanilla furniture definitions are available.
         /// Every multiplayer peer must perform the same registration.
         /// </summary>
+        /// <returns>The registered custom furniture definition.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when required identity or model configuration is missing, or a native donor is unavailable.
+        /// </exception>
         public BuildableItemDefinition Build()
         {
             Validate();
@@ -153,7 +204,7 @@ namespace S1API.Items.Buildable
 
             var builder = new BuildableItemDefinitionBuilder(composition.TemplateDefinition)
                 .WithBasicInfo(_id!, _name!, _description!, ItemCategory.Furniture)
-                .WithBuildSound(_buildSound)
+                .WithNativeBuildSound(FurnitureBuildSoundMapper.ToNative(_buildSound))
                 .WithPricing(_purchasePrice, _resellMultiplier)
                 .WithStackLimit(_stackLimit)
                 .WithBuiltItem(composition.BuiltItem)

--- a/S1API/Items/Buildable/FurnitureDefinitionBuilder.cs
+++ b/S1API/Items/Buildable/FurnitureDefinitionBuilder.cs
@@ -1,0 +1,196 @@
+using System;
+using S1API.Internal.Building;
+using UnityEngine;
+
+namespace S1API.Items.Buildable
+{
+    /// <summary>
+    /// Composes a custom model into a native furniture definition, placement prefab, and inventory prefab.
+    /// </summary>
+    public sealed class FurnitureDefinitionBuilder
+    {
+        private string? _id;
+        private string? _name;
+        private string? _description;
+        private GameObject? _model;
+        private FurniturePlacementMode _placementMode = FurniturePlacementMode.Grid;
+        private int _footprintWidth = 1;
+        private int _footprintDepth = 1;
+        private FurnitureSurfaceType _surfaceTypes = FurnitureSurfaceType.Wall;
+        private bool _allowSurfaceRotation = true;
+        private BuildSoundType _buildSound = BuildSoundType.Wood;
+        private int _stackLimit = 10;
+        private float _purchasePrice = 10f;
+        private float _resellMultiplier = 0.5f;
+        private Sprite? _icon;
+        private bool _generateIcon = true;
+        private int _generatedIconResolution = 512;
+
+        internal FurnitureDefinitionBuilder()
+        {
+        }
+
+        /// <summary>Sets the stable registry ID and player-facing text.</summary>
+        public FurnitureDefinitionBuilder WithBasicInfo(string id, string name, string description)
+        {
+            _id = id;
+            _name = name;
+            _description = description;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the model used for the placed object, placement ghost, stored item, and generated icon.
+        /// The supplied object is cloned and is never modified by S1API.
+        /// </summary>
+        public FurnitureDefinitionBuilder WithModel(GameObject model)
+        {
+            _model = model != null ? model : throw new ArgumentNullException(nameof(model));
+            return this;
+        }
+
+        /// <summary>Chooses the native placement family.</summary>
+        public FurnitureDefinitionBuilder WithPlacement(FurniturePlacementMode placementMode)
+        {
+            if (!Enum.IsDefined(typeof(FurniturePlacementMode), placementMode))
+                throw new ArgumentOutOfRangeException(nameof(placementMode));
+
+            _placementMode = placementMode;
+            return this;
+        }
+
+        /// <summary>Sets the floor-grid footprint in 0.5 metre tiles.</summary>
+        public FurnitureDefinitionBuilder WithFootprint(int width, int depth)
+        {
+            if (width < 1)
+                throw new ArgumentOutOfRangeException(nameof(width), "Footprint width must be at least one tile.");
+            if (depth < 1)
+                throw new ArgumentOutOfRangeException(nameof(depth), "Footprint depth must be at least one tile.");
+
+            _footprintWidth = width;
+            _footprintDepth = depth;
+            return this;
+        }
+
+        /// <summary>Configures valid surfaces and rotation for surface-placed furniture.</summary>
+        public FurnitureDefinitionBuilder WithSurfacePlacement(
+            FurnitureSurfaceType surfaceTypes,
+            bool allowRotation = true)
+        {
+            if (surfaceTypes == FurnitureSurfaceType.None ||
+                (surfaceTypes & ~FurnitureSurfaceType.All) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(surfaceTypes));
+            }
+
+            _surfaceTypes = surfaceTypes;
+            _allowSurfaceRotation = allowRotation;
+            return this;
+        }
+
+        /// <summary>Sets the sound family used when placement completes.</summary>
+        public FurnitureDefinitionBuilder WithBuildSound(BuildSoundType buildSound)
+        {
+            _buildSound = buildSound;
+            return this;
+        }
+
+        /// <summary>Sets the purchase and resale values.</summary>
+        public FurnitureDefinitionBuilder WithPricing(float basePurchasePrice, float resellMultiplier = 0.5f)
+        {
+            _purchasePrice = Mathf.Max(0f, basePurchasePrice);
+            _resellMultiplier = Mathf.Clamp01(resellMultiplier);
+            return this;
+        }
+
+        /// <summary>Sets the inventory stack limit.</summary>
+        public FurnitureDefinitionBuilder WithStackLimit(int stackLimit)
+        {
+            _stackLimit = Mathf.Clamp(stackLimit, 1, 999);
+            return this;
+        }
+
+        /// <summary>Uses an existing inventory icon.</summary>
+        public FurnitureDefinitionBuilder WithIcon(Sprite icon)
+        {
+            _icon = icon != null ? icon : throw new ArgumentNullException(nameof(icon));
+            _generateIcon = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Queues inventory-icon generation from the supplied model. The definition registers immediately,
+        /// and S1API replaces its fallback icon when the gameplay rendering rig becomes available.
+        /// </summary>
+        public FurnitureDefinitionBuilder WithGeneratedIcon(int resolution = 512)
+        {
+            if (resolution < 64 || resolution > 2048)
+                throw new ArgumentOutOfRangeException(nameof(resolution), "Icon resolution must be between 64 and 2048 pixels.");
+
+            _generateIcon = true;
+            _icon = null;
+            _generatedIconResolution = resolution;
+            return this;
+        }
+
+        /// <summary>
+        /// Creates and registers the complete native buildable definition.
+        /// Call this after the game's item registry and vanilla furniture definitions are available.
+        /// Every multiplayer peer must perform the same registration.
+        /// </summary>
+        public BuildableItemDefinition Build()
+        {
+            Validate();
+
+            FurnitureComposition composition = FurniturePrefabComposer.Compose(
+                _id!,
+                _model!,
+                _placementMode,
+                _footprintWidth,
+                _footprintDepth,
+                _surfaceTypes,
+                _allowSurfaceRotation);
+
+            var builder = new BuildableItemDefinitionBuilder(composition.TemplateDefinition)
+                .WithBasicInfo(_id!, _name!, _description!, ItemCategory.Furniture)
+                .WithBuildSound(_buildSound)
+                .WithPricing(_purchasePrice, _resellMultiplier)
+                .WithStackLimit(_stackLimit)
+                .WithBuiltItem(composition.BuiltItem)
+                .WithStoredItem(composition.StoredItem.gameObject)
+                .WithEquippable(composition.Equippable);
+            if (_icon != null)
+                builder.WithIcon(_icon);
+
+            BuildableItemDefinition definition = builder.Build();
+            Transform? visual = composition.BuiltItem.transform.Find(
+                BuildableGhostRuntime.FurnitureVisualName);
+            if (visual == null)
+                throw new InvalidOperationException("Composed furniture has no placement visual source.");
+
+            BuildableGhostRuntime.RegisterVisualSource(
+                _id!,
+                visual.gameObject,
+                BuildableGhostRuntime.FurnitureGhostVisualName,
+                replaceExistingVisual: true);
+            if (_generateIcon)
+            {
+                FurnitureIconRuntime.Queue(definition, visual, _generatedIconResolution);
+            }
+
+            return definition;
+        }
+
+        private void Validate()
+        {
+            if (string.IsNullOrWhiteSpace(_id))
+                throw new InvalidOperationException("Furniture ID must be configured before Build().");
+            if (string.IsNullOrWhiteSpace(_name))
+                throw new InvalidOperationException("Furniture name must be configured before Build().");
+            if (_description == null)
+                throw new InvalidOperationException("Furniture description must be configured before Build().");
+            if (_model == null)
+                throw new InvalidOperationException("Furniture model must be configured before Build().");
+        }
+    }
+}

--- a/S1API/Items/Buildable/FurniturePlacementMode.cs
+++ b/S1API/Items/Buildable/FurniturePlacementMode.cs
@@ -1,0 +1,14 @@
+namespace S1API.Items.Buildable
+{
+    /// <summary>
+    /// Native placement families supported by the furniture builder.
+    /// </summary>
+    public enum FurniturePlacementMode
+    {
+        /// <summary>Places the item on a property's floor grid.</summary>
+        Grid,
+
+        /// <summary>Places the item on a compatible wall or roof surface.</summary>
+        Surface,
+    }
+}

--- a/S1API/Items/Buildable/FurnitureSurfaceType.cs
+++ b/S1API/Items/Buildable/FurnitureSurfaceType.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace S1API.Items.Buildable
+{
+    /// <summary>
+    /// Surface types accepted by surface-placed furniture.
+    /// </summary>
+    [Flags]
+    public enum FurnitureSurfaceType
+    {
+        /// <summary>No surface type.</summary>
+        None = 0,
+
+        /// <summary>Vertical wall surfaces.</summary>
+        Wall = 1,
+
+        /// <summary>Horizontal roof or ceiling surfaces.</summary>
+        Roof = 2,
+
+        /// <summary>All supported surface types.</summary>
+        All = Wall | Roof,
+    }
+}

--- a/S1API/docs/furniture-items.md
+++ b/S1API/docs/furniture-items.md
@@ -1,0 +1,83 @@
+# Custom Furniture
+
+`FurnitureCreator` turns a mod-provided `GameObject` into a complete native buildable item. S1API
+creates the placed prefab, placement ghost source, footprint, bounds, collision, culling metadata,
+stored-item prefab, equippable reference, definition, and icon while preserving Schedule One's
+serialized build handlers, save lifecycle, and multiplayer initialization.
+
+## Grid furniture
+
+The model can come from any loader that returns a Unity `GameObject`. This example uses an embedded
+GLB loaded by S1MAPI:
+
+```csharp
+using S1API.Items.Buildable;
+using S1MAPI.Gltf;
+using S1MAPI.Utils;
+using UnityEngine;
+
+byte[] glb = EmbeddedResourceLoader.LoadBytes("MyMod.Assets.SofaChair.glb")
+    ?? throw new InvalidOperationException("Embedded chair model is missing.");
+GameObject model = GltfLoader.LoadGlb(
+        glb,
+        Shader.Find("Universal Render Pipeline/Lit"))
+    ?? throw new InvalidOperationException("Chair GLB could not be loaded.");
+
+var chair = FurnitureCreator.CreateBuilder()
+    .WithBasicInfo("my-mod:sofa-chair", "Sofa Chair", "A compact upholstered chair.")
+    .WithModel(model)
+    .WithPlacement(FurniturePlacementMode.Grid)
+    .WithFootprint(2, 2)
+    .WithBuildSound(BuildSoundType.Wood)
+    .WithPricing(175f, 0.5f)
+    .WithStackLimit(4)
+    .WithGeneratedIcon()
+    .Build();
+```
+
+Grid footprint cells are 0.5 metres. Size the footprint to cover the model's horizontal bounds;
+for example, a model just under one metre wide and deep uses `WithFootprint(2, 2)`.
+
+## Surface furniture
+
+Use surface placement for wall or roof-mounted decorations:
+
+```csharp
+var wallSign = FurnitureCreator.CreateBuilder()
+    .WithBasicInfo("my-mod:wall-sign", "Wall Sign", "A placeable wall sign.")
+    .WithModel(signModel)
+    .WithPlacement(FurniturePlacementMode.Surface)
+    .WithSurfacePlacement(FurnitureSurfaceType.Wall, allowRotation: true)
+    .WithBuildSound(BuildSoundType.Wood)
+    .WithPricing(45f)
+    .WithGeneratedIcon()
+    .Build();
+```
+
+`FurnitureSurfaceType.All` accepts both walls and roofs. `WithFootprint` applies only to grid
+furniture.
+
+## Registration and multiplayer
+
+Build furniture after the vanilla item registry is initialized. The builder deliberately fails with
+a clear error if its verified native template is not available yet. S1API retains the resulting
+definition across scene transitions.
+
+Every multiplayer peer must load the same mod version and register the same stable item ID, model,
+placement mode, and footprint. Placement authority, observer initialization, late joins, and
+property save/load then travel through the game's native grid or surface item flow.
+
+The generated icon path is the default. Furniture still registers during pre-load using its native
+template icon as a temporary fallback; S1API replaces that icon after the gameplay rendering rig is
+ready and refreshes bound inventory/shop UI. Call `WithIcon(sprite)` when an art-directed icon is
+preferred.
+
+## Placement scope
+
+The initial API supports ordinary floor-grid furniture and wall/roof surface furniture. S1API does
+not expose procedural-grid placement yet because the current game provides no generic serialized
+procedural template that can be composed without inheriting gameplay-specific behavior. This keeps
+the public enum honest and leaves room for an additive placement family later.
+
+For a complete embedded-GLB mod, see the
+[FurnitureMod example](https://github.com/ifBars/S1FurnitureMod).

--- a/S1API/docs/furniture-items.md
+++ b/S1API/docs/furniture-items.md
@@ -38,6 +38,9 @@ var chair = FurnitureCreator.CreateBuilder()
 Grid footprint cells are 0.5 metres. Size the footprint to cover the model's horizontal bounds;
 for example, a model just under one metre wide and deep uses `WithFootprint(2, 2)`.
 
+Schedule One exposes native cardboard, wood, and metal placement sounds. `BuildSoundType.Plastic`
+uses the native metal sound as its compatibility fallback.
+
 ## Surface furniture
 
 Use surface placement for wall or roof-mounted decorations:

--- a/S1API/docs/item-builder-reference.md
+++ b/S1API/docs/item-builder-reference.md
@@ -25,6 +25,29 @@ This page collects the main builder methods, advanced item-instance notes, and i
 - `WithUseCallback(callback)` - Registers a callback when the item is used
 - `Build()` - Finalizes and returns the equippable
 
+## FurnitureDefinitionBuilder Methods
+
+- `WithBasicInfo(id, name, description)` - Sets the stable ID and player-facing text
+- `WithModel(model)` - Supplies the model cloned into all native furniture representations
+- `WithPlacement(mode)` - Selects grid or surface placement
+- `WithFootprint(width, depth)` - Sets a grid footprint in 0.5 metre tiles
+- `WithSurfacePlacement(types, allowRotation)` - Selects wall/roof compatibility
+- `WithBuildSound(soundType)` - Selects the native completion sound
+- `WithPricing(basePrice, resellMultiplier)` - Configures economic properties
+- `WithStackLimit(limit)` - Sets the inventory stack limit
+- `WithIcon(sprite)` / `WithGeneratedIcon(resolution)` - Configures the inventory icon
+- `Build()` - Composes the native prefabs, registers, and returns the furniture definition
+
+## BuildableItemDefinitionBuilder Ghost Visuals
+
+Buildables cloned from a native machine or station can opt into a custom placement visual with
+`WithGhostVisual(visualFactory, replaceExistingVisual)`. S1API invokes the factory after the native
+grid, procedural-grid, or surface placement system creates its ghost, parents and activates the
+returned object, and restores the inherited renderers if the factory fails.
+
+Set `replaceExistingVisual: true` when the custom visual replaces the cloned native model. Buildables
+that do not call this method retain the game's normal ghost behavior.
+
 ## Advanced: Custom Item Instances
 
 For items with custom runtime state, such as extra fields that must serialize, you will need to:
@@ -45,6 +68,7 @@ For items with custom runtime state, such as extra fields that must serialize, y
 ## See Also
 
 - [Item Registration & Basics](item-registration-basics.md)
+- [Custom Furniture](furniture-items.md)
 - [Runtime Additives](runtime-additives.md)
 - [Equippable Items](equippable-items.md)
 - [Avatar Equippable Prefabs](avatar-equippable-prefabs.md)

--- a/S1API/docs/item-builder-reference.md
+++ b/S1API/docs/item-builder-reference.md
@@ -32,7 +32,7 @@ This page collects the main builder methods, advanced item-instance notes, and i
 - `WithPlacement(mode)` - Selects grid or surface placement
 - `WithFootprint(width, depth)` - Sets a grid footprint in 0.5 metre tiles
 - `WithSurfacePlacement(types, allowRotation)` - Selects wall/roof compatibility
-- `WithBuildSound(soundType)` - Selects the native completion sound
+- `WithBuildSound(soundType)` - Selects the native completion sound; plastic furniture uses the metal fallback
 - `WithPricing(basePrice, resellMultiplier)` - Configures economic properties
 - `WithStackLimit(limit)` - Sets the inventory stack limit
 - `WithIcon(sprite)` / `WithGeneratedIcon(resolution)` - Configures the inventory icon

--- a/S1API/docs/items.md
+++ b/S1API/docs/items.md
@@ -7,6 +7,7 @@ S1API provides a comprehensive item system for Schedule One, including standard 
 The Items system allows you to:
 
 - Create standard `StorableItemDefinition` instances with the Creator API or Builder API
+- Create native grid and surface furniture directly from a mod-provided model
 - Register runtime additives with custom effects
 - Attach equippable behavior and viewmodels to items
 - Add icons from embedded resources or AssetBundles
@@ -22,6 +23,7 @@ The Items system is documented across multiple focused pages:
 - **[Item Registration & Basics](item-registration-basics.md)** - Registration timing, Creator API, Builder API, categories, and common setup tips
 - **[Runtime Additives](runtime-additives.md)** - Creating additive definitions and allowing them on grow containers
 - **[Item Icons](item-icons.md)** - Loading item icons from embedded resources and AssetBundles
+- **[Custom Furniture](furniture-items.md)** - Composing native placeable furniture from a model or embedded GLB
 
 ### Equippables
 - **[Equippable Items](equippable-items.md)** - Basic equippables, viewmodels, use callbacks, and custom equippable behaviors
@@ -74,6 +76,7 @@ public class MyMod : MelonMod
 
 - Start here: **[Item Registration & Basics](item-registration-basics.md)**
 - Then: **[Equippable Items](equippable-items.md)** if the item can be held or used
+- For placeable models: **[Custom Furniture](furniture-items.md)**
 - As needed: **[Runtime Additives](runtime-additives.md)**, **[Item Icons](item-icons.md)**, **[Avatar Equippable Prefabs](avatar-equippable-prefabs.md)**
 
 ## Related Systems

--- a/S1API/docs/toc.yml
+++ b/S1API/docs/toc.yml
@@ -86,6 +86,8 @@
           href: item-registration-basics.md
         - name: Item Icons
           href: item-icons.md
+        - name: Custom Furniture
+          href: furniture-items.md
         - name: Equippable Items
           href: equippable-items.md
         - name: Avatar Equippable Prefabs

--- a/S1API/index.md
+++ b/S1API/index.md
@@ -70,7 +70,7 @@ _layout: landing
     </a>
     <a class="s1-card" href="docs/items.md">
       <h3>Items</h3>
-      <p>Register custom storable, additive, buildable, clothing, and equippable item definitions.</p>
+      <p>Register custom storable, furniture, additive, clothing, and equippable item definitions.</p>
     </a>
     <a class="s1-card" href="docs/products-system.md">
       <h3>Products</h3>


### PR DESCRIPTION
## Summary

- Add an additive `FurnitureCreator` / `FurnitureDefinitionBuilder` API that composes mod-supplied models into native grid or surface furniture.
- Preserve the verified vanilla prefab graph for placement, save/load, networking, stored-item footprint data, and equipping while replacing presentation, bounds, culling, collision, and configured footprint dimensions.
- Add an opt-in `BuildableItemDefinitionBuilder.WithGhostVisual(...)` seam for furniture and non-furniture buildables across grid, procedural-grid, and surface placement.
- Defer generated icons until the gameplay icon rig exists, serialize captures through the shared render-rig arbiter, and render from an isolated preview clone.
- Map furniture build sounds explicitly to native values without changing the legacy builder's ordinal behavior.

Closes #232

## Compatibility

- Public/protected API: additive builder types, placement enums, and one additive `WithGhostVisual(...)` method. Existing symbols and parameter names are unchanged.
- Existing placement and ghost defaults are unchanged unless a mod explicitly uses the furniture builder or ghost-visual opt-in.
- Building events now consistently fire for non-storage buildables as documented; `BuildEventArgs.Storage` is null for those items.
- Stable IDs, saves, and network payloads: no existing IDs or payloads change. Composed furniture uses the native grid/surface buildable graph; every peer must register the same custom item ID and configuration.

## Validation

### Mono

- Full S1API test suite: 544/544 passed.
- Solution build: zero warnings/errors.
- FurnitureMod embedded-GLB consumer: zero warnings/errors.

### IL2CPP

- Full S1API test suite: 533/533 passed.
- Solution build: zero warnings/errors.
- FurnitureMod embedded-GLB consumer: zero warnings/errors.

### Runtime evidence

A disposable-save IL2CPP probe exercised the reviewed composition and icon paths with FurnitureMod and MoreDrugs loaded. It verified:

- the custom sofa registered in the Main scene;
- the cloned native stored-item graph retained four footprint tiles and 2x2 dimensions;
- mesh-local bounds produced a non-empty `(0.96, 1.23, 0.76)` native bounding collider;
- the public Wood choice mapped to native Wood;
- the generated `FurnitureVisual_IconPreview_Icon` replaced the donor fallback while sharing the icon render rig with MoreDrugs;
- the earlier native hotbar/input probe and manual gameplay test confirmed the visible 2x2 ghost and placement behavior.

All disposable probes, copied saves, screenshots, logs, generated wrappers, and proprietary game artifacts remained local and were removed after validation. The public game install was restored after the review probe.

## Documentation and compatibility gates

- Add a custom furniture guide with grid, surface, embedded-GLB, lifecycle, multiplayer, icon, and build-sound guidance.
- Add builder-reference and item-navigation entries.
- DocFX metadata/content build: zero errors with four pre-existing unresolved dependency warnings.
- Public API documentation coverage: 80.94% (3,133/3,871).
- APICompat against the exact `stable` base SHA: no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating custom grid- and surface-placeable furniture.
  * Added configuration for furniture models, placement, footprints, surfaces, pricing, stacking, sounds, and icons.
  * Added generated icon support and custom ghost visuals for buildable items.
  * Added supported placement and surface options.

* **Documentation**
  * Added guides and reference documentation for custom furniture and ghost visuals.

* **Bug Fixes**
  * Improved validation for invalid furniture configuration values and placement settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->