### PR TITLE
fix(npc): finalize custom NPCs on multiplayer clients

### DIFF
--- a/S1API.Tests/Entities/CustomNpcReadinessPolicyTests.cs
+++ b/S1API.Tests/Entities/CustomNpcReadinessPolicyTests.cs
@@ -1,0 +1,54 @@
+using S1API.Internal.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class CustomNpcReadinessPolicyTests
+{
+    [Fact]
+    public void ClientRemainsNotReadyWhileARegisteredTypeIsMissing()
+    {
+        Type[] registeredTypes = { typeof(DealerNpc), typeof(CustomerNpc) };
+        HashSet<Type> finalizedTypes = new() { typeof(DealerNpc) };
+
+        bool ready = CustomNpcReadinessPolicy.AreAllTypesFinalized(
+            registeredTypes,
+            finalizedTypes);
+
+        Assert.False(ready);
+    }
+
+    [Fact]
+    public void ClientBecomesReadyAfterEveryRegisteredTypeIsHydrated()
+    {
+        Type[] registeredTypes = { typeof(DealerNpc), typeof(CustomerNpc) };
+        HashSet<Type> finalizedTypes = new() { typeof(DealerNpc) };
+
+        CustomNpcReadinessPolicy.MarkFinalized(
+            typeof(CustomerNpc),
+            finalizedTypes);
+
+        bool ready = CustomNpcReadinessPolicy.AreAllTypesFinalized(
+            registeredTypes,
+            finalizedTypes);
+
+        Assert.True(ready);
+    }
+
+    [Fact]
+    public void NoRegisteredTypesDoesNotSignalReady()
+    {
+        bool ready = CustomNpcReadinessPolicy.AreAllTypesFinalized(
+            Array.Empty<Type>(),
+            new HashSet<Type>());
+
+        Assert.False(ready);
+    }
+
+    private sealed class DealerNpc
+    {
+    }
+
+    private sealed class CustomerNpc
+    {
+    }
+}

--- a/S1API.Tests/Entities/CustomNpcReadinessPolicyTests.cs
+++ b/S1API.Tests/Entities/CustomNpcReadinessPolicyTests.cs
@@ -1,9 +1,37 @@
+using S1API.Entities;
 using S1API.Internal.Entities;
+using S1API.Internal.Patches;
 
 namespace S1API.Tests.Entities;
 
 public sealed class CustomNpcReadinessPolicyTests
 {
+    [Fact]
+    public void ClientHydrationSignalsReadyOnlyAfterEveryCustomNpcTypeCompletes()
+    {
+        NPC.FinalizedCustomNpcTypes.Clear();
+        NPCPatches.CustomNpcsReady = false;
+
+        try
+        {
+            var dealer = TestObjectFactory.CreateUninitialized<DealerNpc>();
+            var customer = TestObjectFactory.CreateUninitialized<CustomerNpc>();
+
+            dealer.CreateFromClientNetworkSpawn();
+
+            Assert.False(NPC.CustomNpcsReady);
+
+            customer.CreateFromClientNetworkSpawn();
+
+            Assert.True(NPC.CustomNpcsReady);
+        }
+        finally
+        {
+            NPC.FinalizedCustomNpcTypes.Clear();
+            NPCPatches.CustomNpcsReady = false;
+        }
+    }
+
     [Fact]
     public void ClientRemainsNotReadyWhileARegisteredTypeIsMissing()
     {
@@ -44,11 +72,17 @@ public sealed class CustomNpcReadinessPolicyTests
         Assert.False(ready);
     }
 
-    private sealed class DealerNpc
+    private sealed class DealerNpc : NPC
     {
+        internal override void CreateInternal()
+        {
+        }
     }
 
-    private sealed class CustomerNpc
+    private sealed class CustomerNpc : NPC
     {
+        internal override void CreateInternal()
+        {
+        }
     }
 }

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -3489,6 +3489,8 @@ namespace S1API.Entities
             {
                 _clientNetworkSpawnHydrationDepth--;
             }
+
+            MarkCustomNpcFinalized();
         }
 
         internal override void SaveInternal(string folderPath, ref List<string> extraSaveables)
@@ -4659,9 +4661,7 @@ namespace S1API.Entities
 
                 // Check if all custom NPCs are now ready (finalized)
                 // This sets the CustomNpcsReady flag once all custom NPCs have been spawned and finalized
