### PR TITLE
fix(items): restore the pre-3.1 CreateItem overload

### DIFF
--- a/S1API.Tests/Items/ItemCreatorApiCompatibilityTests.cs
+++ b/S1API.Tests/Items/ItemCreatorApiCompatibilityTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using S1API.Items;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+#pragma warning disable CS0618
+public sealed class ItemCreatorApiCompatibilityTests
+{
+    [Fact]
+    public void LegacyCreateItemOverloadsPreserveSourceAndBinaryShapes()
+    {
+        MethodInfo? nineArgumentOverload = typeof(ItemCreator).GetMethod(
+            nameof(ItemCreator.CreateItem),
+            new[]
+            {
+                typeof(string), typeof(string), typeof(string), typeof(ItemCategory),
+                typeof(int), typeof(float), typeof(float), typeof(LegalStatus), typeof(Sprite)
+            });
+        MethodInfo? tenArgumentOverload = typeof(ItemCreator).GetMethod(
+            nameof(ItemCreator.CreateItem),
+            new[]
+            {
+                typeof(string), typeof(string), typeof(string), typeof(ItemCategory),
+                typeof(int), typeof(float), typeof(float), typeof(LegalStatus), typeof(Sprite),
+                typeof(Equippable)
+            });
+
+        Assert.NotNull(nineArgumentOverload);
+        Assert.NotNull(tenArgumentOverload);
+        Assert.Equal("legacyIcon", nineArgumentOverload.GetParameters()[8].Name);
+        Assert.Equal("icon", tenArgumentOverload.GetParameters()[8].Name);
+        Assert.Equal("equippable", tenArgumentOverload.GetParameters()[9].Name);
+        Assert.All(nineArgumentOverload.GetParameters(), parameter => Assert.False(parameter.IsOptional));
+        Assert.All(tenArgumentOverload.GetParameters(), parameter => Assert.False(parameter.IsOptional));
+        Assert.Single(nineArgumentOverload.GetCustomAttributes<ObsoleteAttribute>());
+        Assert.Single(tenArgumentOverload.GetCustomAttributes<ObsoleteAttribute>());
+    }
+}
+#pragma warning restore CS0618

--- a/S1API.Tests/Items/ItemCreatorApiCompileFixture.cs
+++ b/S1API.Tests/Items/ItemCreatorApiCompileFixture.cs
@@ -1,0 +1,55 @@
+using S1API.Items;
+using UnityEngine;
+
+namespace S1API.Tests.Items;
+
+#pragma warning disable CS0618
+internal static class ItemCreatorApiCompileFixture
+{
+    internal static void CompileLegacyAndCurrentCallers(Sprite? icon, Equippable? equippable)
+    {
+        _ = ItemCreator.CreateItem(
+            "examplemod:legacy-nine",
+            "Legacy Nine",
+            "Legacy positional call without an equippable.",
+            ItemCategory.Tools,
+            1,
+            10f,
+            0.5f,
+            LegalStatus.Legal,
+            icon);
+
+        _ = ItemCreator.CreateItem(
+            "examplemod:legacy-ten",
+            "Legacy Ten",
+            "Legacy positional call with an equippable.",
+            ItemCategory.Tools,
+            1,
+            10f,
+            0.5f,
+            LegalStatus.Legal,
+            icon,
+            equippable);
+
+        _ = ItemCreator.CreateItem(
+            "examplemod:current-named-icon",
+            "Current Named Icon",
+            "Current call that names the icon parameter.",
+            ItemCategory.Tools,
+            legalStatus: LegalStatus.Legal,
+            icon: icon);
+
+        _ = ItemCreator.CreateItem(
+            "examplemod:current-rank",
+            "Current Rank",
+            "Current positional rank-gating call.",
+            ItemCategory.Tools,
+            1,
+            10f,
+            0.5f,
+            LegalStatus.Legal,
+            false,
+            null);
+    }
+}
+#pragma warning restore CS0618

--- a/S1API/Items/ItemCreator.cs
+++ b/S1API/Items/ItemCreator.cs
@@ -14,7 +14,9 @@ namespace S1API.Items
 {
     /// <summary>
     /// Provides convenient static methods for creating custom items.
-    /// Use <see cref="CreateBuilder"/> for flexible configuration or <see cref="CreateItem"/> for quick creation.
+    /// Use <see cref="CreateBuilder"/> for flexible configuration or
+    /// <see cref="CreateItem(string,string,string,ItemCategory,int,float,float,LegalStatus,bool,FullRank?,Sprite?,Equippable?)"/>
+    /// for quick creation.
     /// </summary>
     /// <remarks>
     /// All items in Schedule One are storable items (StorableItemDefinition), so both methods create the same type.
@@ -140,6 +142,46 @@ namespace S1API.Items
             }
 
             return builder.Build();
