### PR TITLE
fix(npc): bridge contract events on IL2CPP

### DIFF
--- a/S1API.Tests/Entities/NpcCustomerContractAssignedBridgeTests.cs
+++ b/S1API.Tests/Entities/NpcCustomerContractAssignedBridgeTests.cs
@@ -1,0 +1,52 @@
+#if IL2CPPMELON
+using S1Quests = Il2CppScheduleOne.Quests;
+#else
+using S1Quests = ScheduleOne.Quests;
+#endif
+
+using System.Reflection;
+using S1API.Entities;
+using UnityEngine.Events;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NpcCustomerContractAssignedBridgeTests
+{
+    [Fact]
+    public void BridgeMatchesRuntimeUnityEventSignature()
+    {
+        Type customerType = typeof(NPCCustomer);
+        FieldInfo bridgeField = customerType.GetField(
+            "_contractAssignedBridge",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        FieldInfo eventField = customerType.GetField(
+            "_contractAssignedUnityEvent",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        MethodInfo handler = customerType.GetMethod(
+            "HandleContractAssigned",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        Assert.Equal(
+            typeof(UnityAction<S1Quests.Contract>),
+            bridgeField.FieldType);
+        Assert.Equal(
+            typeof(UnityEvent<S1Quests.Contract>),
+            eventField.FieldType);
+        Assert.Equal(
+            typeof(S1Quests.Contract),
+            Assert.Single(handler.GetParameters()).ParameterType);
+    }
+
+    [Fact]
+    public void UnityActionDelegateInheritanceMatchesRuntime()
+    {
+        bool derivesFromManagedDelegate = typeof(Delegate).IsAssignableFrom(
+            typeof(UnityAction<S1Quests.Contract>));
+
+#if IL2CPPMELON
+        Assert.False(derivesFromManagedDelegate);
+#else
+        Assert.True(derivesFromManagedDelegate);
+#endif
+    }
+}

--- a/S1API/Entities/NPCCustomer.cs
+++ b/S1API/Entities/NPCCustomer.cs
@@ -42,6 +42,7 @@ using S1API.Economy;
 using S1API.Internal.Abstraction;
 using S1API.Internal.Utils;
 #if (IL2CPPMELON)
+using Il2CppInterop.Runtime;
 using Il2CppFishNet;
 using Il2CppFishNet.Managing;
 using Il2CppFishNet.Managing.Object;
@@ -782,20 +783,21 @@ namespace S1API.Entities
 
             try
             {
-                var evt = Utils.ReflectionUtils.TryGetFieldOrProperty(Component, "onContractAssigned");
+                UnityEvent<S1Quests.Contract>? evt = Component.onContractAssigned;
                 if (evt == null)
                     return false;
 
-                var contractType = typeof(S1Quests.Contract);
-                var unityActionType = typeof(UnityAction<>).MakeGenericType(contractType);
-                var method = GetType().GetMethod(nameof(HandleContractAssigned), BindingFlags.NonPublic | BindingFlags.Instance);
-                if (method == null)
-                    return false;
-
-                var del = Delegate.CreateDelegate(unityActionType, this, method);
-                var addListener = evt.GetType().GetMethod("AddListener", new[] { unityActionType });
-                addListener?.Invoke(evt, new object[] { del });
-                _contractAssignedBridge = del;
+#if IL2CPPMELON
+                _contractAssignedBridge =
+                    DelegateSupport.ConvertDelegate<UnityAction<S1Quests.Contract>>(
+                        new Action<S1Quests.Contract>(HandleContractAssigned))
+                    ?? throw new InvalidOperationException(
+                        "Could not create the native contract-assigned listener.");
+#else
+                _contractAssignedBridge =
+                    new UnityAction<S1Quests.Contract>(HandleContractAssigned);
+#endif
+                evt.AddListener(_contractAssignedBridge);
                 _contractAssignedUnityEvent = evt;
                 return true;
             }
@@ -813,9 +815,7 @@ namespace S1API.Entities
 
             try
             {
-                var unityActionType = _contractAssignedBridge.GetType();
-                var removeListener = _contractAssignedUnityEvent.GetType().GetMethod("RemoveListener", new[] { unityActionType });
-                removeListener?.Invoke(_contractAssignedUnityEvent, new object[] { _contractAssignedBridge });
+                _contractAssignedUnityEvent.RemoveListener(_contractAssignedBridge);
             }
             catch (Exception ex)
             {
@@ -829,11 +829,11 @@ namespace S1API.Entities
         }
 
         private Action<float, int, int, int>? _onContractAssigned;
-        private Delegate? _contractAssignedBridge;
-        private object? _contractAssignedUnityEvent;
+        private UnityAction<S1Quests.Contract>? _contractAssignedBridge;
+        private UnityEvent<S1Quests.Contract>? _contractAssignedUnityEvent;
 
         // Maps Contract to safe primitives for modders
-        private void HandleContractAssigned(object contract)
+        private void HandleContractAssigned(S1Quests.Contract contract)
         {
             try
             {


### PR DESCRIPTION
Closes #273

## Root cause

`NPCCustomer.EnsureContractAssignedHook()` constructed `UnityAction<Contract>` through reflection and passed that IL2CPP proxy type to managed `System.Delegate.CreateDelegate`.

Local `ilspycmd` inspection confirms the runtime mismatch:

- Mono `UnityAction<Contract>` is a managed delegate.
- The generated IL2CPP `UnityAction<Contract>` derives from `Il2CppSystem.MulticastDelegate`, not `System.Delegate`.
- Generated IL2CPP `Customer.onContractAssigned` is a public forwarded `UnityEvent<Contract>` property backed by the native field pointer, and `AddListener` accepts the generated `UnityAction<Contract>` shape.

That makes `Delegate.CreateDelegate(...)` throw `Type must derive from Delegate` before the listener is attached.

## Fix

- Access the native `onContractAssigned` member through its strongly typed field/property surface.
- Store a typed `UnityAction<Contract>` bridge and `UnityEvent<Contract>` reference.
- On IL2CPP, create the native bridge with `DelegateSupport.ConvertDelegate`, matching S1API's existing NPC event pattern.
- Retain direct managed `UnityAction<Contract>` construction on Mono.
- Remove the exact stored typed listener during unsubscription.

## Compatibility

- Source compatibility: unchanged; no public or protected symbols changed.
- Binary compatibility: unchanged; only private implementation fields and methods changed.
- Behavioral compatibility: Mono retains the existing event contract; IL2CPP now successfully subscribes and unsubscribes.
- Save compatibility: unchanged.
- Network compatibility: unchanged; no payloads, IDs, or authority behavior changed.

## Validation

### Automated tests

- Focused bridge tests: **2 passed** on MonoMelon and **2 passed** on Il2CppMelon.
- MonoMelon full suite: **624 passed**, 0 failed.
- Il2CppMelon full suite: **613 passed**, 0 failed.
- Both product configurations build with 0 warnings and 0 errors.

The focused tests freeze the runtime-specific delegate inheritance and require the private bridge, stored event, and handler parameter to exactly match `UnityAction<Contract>`, `UnityEvent<Contract>`, and `Contract`.

### Single-player gameplay smoke

Both runs used isolated installs containing only the built `S1API.dll` and a local disposable probe. The probe loaded clean save slot 2 through native `LoadManager`, reached loaded `Main` gameplay, waited for a physical custom customer, then:

1. subscribed to `NPCCustomer.OnContractAssigned`;
2. invoked the native `UnityEvent<Contract>` with a live contract component;
3. verified exactly one managed callback;
4. unsubscribed and verified both stored bridge fields cleared;
5. invoked the native event again and verified the callback count remained one;
6. scanned the runtime log for the original wiring warning.

Results:

- IL2CPP game 0.4.6f11: **PASS**, callback count 1, bridge cleared, original warning absent.
- Mono game 0.4.6f13 Alternate: **PASS**, callback count 1, bridge cleared, original warning absent.

No game assemblies, generated wrappers, decompiled dumps, saves, isolated installs, logs, or smoke-test sources are included in this PR.
