### PR TITLE
fix(NPC): hide locked dealer conversations

### DIFF
--- a/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
+++ b/S1API.Tests/Entities/DealerLifecyclePolicyTests.cs
@@ -55,6 +55,43 @@ public sealed class DealerLifecyclePolicyTests
         Assert.Equal(expected, NPCPrefabBuilder.IsDealerHomeEventName(name));
     }
 
+    [Theory]
+    [InlineData(false, true, 0, 0, 0, true)]
+    [InlineData(false, false, 0, 0, 0, false)]
+    [InlineData(true, true, 0, 0, 0, false)]
+    [InlineData(false, true, 1, 0, 0, false)]
+    [InlineData(false, true, 0, 1, 0, false)]
+    [InlineData(false, true, 0, 0, 1, false)]
+    public void OnlyCreatedEmptyLockedDealerConversationsAreHidden(
+        bool relationshipUnlocked,
+        bool uiCreated,
+        int messageCount,
+        int messageChainCount,
+        int responseCount,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPCDealer.ShouldHideLockedConversation(
+                relationshipUnlocked,
+                uiCreated,
+                messageCount,
+                messageChainCount,
+                responseCount));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void DealerConversationUiIsCreatedOnlyForUnlockedRelationships(
+        bool relationshipUnlocked,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            NPCDealer.ShouldEnsureConversationUi(relationshipUnlocked));
+    }
+
     [Fact]
     public void ConnectionIdsAreStableAcrossSpawnOrderReconciliation()
     {

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -5014,6 +5014,7 @@ namespace S1API.Entities
         {
             ClearDealerRecommendationHooks();
             CleanupAwarenessEventHooks();
+            _dealer?.Cleanup();
             _messaging?.Cleanup();
             CleanupVehicleLifecycleHooks();
         }

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -69,6 +69,7 @@ namespace S1API.Entities
         private Action? _contractAcceptedHandlers;
         private bool _contractAcceptedHooked;
         private Action<NPCRelationship.UnlockType, bool>? _relationshipUnlockedHandler;
+        private S1Messaging.MSGConversation? _conversationUiRefreshHooked;
 
         internal NPCDealer(NPC npc)
         {
@@ -178,6 +179,9 @@ namespace S1API.Entities
                     RefreshDealerCategoryBadge();
                 }
 
+                if (ReferenceEquals(_conversationUiRefreshHooked, convo))
+                    return;
+
                 // Hook onLoaded (called after UI is loaded from save)
                 var prevLoaded = convo.onLoaded;
                 convo.onLoaded = new System.Action(() =>
@@ -194,6 +198,8 @@ namespace S1API.Entities
                     try { prevOpened?.Invoke(); } catch { }
                     RefreshDealerCategoryBadge();
                 });