-                FinalizedCustomNpcTypes.Add(GetType());
-                ReconcileAllCustomNpcRelationshipConnections();
-                CheckAndSetCustomNpcsReady();
+                MarkCustomNpcFinalized();
             }
             catch (Exception ex)
             {
@@ -4671,7 +4671,7 @@ namespace S1API.Entities
 
         /// <summary>
         /// Checks if all custom NPCs have been finalized and sets the CustomNpcsReady flag.
-        /// This is called from FinalizeNetworkSpawn to signal when all custom NPCs are ready.
+        /// Called after server finalization and client network-spawn hydration.
         /// </summary>
         internal static void CheckAndSetCustomNpcsReady()
         {
@@ -4689,8 +4689,8 @@ namespace S1API.Entities
                 if (customNpcTypes.Count == 0)
                     return;
 
-                bool allTypesFinalized = customNpcTypes.All(
-                    type => FinalizedCustomNpcTypes.Contains(type));
+                bool allTypesFinalized = Internal.Entities.CustomNpcReadinessPolicy
+                    .AreAllTypesFinalized(customNpcTypes, FinalizedCustomNpcTypes);
 
                 if (allTypesFinalized)
                     CustomNpcsReady = true;
@@ -4699,6 +4699,15 @@ namespace S1API.Entities
             {
                 Logger.Warning($"[NPC] Failed to check CustomNpcsReady status: {ex.Message}");
             }
+        }
+
+        private void MarkCustomNpcFinalized()
+        {
+            Internal.Entities.CustomNpcReadinessPolicy.MarkFinalized(
+                GetType(),
+                FinalizedCustomNpcTypes);
+            ReconcileAllCustomNpcRelationshipConnections();
+            CheckAndSetCustomNpcsReady();
         }
 
         internal static void ReconcileAllCustomNpcRelationshipConnections()

--- a/S1API/Internal/Entities/CustomNpcReadinessPolicy.cs
+++ b/S1API/Internal/Entities/CustomNpcReadinessPolicy.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace S1API.Internal.Entities
+{
+    /// <summary>
+    /// Determines whether every registered custom NPC type completed runtime hydration.
+    /// </summary>
+    internal static class CustomNpcReadinessPolicy
+    {
+        internal static void MarkFinalized(Type customNpcType, ISet<Type> finalizedTypes) =>
+            finalizedTypes.Add(customNpcType);
+
+        internal static bool AreAllTypesFinalized(
+            IEnumerable<Type> customNpcTypes,
+            ISet<Type> finalizedTypes)
+        {
+            var expectedTypes = customNpcTypes as IReadOnlyCollection<Type>
+                ?? customNpcTypes.ToList();
+
+            return expectedTypes.Count > 0
+                && expectedTypes.All(finalizedTypes.Contains);
+        }
+    }
+}

--- a/S1API/Internal/Patches/NPCPatches.cs
+++ b/S1API/Internal/Patches/NPCPatches.cs
@@ -1277,7 +1277,6 @@ namespace S1API.Internal.Patches
                 else
                 {
                     apiNpc.CreateFromClientNetworkSpawn();
-                    NPC.CheckAndSetCustomNpcsReady();
                 }
                 
                 // Ensure visibility is set correctly on clients based on IsPhysical


### PR DESCRIPTION
Closes #275

## Root cause

Joined clients reconstruct custom NPC wrappers in `NPC.CreateWrapperForNetworkSpawnedNPC` and run `CreateFromClientNetworkSpawn()`, but that client lifecycle never added the wrapper type to `FinalizedCustomNpcTypes`.

`ContactsAppPatches.WaitForNPCs` waits for `CustomNpcsReady` before creating custom relation circles. Since readiness requires every registered custom NPC type to be finalized, clients waited forever even though FishNet had spawned a usable world NPC. The server path already recorded finalization in `FinalizeNetworkSpawn()`, which explains the host/client split.

## Fix

- Record custom NPC finalization after successful client network-spawn hydration.
- Share the same finalization/readiness path between server and client lifecycles.
- Keep the readiness rule in a small internal policy with focused regression coverage.
- Remove the now-redundant patch-level readiness check.

Finalization is recorded only after `CreateInternal()` succeeds; an exception cannot falsely signal that the client is ready.

## Game-code and prefab evidence

Local read-only inspection of the current game export and generated runtime bindings found:

- Native `ContactsApp.Start` snapshots the serialized `RelationCircle` graph from the Player prefab; S1API must add custom circles after native startup.
- The Player prefab contains the serialized Contacts containers, region UI graph, and native relation circles.
- The BaseEmployee-derived NPC prefab contains `CustomerAttendDealBehaviour`; native `Customer.Start` disables the customer component if that behavior is absent.
- `ilspycmd` inspection of the current IL2CPP `Assembly-CSharp.dll` confirms `completeContractChoice` and `_attendDealBehaviour` are emitted as public forwarded properties backed by their native field pointers.

No game assemblies, AssetRipper output, saves, GSE files, or smoke-test artifacts are included in this PR.

## Validation

### Automated suites

- MonoMelon: **622 passed**
- Il2CppMelon: **611 passed**
- Focused readiness tests: the real client hydration entry point remains false after the first of two custom NPC types and transitions true after the second; missing type remains false; final type transitions true; empty registration remains false.

### Three-peer GSE gameplay smoke

Both runs used isolated host + 2 client identities and enforced join-before-load:

1. Host created the GSE lobby in `Menu`.
2. Both clients joined and every peer proved a three-member lobby.
3. Only then did the host load a clean save.
4. All three peers reached `Main` with real network state.

Each role had to prove:

- `CustomNpcsReady=true`
- custom NPC relation circle exists and is assigned
- native `Customer` component is enabled
- `CustomerAttendDealBehaviour` exists
- the public dialogue choices contain `[Complete Deal]`
- the NPC messaging conversation is ready

Results:

- Mono (game 0.4.6f12): host **PASS**, client 1 **PASS**, client 2 **PASS**
- IL2CPP (game 0.4.6f11): host **PASS**, client 1 **PASS**, client 2 **PASS**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom NPC readiness tracking during client hydration and server finalization.
  * Ensured readiness is reported only after all registered custom NPC types are finalized.
  * Prevented readiness from being signaled when no custom NPC types are registered.
  * Improved handling of custom NPC visibility after network spawning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->