### PR TITLE
fix(phoneapp): hide default notification badge

### DIFF
--- a/S1API/PhoneApp/PhoneApp.cs
+++ b/S1API/PhoneApp/PhoneApp.cs
@@ -394,6 +394,8 @@ namespace S1API.PhoneApp
             }
 
             GameObject iconObject = Object.Instantiate(iconPrefab, parent);
+            iconObject.transform.Find("Notifications")?.gameObject.SetActive(false);
+
             Button? button = iconObject.GetComponent<Button>();
             UISelectable? selectable = iconObject.GetComponent<UISelectable>();
             if (button == null || selectable == null)


### PR DESCRIPTION
## Summary

- disable the native `Notifications` child on newly cloned custom phone-app icons
- mirror the initialization performed by the base game's `App<T>.GenerateHomeScreenIcon`
- keep the lookup null-safe so upstream prefab hierarchy drift does not prevent icon creation

## Root cause

The native `AppIcon` prefab defaults its `Notifications` child to active with text `1`. Vanilla apps disable that child immediately after cloning the prefab, but S1API's dedicated custom-icon path did not. Custom apps therefore inherited a false notification badge without requesting one.

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- Mono contract suite: 544 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- IL2CPP contract suite: 533 passed
- copied progressed-save runtime smoke:
  - `PASS|Runtime=Mono|Scene=Main|IconActive=True|NotificationActive=False|Screenshot=True`
  - `PASS|Runtime=Il2Cpp|Scene=Main|IconActive=True|NotificationActive=False|Screenshot=True`
- visually inspected the IL2CPP phone home screen and confirmed the custom icon renders without a notification badge

## Compatibility

- Source compatibility: unchanged
- Binary compatibility: unchanged
- Public/protected API surface: unchanged
- Save and network formats: unchanged
- Behavioral change: custom phone-app icons now start with the native notification badge hidden

Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created phone app icons no longer display notification indicators by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->