+
+                _conversationUiRefreshHooked = convo;
             }
             catch (Exception ex)
             {
@@ -286,11 +292,13 @@ namespace S1API.Entities
 
         internal void Cleanup()
         {
-            if (_relationshipUnlockedHandler == null)
-                return;
+            if (_relationshipUnlockedHandler != null)
+            {
+                NPC.Relationship.OnUnlocked -= _relationshipUnlockedHandler;
+                _relationshipUnlockedHandler = null;
+            }
 
-            NPC.Relationship.OnUnlocked -= _relationshipUnlockedHandler;
-            _relationshipUnlockedHandler = null;
+            _conversationUiRefreshHooked = null;
         }
 
         /// <summary>

--- a/S1API/Entities/NPCDealer.cs
+++ b/S1API/Entities/NPCDealer.cs
@@ -68,6 +68,7 @@ namespace S1API.Entities
         private readonly ManagedEventRegistrationTracker<NativeDealerRecruitedAction> _dealerRecruitedHandlers = new ManagedEventRegistrationTracker<NativeDealerRecruitedAction>();
         private Action? _contractAcceptedHandlers;
         private bool _contractAcceptedHooked;
+        private Action<NPCRelationship.UnlockType, bool>? _relationshipUnlockedHandler;
 
         internal NPCDealer(NPC npc)
         {
@@ -138,10 +139,16 @@ namespace S1API.Entities
         {
             try
             {
-                NPC.SetConversationCategory(S1Messaging.EConversationCategory.Dealer);
+                bool isUnlocked = NPC.Relationship.IsUnlocked;
+                NPC.SetConversationCategory(
+                    S1Messaging.EConversationCategory.Dealer,
+                    ensureUi: ShouldEnsureConversationUi(isUnlocked));
+                EnsureRelationshipUnlockHook();
+
                 if (NPC.S1NPC.MSGConversation != null)
                 {
                     TryHookConversationUIRefresh(NPC.S1NPC.MSGConversation);
+                    HideLockedEmptyConversation();
                     RefreshDealerCategoryBadge();
                 }
             }
@@ -176,6 +183,7 @@ namespace S1API.Entities
                 convo.onLoaded = new System.Action(() =>
                 {
                     try { prevLoaded?.Invoke(); } catch { }
+                    HideLockedEmptyConversation();
                     RefreshDealerCategoryBadge();
                 });
 
@@ -191,6 +199,98 @@ namespace S1API.Entities
             {
                 Logger.Warning($"Exception in TryHookConversationUIRefresh: {ex.Message}");
             }
+        }
+
+        private void EnsureRelationshipUnlockHook()
+        {
+            _relationshipUnlockedHandler ??= (_, _) => ShowConversationAfterUnlock();
+
+            NPC.Relationship.OnUnlocked -= _relationshipUnlockedHandler;
+            NPC.Relationship.OnUnlocked += _relationshipUnlockedHandler;
+        }
+
+        private void ShowConversationAfterUnlock()
+        {
+            try
+            {
+                NPC.SetConversationCategory(
+                    S1Messaging.EConversationCategory.Dealer,
+                    ensureUi: true);
+
+                var conversation = NPC.S1NPC.MSGConversation;
+                if (conversation == null)
+                    return;
+
+                conversation.SetIsKnown(true);
+                conversation.SetEntryVisibility(true);
+                TryHookConversationUIRefresh(conversation);
+                RefreshDealerCategoryBadge();
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Exception showing dealer conversation after unlock for {NPC.ID}: {ex.Message}");
+            }
+        }
+
+        private void HideLockedEmptyConversation()
+        {
+            var conversation = NPC.S1NPC.MSGConversation;
+            if (conversation == null)
+                return;
+
+            bool uiCreated =
+                Internal.Utils.ReflectionUtils.TryGetFieldOrProperty(conversation, "uiCreated") is bool created
+                && created;
+            int messageCount = conversation.messageHistory?.Count ?? 0;
+            int messageChainCount = conversation.messageChainHistory?.Count ?? 0;
+            int responseCount = conversation.currentResponses?.Count ?? 0;
+            if (!ShouldHideLockedConversation(
+                    NPC.Relationship.IsUnlocked,
+                    uiCreated,
+                    messageCount,
+                    messageChainCount,
+                    responseCount))
+            {
+                return;
+            }
+
+            bool conversationCanBeHidden = NPC.ConversationCanBeHidden;
+            try
+            {
+                if (!conversationCanBeHidden)
+                    NPC.ConversationCanBeHidden = true;
+
+                conversation.SetEntryVisibility(false);
+            }
+            finally
+            {
+                if (!conversationCanBeHidden)
+                    NPC.ConversationCanBeHidden = false;
+            }
+        }
+
+        internal static bool ShouldHideLockedConversation(
+            bool relationshipUnlocked,
+            bool uiCreated,
+            int messageCount,
+            int messageChainCount,
+            int responseCount) =>
+            !relationshipUnlocked
+            && uiCreated
+            && messageCount == 0
+            && messageChainCount == 0
+            && responseCount == 0;
+
+        internal static bool ShouldEnsureConversationUi(bool relationshipUnlocked) =>
+            relationshipUnlocked;
+
+        internal void Cleanup()
+        {
+            if (_relationshipUnlockedHandler == null)
+                return;
+
+            NPC.Relationship.OnUnlocked -= _relationshipUnlockedHandler;
+            _relationshipUnlockedHandler = null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- avoid creating a Messages UI entry while a custom dealer relationship is locked
- create and reveal the dealer conversation when the relationship unlocks
- hide legacy empty locked-dealer entries created by older S1API builds without hiding conversations that contain messages or responses
- remove the relationship hook during NPC cleanup
- add dealer conversation lifecycle policy coverage

## Root cause

`NPCDealer.EnsureDealerCategory()` called `NPC.SetConversationCategory(...)` with `ensureUi: true` unconditionally. Categorizing a locked custom dealer therefore called `MSGConversation.EnsureUIExists()` and inserted an empty thread into the Messages app before the player had discovered the dealer.

## Compatibility

- unlocked and saved dealer conversations keep their existing visibility state
- a real incoming message can still create and reveal a conversation before relationship unlock
- older empty locked-dealer entries are hidden after load
- Mono and IL2CPP use the same policy and the existing relationship event bridge

## Validation

- MonoMelon: 600/600 tests passed
- Il2CppMelon: 589/589 tests passed
- `git diff --check`

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dealer conversations now appear or remain hidden based on relationship unlock status.
  - Empty conversations are hidden while locked and revealed automatically when unlocked.
  - Conversation UI refreshes when relationship status changes.

- **Bug Fixes**
  - Improved cleanup of dealer-related runtime hooks when NPCs are removed.

- **Tests**
  - Added coverage for locked conversation visibility and relationship-based UI creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->