### PR TITLE
chore(release): prepare 3.1.12

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -12,7 +12,7 @@ using S1API.Internal.Weather;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.11", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.12", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.11</Version>
+        <Version>3.1.12</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">

--- a/S1API/docs/furniture-items.md
+++ b/S1API/docs/furniture-items.md
@@ -38,6 +38,18 @@ var chair = FurnitureCreator.CreateBuilder()
 Grid footprint cells are 0.5 metres. Size the footprint to cover the model's horizontal bounds;
 for example, a model just under one metre wide and deep uses `WithFootprint(2, 2)`.
 
+## Placement ghost
+
+Furniture created with `FurnitureCreator` does not need separate ghost setup. `WithModel(model)`
+uses the supplied model for the placed object, stored item, generated icon, and placement ghost.
+When the native placement system creates a ghost, S1API clones that model into it and prepares the
+clone as a non-interactive placement visual.
+
+`WithGhostVisual(...)` belongs to the lower-level `BuildableItemDefinitionBuilder` path. Use it when
+cloning a native non-furniture buildable, such as a machine or station, whose inherited ghost should
+show a custom model. See [Custom ghosts for cloned buildables](item-builder-reference.md#custom-ghosts-for-cloned-buildables)
+for the complete pattern.
+
 Schedule One exposes native cardboard, wood, and metal placement sounds. `BuildSoundType.Plastic`
 uses the native metal sound as its compatibility fallback.
 

--- a/S1API/docs/item-builder-reference.md
+++ b/S1API/docs/item-builder-reference.md
@@ -38,15 +38,37 @@ This page collects the main builder methods, advanced item-instance notes, and i
 - `WithIcon(sprite)` / `WithGeneratedIcon(resolution)` - Configures the inventory icon
 - `Build()` - Composes the native prefabs, registers, and returns the furniture definition
 
-## BuildableItemDefinitionBuilder Ghost Visuals
+## Custom ghosts for cloned buildables
 
-Buildables cloned from a native machine or station can opt into a custom placement visual with
-`WithGhostVisual(visualFactory, replaceExistingVisual)`. S1API invokes the factory after the native
-grid, procedural-grid, or surface placement system creates its ghost, parents and activates the
-returned object, and restores the inherited renderers if the factory fails.
+Use `WithGhostVisual(visualFactory, replaceExistingVisual)` when a buildable cloned from a native
+machine or station needs a different placement model. Furniture created through `FurnitureCreator`
+does not call this method: `WithModel(...)` automatically supplies its placed, stored, icon, and
+ghost visuals.
+
+```csharp
+GameObject ghostModel = LoadMachineModel();
+ghostModel.SetActive(false);
+
+var machine = BuildableItemCreator.CloneFrom("brickpress")
+    .WithBasicInfo(
+        "my-mod:tablet-press",
+        "Tablet Press",
+        "A compact manual tablet press.",
+        ItemCategory.Equipment)
+    .WithGhostVisual(
+        parent => Object.Instantiate(ghostModel, parent, false),
+        replaceExistingVisual: true)
+    .Build();
+```
+
+The factory runs on Unity's main thread whenever the native grid, procedural-grid, or surface
+placement system creates a ghost. It must create and return a fresh `GameObject`; do not return the
+shared source object. S1API parents the result when necessary, activates it, and disables its
+colliders, navigation, networking, canvases, and lights so it behaves as a placement visual.
 
 Set `replaceExistingVisual: true` when the custom visual replaces the cloned native model. Buildables
-that do not call this method retain the game's normal ghost behavior.
+that do not call this method retain the game's normal ghost behavior. If the factory throws or
+returns `null`, S1API removes the partial visual and restores any inherited renderers it hid.
 
 ## Advanced: Custom Item Instances
 


### PR DESCRIPTION
## Summary

- bump the S1API project package version from 3.1.11 to 3.1.12
- bump the MelonLoader assembly metadata version from 3.1.11 to 3.1.12
- prepare the immutable `releases/3.1.12` branch for tag-driven publication

## Validation

- Mono solution build: zero warnings/errors
- Mono tests: 544/544 passed
- IL2CPP solution build: zero warnings/errors
- IL2CPP tests: 533/533 passed
- DocFX: zero errors; four pre-existing local unresolved dependency warnings

## Release policy

After this PR merges into `stable`, fast-forward `releases/3.1.12` to the stable merge commit and tag that exact shared commit as `v3.1.12`.