+        }
+
+        /// <summary>
+        /// Creates an item using the parameter order used before S1API 3.1, without a rank requirement.
+        /// Provided for backwards compatibility with mods compiled against S1API 3.0.x.
+        /// </summary>
+        /// <param name="id">Unique identifier for the item (e.g., "my_custom_tool").</param>
+        /// <param name="name">Display name shown in UI.</param>
+        /// <param name="description">Item description shown in tooltips.</param>
+        /// <param name="category">Item category for inventory organization.</param>
+        /// <param name="stackLimit">Maximum quantity per inventory slot.</param>
+        /// <param name="basePurchasePrice">Base price when buying from shops.</param>
+        /// <param name="resellMultiplier">Fraction of purchase price recovered when selling.</param>
+        /// <param name="legalStatus">Whether the item is legal or illegal.</param>
+        /// <param name="icon">Optional sprite to use as the item icon.</param>
+        /// <param name="equippable">Optional equippable component to attach.</param>
+        /// <returns>A wrapper around the created item definition.</returns>
+        /// <remarks>
+        /// 3.1 inserted <c>requiresLevelToPurchase</c> and <c>requiredRank</c> before <c>icon</c>. Optional
+        /// parameters are source-compatible, so nothing failed to compile, but the ten-parameter method a
+        /// 3.0.x mod was compiled against no longer exists and throws <see cref="MissingMethodException"/>
+        /// when the feature runs. This overload declares no default values, so it is reachable only by an
+        /// exact ten-argument call in the old order and no existing call site rebinds to it.
+        /// </remarks>
+        [Obsolete("Use the overload with requiresLevelToPurchase and requiredRank. This compatibility overload may be removed in a future S1API version.")]
+        public static StorableItemDefinition CreateItem(
+            string id,
+            string name,
+            string description,
+            ItemCategory category,
+            int stackLimit,
+            float basePurchasePrice,
+            float resellMultiplier,
+            LegalStatus legalStatus,
+            Sprite? icon,
+            Equippable? equippable)
+        {
+            return CreateItem(id, name, description, category, stackLimit, basePurchasePrice,
+                resellMultiplier, legalStatus, requiresLevelToPurchase: false, requiredRank: null,
+                icon: icon, equippable: equippable);
         }
 
         /// <summary>

--- a/S1API/Items/ItemCreator.cs
+++ b/S1API/Items/ItemCreator.cs
@@ -145,8 +145,40 @@ namespace S1API.Items
         }
 
         /// <summary>
-        /// Creates an item using the parameter order used before S1API 3.1, without a rank requirement.
-        /// Provided for backwards compatibility with mods compiled against S1API 3.0.x.
+        /// Creates an item using the parameter order from S1API 3.0.0 through 3.0.4, without a rank requirement.
+        /// Provided for source compatibility with nine-argument positional calls.
+        /// </summary>
+        /// <param name="id">Unique identifier for the item (e.g., "my_custom_tool").</param>
+        /// <param name="name">Display name shown in UI.</param>
+        /// <param name="description">Item description shown in tooltips.</param>
+        /// <param name="category">Item category for inventory organization.</param>
+        /// <param name="stackLimit">Maximum quantity per inventory slot.</param>
+        /// <param name="basePurchasePrice">Base price when buying from shops.</param>
+        /// <param name="resellMultiplier">Fraction of purchase price recovered when selling.</param>
+        /// <param name="legalStatus">Whether the item is legal or illegal.</param>
+        /// <param name="legacyIcon">Optional sprite to use as the item icon.</param>
+        /// <returns>A wrapper around the created item definition.</returns>
+        /// <remarks>
+        /// The distinct parameter name keeps calls that target the current overload with <c>icon:</c> unambiguous.
+        /// </remarks>
+        [Obsolete("Use the overload with requiresLevelToPurchase and requiredRank. This compatibility overload may be removed in a future S1API version.")]
+        public static StorableItemDefinition CreateItem(
+            string id,
+            string name,
+            string description,
+            ItemCategory category,
+            int stackLimit,
+            float basePurchasePrice,
+            float resellMultiplier,
+            LegalStatus legalStatus,
+            Sprite? legacyIcon) =>
+            CreateItem(id, name, description, category, stackLimit, basePurchasePrice,
+                resellMultiplier, legalStatus, requiresLevelToPurchase: false, requiredRank: null,
+                icon: legacyIcon, equippable: null);
+
+        /// <summary>
+        /// Creates an item using the parameter order from S1API 3.0.0 through 3.0.4, without a rank requirement.
+        /// Provided for binary compatibility with mods compiled against those versions.
         /// </summary>
         /// <param name="id">Unique identifier for the item (e.g., "my_custom_tool").</param>
         /// <param name="name">Display name shown in UI.</param>
