### PR TITLE
fix(npc): tolerate removed region unlock member

### DIFF
--- a/S1API.Tests/Entities/NPCRegionUnlockCompatibilityTests.cs
+++ b/S1API.Tests/Entities/NPCRegionUnlockCompatibilityTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using S1API.Entities;
+
+namespace S1API.Tests.Entities;
+
+public sealed class NPCRegionUnlockCompatibilityTests
+{
+    [Fact]
+    public void RequiresRegionUnlockedRetainsItsPublicSurface()
+    {
+        PropertyInfo? property = typeof(NPC).GetProperty(
+            nameof(NPC.RequiresRegionUnlocked),
+            BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(property);
+        Assert.Equal(typeof(bool), property!.PropertyType);
+        Assert.True(property.CanRead);
+        Assert.True(property.CanWrite);
+    }
+
+    [Fact]
+    public void OptionalRegionUnlockMemberSupportsFieldAndPropertyShapes()
+    {
+        var fieldShape = new FieldShape();
+        var propertyShape = new PropertyShape();
+
+        Assert.True(NPC.TrySetRequiresRegionUnlocked(fieldShape, false));
+        Assert.True(NPC.TrySetRequiresRegionUnlocked(propertyShape, false));
+        Assert.False(NPC.ResolveRequiresRegionUnlocked(fieldShape));
+        Assert.False(NPC.ResolveRequiresRegionUnlocked(propertyShape));
+    }
+
+    [Fact]
+    public void MissingRegionUnlockMemberUsesDefaultAndIgnoresWrites()
+    {
+        var missingShape = new MissingShape();
+
+        Assert.True(NPC.ResolveRequiresRegionUnlocked(missingShape));
+        Assert.False(NPC.TrySetRequiresRegionUnlocked(missingShape, false));
+        Assert.True(NPC.ResolveRequiresRegionUnlocked(missingShape));
+    }
+
+    private sealed class FieldShape
+    {
+        public bool RequiresRegionUnlocked = true;
+    }
+
+    private sealed class PropertyShape
+    {
+        public bool RequiresRegionUnlocked { get; set; } = true;
+    }
+
+    private sealed class MissingShape
+    {
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -2790,13 +2790,8 @@ namespace S1API.Entities
         /// </summary>
         public bool RequiresRegionUnlocked
         {
-#if IL2CPPMELON
-            get => DefaultRequiresRegionUnlocked;
-            set { /* no-op under IL2CPP; constant in base game so non accessible */ }
-#else
-            get => _requiresRegionUnlockedField != null && (bool)_requiresRegionUnlockedField.GetValue(S1NPC)!;
-            set { _requiresRegionUnlockedField?.SetValue(S1NPC, value); }
-#endif
+            get => ResolveRequiresRegionUnlocked(S1NPC);
+            set => TrySetRequiresRegionUnlocked(S1NPC, value);
         }
 
         /// <summary>
@@ -4282,11 +4277,15 @@ namespace S1API.Entities
 
         internal readonly bool IsCustomNPC;
 
-#if IL2CPPMELON
         private const bool DefaultRequiresRegionUnlocked = true;
-#else
-        private readonly FieldInfo _requiresRegionUnlockedField = AccessTools.Field(typeof(S1NPCs.NPC), "RequiresRegionUnlocked");
-#endif
+
+        internal static bool ResolveRequiresRegionUnlocked(object npc) =>
+            Internal.Utils.ReflectionUtils.TryGetFieldOrProperty(npc, "RequiresRegionUnlocked") is bool value
+                ? value
+                : DefaultRequiresRegionUnlocked;
+
+        internal static bool TrySetRequiresRegionUnlocked(object npc, bool value) =>
+            Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(npc, "RequiresRegionUnlocked", value);
 
         private readonly MethodInfo _unsettleMethod = AccessTools.Method(typeof(S1NPCs.NPC), "SetUnsettled");
         private readonly MethodInfo _removePanicMethod = AccessTools.Method(typeof(S1NPCs.NPC), "RemovePanicked");


### PR DESCRIPTION
## Summary

- stop resolving the removed `RequiresRegionUnlocked` field through Harmony during every Mono NPC wrapper construction
- resolve the optional native field/property silently and lazily when the public property is used
- use the existing `true` default and ignore writes when the game exposes neither member shape
- add contract coverage for field, property, and missing-member runtime shapes

Closes #272

## Root cause

The Mono-only instance initializer called `AccessTools.Field(typeof(ScheduleOne.NPCs.NPC), "RequiresRegionUnlocked")`. Current Mono no longer exposes that field, and Harmony logs every failed lookup, so each constructed S1API NPC wrapper emitted a warning even if the public property was never used.

## Game code evidence

Focused `ilspycmd` inspection of the current local game-owned assemblies found no `RequiresRegionUnlocked` field or property on either:

- Mono: `ScheduleOne.NPCs.NPC`
- IL2CPP generated wrapper: `Il2CppScheduleOne.NPCs.NPC`

The implementation still accepts either field or property shape for compatibility with other game versions, without publishing or committing assemblies, generated wrappers, or decompiled output.

## Compatibility

- **Source:** unchanged; `NPC.RequiresRegionUnlocked` remains a public read/write `bool` property.
- **Binary:** unchanged; no public or protected signatures changed.
- **Behavior:** available field/property members remain readable and writable. When absent, reads now consistently return the existing IL2CPP default (`true`) and writes are safe no-ops. Wrapper construction no longer performs or logs a missing-member lookup.
- **Save/network:** unchanged; no IDs, serialization, save data, or network payloads changed.

## Validation

- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false -v:q`
- focused Mono tests: 3 passed
- full Mono suite: 627 passed
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false -v:q`
- focused IL2CPP tests: 3 passed
- full IL2CPP suite: 616 passed
- both builds completed with 0 warnings and 0 errors
- `git diff --check`

No gameplay smoke was run because this regression is limited to reflection member resolution and both runtime type shapes were directly inspected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NPC region-unlock compatibility across supported runtimes.
  - NPC region-unlock status now reads and updates correctly where supported.
  - Added a safe default when the status cannot be read, while unsupported updates are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->