### PR TITLE
chore(release): prepare 3.1.13

### DIFF
--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -12,7 +12,7 @@ using S1API.Internal.Weather;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.12", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.13", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.12</Version>
+        <Version>3.1.13</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- bump the S1API project package version from 3.1.12 to 3.1.13
- bump the MelonLoader assembly metadata version from 3.1.12 to 3.1.13
- prepare the immutable `releases/3.1.13` branch for tag-driven publication

## Validation

- Mono solution build: zero warnings/errors
- Mono tests: 556/556 passed
- IL2CPP solution build: zero warnings/errors
- IL2CPP tests: 545/545 passed
- DocFX: zero errors; four pre-existing local unresolved dependency warnings

## Compatibility

- Public/protected API inventory: no symbol changes; version metadata only
- Source, binary, behavioral, save, and network compatibility are unchanged
- Omitted/default inputs, invalid inputs, duplicate registration, builder reuse, save/load, and multiplayer behavior are unaffected by this release-only change

## Release policy

After this PR merges into `stable`, fast-forward `releases/3.1.13` to the stable merge commit and tag that exact shared commit as `v3.1.13`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and package version to **3.1.13**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->