@@ -160,11 +192,9 @@ namespace S1API.Items
         /// <param name="equippable">Optional equippable component to attach.</param>
         /// <returns>A wrapper around the created item definition.</returns>
         /// <remarks>
-        /// 3.1 inserted <c>requiresLevelToPurchase</c> and <c>requiredRank</c> before <c>icon</c>. Optional
-        /// parameters are source-compatible, so nothing failed to compile, but the ten-parameter method a
-        /// 3.0.x mod was compiled against no longer exists and throws <see cref="MissingMethodException"/>
-        /// when the feature runs. This overload declares no default values, so it is reachable only by an
-        /// exact ten-argument call in the old order and no existing call site rebinds to it.
+        /// S1API 3.0.5 inserted <c>requiresLevelToPurchase</c> and <c>requiredRank</c> before <c>icon</c>.
+        /// This overload retains the former ten-parameter binary signature. Its parameters remain required
+        /// so current calls that use the named <c>icon</c> parameter continue to bind unambiguously.
         /// </remarks>
         [Obsolete("Use the overload with requiresLevelToPurchase and requiredRank. This compatibility overload may be removed in a future S1API version.")]
         public static StorableItemDefinition CreateItem(
@@ -177,12 +207,10 @@ namespace S1API.Items
             float resellMultiplier,
             LegalStatus legalStatus,
             Sprite? icon,
-            Equippable? equippable)
-        {
-            return CreateItem(id, name, description, category, stackLimit, basePurchasePrice,
+            Equippable? equippable) =>
+            CreateItem(id, name, description, category, stackLimit, basePurchasePrice,
                 resellMultiplier, legalStatus, requiresLevelToPurchase: false, requiredRank: null,
                 icon: icon, equippable: equippable);
-        }
 
         /// <summary>
         /// Creates a new equippable builder for creating custom equippable components.


### PR DESCRIPTION
﻿Mods built against S1API 3.0.0-3.0.4 can throw `MissingMethodException` when they first call the former `ItemCreator.CreateItem` signature. S1API 3.0.5 inserted `requiresLevelToPurchase` and `requiredRank` before `icon`, removing the old ten-parameter CLR signature.

This restores that exact ten-parameter signature and forwards without a rank gate, matching the old behavior. It also adds a dedicated nine-parameter positional shim for recompiled callers that omitted the optional `equippable` argument.

The nine-parameter shim deliberately names its final parameter `legacyIcon` rather than making `equippable` optional on the ten-parameter overload. That keeps modern calls using `icon:` bound to the current API instead of making them ambiguous. Both compatibility shims are marked `[Obsolete]` and use expression-bodied forwarding.

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build`: 545 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build`: 534 passed
- `docfx docfx.json`: succeeded with four existing assembly-reference warnings
- Documentation coverage: 80.95%

## Compatibility

- **Public/protected API:** adds obsolete nine- and ten-parameter `CreateItem` compatibility overloads; the existing twelve-parameter signature and parameter names are unchanged.
- **Source:** legacy nine- and ten-argument positional callers compile, while current `icon:` named calls and rank-gating calls remain unambiguous. As with any restoration of overloads whose ninth parameters differ only by type, an untyped positional `default` literal can be ambiguous; typed callers are unaffected.
- **Binary:** restores the exact pre-3.0.5 ten-parameter CLR signature, including `icon` and `equippable` parameter names.
- **Behavior:** both shims forward with `requiresLevelToPurchase: false` and `requiredRank: null`, preserving the former no-rank-gate behavior.
- **Save/network:** unchanged; no identifiers, serialization, persistence, or network payloads are modified.
- **Regression coverage:** compile-only fixtures freeze legacy 9/10 positional calls and current named/rank calls; reflection coverage freezes both compatibility signatures and their required-parameter shape.
