### PR TITLE
feat(casino): expose game state and lifecycle events

### DIFF
--- a/S1API.Tests/Casino/CasinoApiContractTests.cs
+++ b/S1API.Tests/Casino/CasinoApiContractTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reflection;
 using S1API.Casino;
 
@@ -20,9 +21,10 @@ public sealed class CasinoApiContractTests
         Assert.NotNull(typeof(S1Casino.RTBGameController).GetMethod(
             "set_CurrentStage",
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
-        Assert.NotNull(typeof(S1Casino.SlotMachine).GetMethod(
-            "RpcLogic___StartSpin_2659526290",
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+        MethodBase? slotStartMethod = global::S1API.Internal.Patches.CasinoGamePatches
+            .FindSlotStartLogicMethod(typeof(S1Casino.SlotMachine));
+        Assert.NotNull(slotStartMethod);
+        Assert.StartsWith("RpcLogic___StartSpin_", slotStartMethod!.Name);
         Assert.NotNull(typeof(S1Casino.SlotMachine).GetMethod(
             "DisplayOutcome",
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
@@ -49,6 +51,7 @@ public sealed class CasinoApiContractTests
         Assert.All(
             snapshotType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
             property => Assert.Null(property.SetMethod));
+        AssertPublicInstanceFieldsAreReadonly(snapshotType);
         Assert.Empty(snapshotType.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
     }
 
@@ -68,6 +71,7 @@ public sealed class CasinoApiContractTests
             Assert.All(
                 wrapperType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
                 property => Assert.Null(property.SetMethod));
+            AssertPublicInstanceFieldsAreReadonly(wrapperType);
         }
     }
 
@@ -99,7 +103,12 @@ public sealed class CasinoApiContractTests
             modifiers: null)!;
 
         Assert.NotNull(method);
-        Assert.NotNull(method.GetCustomAttribute<ObsoleteAttribute>());
+        ObsoleteAttribute obsolete = Assert.IsType<ObsoleteAttribute>(
+            method.GetCustomAttribute<ObsoleteAttribute>());
+        Assert.False(obsolete.IsError);
+        EditorBrowsableAttribute editorBrowsable = Assert.IsType<EditorBrowsableAttribute>(
+            method.GetCustomAttribute<EditorBrowsableAttribute>());
+        Assert.Equal(EditorBrowsableState.Never, editorBrowsable.State);
         Assert.Equal(typeof(S1Casino.SlotMachine), method.ReturnType);
 
         MethodInfo managedMethod = typeof(CasinoGameRegistry).GetMethod(
@@ -141,26 +150,64 @@ public sealed class CasinoApiContractTests
 
     private static IEnumerable<Type> GetExposedTypes(MemberInfo member)
     {
+        IEnumerable<Type> declaredTypes;
         switch (member)
         {
             case PropertyInfo property:
-                yield return property.PropertyType;
+                declaredTypes = new[] { property.PropertyType };
                 break;
             case FieldInfo field:
-                yield return field.FieldType;
+                declaredTypes = new[] { field.FieldType };
                 break;
             case EventInfo eventInfo when eventInfo.EventHandlerType != null:
-                yield return eventInfo.EventHandlerType;
+                declaredTypes = new[] { eventInfo.EventHandlerType };
                 break;
             case MethodInfo method:
-                yield return method.ReturnType;
-                foreach (ParameterInfo parameter in method.GetParameters())
-                    yield return parameter.ParameterType;
+                declaredTypes = new[] { method.ReturnType }
+                    .Concat(method.GetParameters().Select(parameter => parameter.ParameterType));
                 break;
             case ConstructorInfo constructor:
-                foreach (ParameterInfo parameter in constructor.GetParameters())
-                    yield return parameter.ParameterType;
+                declaredTypes = constructor.GetParameters().Select(parameter => parameter.ParameterType);
                 break;
+            default:
+                return Array.Empty<Type>();
         }
+
+        return declaredTypes.SelectMany(ExpandCompositeType);
+    }
+
+    private static IEnumerable<Type> ExpandCompositeType(Type root)
+    {
+        var pending = new Stack<Type>();
+        var visited = new HashSet<Type>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            Type current = pending.Pop();
+            if (!visited.Add(current))
+                continue;
+
+            yield return current;
+
+            if (current.HasElementType && current.GetElementType() is Type elementType)
+                pending.Push(elementType);
+
+            foreach (Type argument in current.GetGenericArguments())
+                pending.Push(argument);
+
+            if (current.BaseType != null)
+                pending.Push(current.BaseType);
+
+            foreach (Type implementedInterface in current.GetInterfaces())
+                pending.Push(implementedInterface);
+        }
+    }
+
+    private static void AssertPublicInstanceFieldsAreReadonly(Type type)
+    {
+        Assert.All(
+            type.GetFields(BindingFlags.Public | BindingFlags.Instance),
+            field => Assert.True(field.IsInitOnly, $"{type.Name}.{field.Name} must be readonly."));
     }
 }

--- a/S1API.Tests/Casino/CasinoApiContractTests.cs
+++ b/S1API.Tests/Casino/CasinoApiContractTests.cs
@@ -1,0 +1,166 @@
+using System.Reflection;
+using S1API.Casino;
+
+#if IL2CPPMELON
+using S1Casino = Il2CppScheduleOne.Casino;
+#elif MONOMELON
+using S1Casino = ScheduleOne.Casino;
+#endif
+
+namespace S1API.Tests.Casino;
+
+public sealed class CasinoApiContractTests
+{
+    [Fact]
+    public void NativeLifecyclePatchPointsExistInTargetRuntime()
+    {
+        Assert.NotNull(typeof(S1Casino.BlackjackGameController).GetMethod(
+            "set_CurrentStage",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+        Assert.NotNull(typeof(S1Casino.RTBGameController).GetMethod(
+            "set_CurrentStage",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+        Assert.NotNull(typeof(S1Casino.SlotMachine).GetMethod(
+            "RpcLogic___StartSpin_2659526290",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+        Assert.NotNull(typeof(S1Casino.SlotMachine).GetMethod(
+            "DisplayOutcome",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public));
+    }
+
+    [Fact]
+    public void ManagedEnumsPreserveNativeWireValues()
+    {
+        Assert.Equal((int)S1Casino.BlackjackGameController.EStage.WaitingForPlayers, (int)BlackjackStage.WaitingForPlayers);
+        Assert.Equal((int)S1Casino.BlackjackGameController.EStage.Ending, (int)BlackjackStage.Ending);
+        Assert.Equal((int)S1Casino.RTBGameController.EStage.RedOrBlack, (int)RideTheBusStage.RedOrBlack);
+        Assert.Equal((int)S1Casino.RTBGameController.EStage.Suit, (int)RideTheBusStage.Suit);
+        Assert.Equal((int)S1Casino.PlayingCard.ECardSuit.Clubs, (int)CasinoCardSuit.Clubs);
+        Assert.Equal((int)S1Casino.PlayingCard.ECardValue.King, (int)CasinoCardValue.King);
+        Assert.Equal((int)S1Casino.SlotMachine.ESymbol.Seven, (int)SlotSymbol.Seven);
+        Assert.Equal((int)S1Casino.SlotMachine.EOutcome.NoWin, (int)SlotOutcome.NoWin);
+    }
+
+    [Theory]
+    [InlineData(typeof(CasinoPlayerSnapshot))]
+    [InlineData(typeof(SlotSpinSnapshot))]
+    public void SnapshotReferenceTypesExposeNoPublicSetters(Type snapshotType)
+    {
+        Assert.All(
+            snapshotType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
+            property => Assert.Null(property.SetMethod));
+        Assert.Empty(snapshotType.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+    }
+
+    [Fact]
+    public void CasinoWrappersCannotBePubliclyConstructedOrMutated()
+    {
+        Type[] wrapperTypes =
+        {
+            typeof(BlackjackGame),
+            typeof(RideTheBusGame),
+            typeof(SlotMachine)
+        };
+
+        foreach (Type wrapperType in wrapperTypes)
+        {
+            Assert.Empty(wrapperType.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+            Assert.All(
+                wrapperType.GetProperties(BindingFlags.Public | BindingFlags.Instance),
+                property => Assert.Null(property.SetMethod));
+        }
+    }
+
+    [Fact]
+    public void RegistrySurfaceIsReadOnlyDiscoveryAndQueriesOnly()
+    {
+        MethodInfo[] publicMethods = typeof(CasinoGameRegistry)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(method => !method.IsSpecialName)
+            .ToArray();
+
+        Assert.NotEmpty(publicMethods);
+        Assert.All(publicMethods, method =>
+            Assert.True(
+                method.Name.StartsWith("Get", StringComparison.Ordinal) ||
+                method.Name.StartsWith("Find", StringComparison.Ordinal),
+                $"Unexpected registry method: {method.Name}"));
+        Assert.DoesNotContain(publicMethods, method => method.ReturnType == typeof(void));
+    }
+
+    [Fact]
+    public void LegacyNativeSlotLookupRemainsAsAnObsoleteCompatibilityShim()
+    {
+        MethodInfo method = typeof(SlotMachineHelper).GetMethod(
+            nameof(SlotMachineHelper.FindNearestSlotMachine),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(UnityEngine.Vector3), typeof(float) },
+            modifiers: null)!;
+
+        Assert.NotNull(method);
+        Assert.NotNull(method.GetCustomAttribute<ObsoleteAttribute>());
+        Assert.Equal(typeof(S1Casino.SlotMachine), method.ReturnType);
+
+        MethodInfo managedMethod = typeof(CasinoGameRegistry).GetMethod(
+            nameof(CasinoGameRegistry.FindNearestSlotMachine),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { typeof(UnityEngine.Vector3), typeof(float) },
+            modifiers: null)!;
+
+        Assert.NotNull(managedMethod);
+        Assert.Equal(typeof(SlotMachine), managedMethod.ReturnType);
+    }
+
+    [Fact]
+    public void PublicCasinoApiDoesNotExposeNativeCasinoTypes()
+    {
+        Type[] publicCasinoTypes =
+        {
+            typeof(CasinoGameRegistry),
+            typeof(CasinoGameTable),
+            typeof(BlackjackGame),
+            typeof(RideTheBusGame),
+            typeof(SlotMachine),
+            typeof(CasinoPlayerSnapshot),
+            typeof(CasinoCardSnapshot),
+            typeof(SlotSpinSnapshot)
+        };
+
+        foreach (Type type in publicCasinoTypes)
+        {
+            IEnumerable<Type> exposedTypes = type
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                .SelectMany(GetExposedTypes);
+
+            Assert.DoesNotContain(exposedTypes, exposed =>
+                exposed.Namespace?.Contains("ScheduleOne.Casino", StringComparison.Ordinal) == true);
+        }
+    }
+
+    private static IEnumerable<Type> GetExposedTypes(MemberInfo member)
+    {
+        switch (member)
+        {
+            case PropertyInfo property:
+                yield return property.PropertyType;
+                break;
+            case FieldInfo field:
+                yield return field.FieldType;
+                break;
+            case EventInfo eventInfo when eventInfo.EventHandlerType != null:
+                yield return eventInfo.EventHandlerType;
+                break;
+            case MethodInfo method:
+                yield return method.ReturnType;
+                foreach (ParameterInfo parameter in method.GetParameters())
+                    yield return parameter.ParameterType;
+                break;
+            case ConstructorInfo constructor:
+                foreach (ParameterInfo parameter in constructor.GetParameters())
+                    yield return parameter.ParameterType;
+                break;
+        }
+    }
+}

--- a/S1API/Casino/CasinoGameRegistry.cs
+++ b/S1API/Casino/CasinoGameRegistry.cs
@@ -7,6 +7,7 @@ using S1Casino = ScheduleOne.Casino;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using S1API.Internal;
 using S1API.Lifecycle;
 using S1API.Logging;
 using UnityEngine;
@@ -53,7 +54,7 @@ namespace S1API.Casino
         /// <summary>Raised when a slot machine displays a synchronized spin outcome.</summary>
         public static event Action<SlotMachine, SlotSpinSnapshot>? SlotSpinCompleted;
 
-        /// <summary>Gets immutable wrappers for all active blackjack tables.</summary>
+        /// <summary>Gets a read-only snapshot of all active blackjack tables.</summary>
         public static IReadOnlyList<BlackjackGame> GetBlackjackGames()
         {
             EnsureLifecycleHook();
@@ -67,7 +68,7 @@ namespace S1API.Casino
             return new ReadOnlyCollection<BlackjackGame>(games);
         }
 
-        /// <summary>Gets immutable wrappers for all active Ride the Bus tables.</summary>
+        /// <summary>Gets a read-only snapshot of all active Ride the Bus tables.</summary>
         public static IReadOnlyList<RideTheBusGame> GetRideTheBusGames()
         {
             EnsureLifecycleHook();
@@ -81,7 +82,7 @@ namespace S1API.Casino
             return new ReadOnlyCollection<RideTheBusGame>(games);
         }
 
-        /// <summary>Gets immutable wrappers for all active native slot machines.</summary>
+        /// <summary>Gets a read-only snapshot of all active native slot machines.</summary>
         public static IReadOnlyList<SlotMachine> GetSlotMachines()
         {
             EnsureLifecycleHook();
@@ -105,7 +106,7 @@ namespace S1API.Casino
             return native == null ? null : Wrap(native);
         }
 
-        /// <summary>Gets immutable wrappers for all active blackjack and Ride the Bus tables.</summary>
+        /// <summary>Gets a read-only snapshot of all active blackjack and Ride the Bus tables.</summary>
         public static IReadOnlyList<CasinoGameTable> GetTables()
         {
             var tables = new List<CasinoGameTable>();
@@ -160,12 +161,12 @@ namespace S1API.Casino
 
             BlackjackGame game = Wrap(native);
             game.NotifyStageChanged(previous, current);
-            InvokeSafely(BlackjackStageChanged, game, previous, current, nameof(BlackjackStageChanged));
+            CasinoEventInvoker.Invoke(BlackjackStageChanged, game, previous, current, nameof(BlackjackStageChanged));
 
             if (current == BlackjackStage.Dealing && previous == BlackjackStage.WaitingForPlayers)
-                InvokeSafely(BlackjackRoundStarted, game, nameof(BlackjackRoundStarted));
+                CasinoEventInvoker.Invoke(BlackjackRoundStarted, game, nameof(BlackjackRoundStarted));
             if (current == BlackjackStage.WaitingForPlayers)
-                InvokeSafely(BlackjackRoundEnded, game, nameof(BlackjackRoundEnded));
+                CasinoEventInvoker.Invoke(BlackjackRoundEnded, game, nameof(BlackjackRoundEnded));
         }
 
         internal static void NotifyRideTheBusStageChanged(
@@ -178,12 +179,12 @@ namespace S1API.Casino
 
             RideTheBusGame game = Wrap(native);
             game.NotifyStageChanged(previous, current);
-            InvokeSafely(RideTheBusStageChanged, game, previous, current, nameof(RideTheBusStageChanged));
+            CasinoEventInvoker.Invoke(RideTheBusStageChanged, game, previous, current, nameof(RideTheBusStageChanged));
 
             if (current == RideTheBusStage.RedOrBlack && previous == RideTheBusStage.WaitingForPlayers)
-                InvokeSafely(RideTheBusRoundStarted, game, nameof(RideTheBusRoundStarted));
+                CasinoEventInvoker.Invoke(RideTheBusRoundStarted, game, nameof(RideTheBusRoundStarted));
             if (current == RideTheBusStage.WaitingForPlayers)
-                InvokeSafely(RideTheBusRoundEnded, game, nameof(RideTheBusRoundEnded));
+                CasinoEventInvoker.Invoke(RideTheBusRoundEnded, game, nameof(RideTheBusRoundEnded));
         }
 
         internal static void NotifySlotSpinStarted(
@@ -195,7 +196,7 @@ namespace S1API.Casino
 
             SlotMachine machine = Wrap(native);
             machine.NotifySpinStarted(snapshot);
-            InvokeSafely(SlotSpinStarted, machine, snapshot, nameof(SlotSpinStarted));
+            CasinoEventInvoker.Invoke(SlotSpinStarted, machine, snapshot, nameof(SlotSpinStarted));
         }
 
         internal static void NotifySlotSpinCompleted(
@@ -211,7 +212,7 @@ namespace S1API.Casino
             SlotSpinSnapshot completed = started.Complete(outcome, winAmount);
             SlotMachine machine = Wrap(native);
             machine.NotifySpinCompleted(completed);
-            InvokeSafely(SlotSpinCompleted, machine, completed, nameof(SlotSpinCompleted));
+            CasinoEventInvoker.Invoke(SlotSpinCompleted, machine, completed, nameof(SlotSpinCompleted));
         }
 
         internal static void LogSubscriberFailure(string eventName, Exception exception) =>
@@ -232,51 +233,6 @@ namespace S1API.Casino
             RideTheBusGames.Clear();
             SlotMachines.Clear();
             ActiveSpins.Clear();
-        }
-
-        private static void InvokeSafely<T>(Action<T>? handlers, T value, string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<T> handler in handlers.GetInvocationList())
-            {
-                try { handler(value); }
-                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
-            }
-        }
-
-        private static void InvokeSafely<T1, T2>(
-            Action<T1, T2>? handlers,
-            T1 value1,
-            T2 value2,
-            string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<T1, T2> handler in handlers.GetInvocationList())
-            {
-                try { handler(value1, value2); }
-                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
-            }
-        }
-
-        private static void InvokeSafely<T1, T2, T3>(
-            Action<T1, T2, T3>? handlers,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<T1, T2, T3> handler in handlers.GetInvocationList())
-            {
-                try { handler(value1, value2, value3); }
-                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
-            }
         }
     }
 }

--- a/S1API/Casino/CasinoGameRegistry.cs
+++ b/S1API/Casino/CasinoGameRegistry.cs
@@ -1,0 +1,282 @@
+#if IL2CPPMELON
+using S1Casino = Il2CppScheduleOne.Casino;
+#elif MONOMELON
+using S1Casino = ScheduleOne.Casino;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using S1API.Lifecycle;
+using S1API.Logging;
+using UnityEngine;
+
+namespace S1API.Casino
+{
+    /// <summary>
+    /// Discovers native casino games and publishes their synchronized lifecycle transitions.
+    /// </summary>
+    /// <remarks>
+    /// This first-version API is intentionally read-only. It does not expose native RPCs, payout
+    /// replacement, game authoring, or methods that mutate bets and round state.
+    /// </remarks>
+    public static class CasinoGameRegistry
+    {
+        private static readonly Log Logger = new Log("CasinoGameRegistry");
+        private static readonly Dictionary<int, BlackjackGame> BlackjackGames = new Dictionary<int, BlackjackGame>();
+        private static readonly Dictionary<int, RideTheBusGame> RideTheBusGames = new Dictionary<int, RideTheBusGame>();
+        private static readonly Dictionary<int, SlotMachine> SlotMachines = new Dictionary<int, SlotMachine>();
+        private static readonly Dictionary<int, SlotSpinSnapshot> ActiveSpins = new Dictionary<int, SlotSpinSnapshot>();
+        private static bool _lifecycleHooked;
+
+        /// <summary>Raised after a blackjack table changes stage.</summary>
+        public static event Action<BlackjackGame, BlackjackStage, BlackjackStage>? BlackjackStageChanged;
+
+        /// <summary>Raised when a blackjack table enters the dealing stage.</summary>
+        public static event Action<BlackjackGame>? BlackjackRoundStarted;
+
+        /// <summary>Raised when a blackjack table returns to the waiting stage.</summary>
+        public static event Action<BlackjackGame>? BlackjackRoundEnded;
+
+        /// <summary>Raised after the Ride the Bus table changes stage.</summary>
+        public static event Action<RideTheBusGame, RideTheBusStage, RideTheBusStage>? RideTheBusStageChanged;
+
+        /// <summary>Raised when a Ride the Bus table begins its first question.</summary>
+        public static event Action<RideTheBusGame>? RideTheBusRoundStarted;
+
+        /// <summary>Raised when a Ride the Bus table returns to the waiting stage.</summary>
+        public static event Action<RideTheBusGame>? RideTheBusRoundEnded;
+
+        /// <summary>Raised when a slot machine begins a synchronized spin.</summary>
+        public static event Action<SlotMachine, SlotSpinSnapshot>? SlotSpinStarted;
+
+        /// <summary>Raised when a slot machine displays a synchronized spin outcome.</summary>
+        public static event Action<SlotMachine, SlotSpinSnapshot>? SlotSpinCompleted;
+
+        /// <summary>Gets immutable wrappers for all active blackjack tables.</summary>
+        public static IReadOnlyList<BlackjackGame> GetBlackjackGames()
+        {
+            EnsureLifecycleHook();
+            var nativeGames = UnityEngine.Object.FindObjectsOfType<S1Casino.BlackjackGameController>();
+            var games = new List<BlackjackGame>(nativeGames.Length);
+            for (int i = 0; i < nativeGames.Length; i++)
+            {
+                if (nativeGames[i] != null)
+                    games.Add(Wrap(nativeGames[i]));
+            }
+            return new ReadOnlyCollection<BlackjackGame>(games);
+        }
+
+        /// <summary>Gets immutable wrappers for all active Ride the Bus tables.</summary>
+        public static IReadOnlyList<RideTheBusGame> GetRideTheBusGames()
+        {
+            EnsureLifecycleHook();
+            var nativeGames = UnityEngine.Object.FindObjectsOfType<S1Casino.RTBGameController>();
+            var games = new List<RideTheBusGame>(nativeGames.Length);
+            for (int i = 0; i < nativeGames.Length; i++)
+            {
+                if (nativeGames[i] != null)
+                    games.Add(Wrap(nativeGames[i]));
+            }
+            return new ReadOnlyCollection<RideTheBusGame>(games);
+        }
+
+        /// <summary>Gets immutable wrappers for all active native slot machines.</summary>
+        public static IReadOnlyList<SlotMachine> GetSlotMachines()
+        {
+            EnsureLifecycleHook();
+            var nativeMachines = UnityEngine.Object.FindObjectsOfType<S1Casino.SlotMachine>();
+            var machines = new List<SlotMachine>(nativeMachines.Length);
+            for (int i = 0; i < nativeMachines.Length; i++)
+            {
+                if (nativeMachines[i] != null)
+                    machines.Add(Wrap(nativeMachines[i]));
+            }
+            return new ReadOnlyCollection<SlotMachine>(machines);
+        }
+
+        /// <summary>Finds the active slot machine nearest to a world position.</summary>
+        /// <param name="position">The world position to search from.</param>
+        /// <param name="maxDistance">The maximum search distance.</param>
+        /// <returns>The nearest managed slot-machine wrapper, or <see langword="null"/> when none is in range.</returns>
+        public static SlotMachine? FindNearestSlotMachine(Vector3 position, float maxDistance)
+        {
+            S1Casino.SlotMachine? native = SlotMachineHelper.FindNearestNativeSlotMachine(position, maxDistance);
+            return native == null ? null : Wrap(native);
+        }
+
+        /// <summary>Gets immutable wrappers for all active blackjack and Ride the Bus tables.</summary>
+        public static IReadOnlyList<CasinoGameTable> GetTables()
+        {
+            var tables = new List<CasinoGameTable>();
+            tables.AddRange(GetBlackjackGames());
+            tables.AddRange(GetRideTheBusGames());
+            return new ReadOnlyCollection<CasinoGameTable>(tables);
+        }
+
+        internal static BlackjackGame Wrap(S1Casino.BlackjackGameController native)
+        {
+            EnsureLifecycleHook();
+            int key = native.GetInstanceID();
+            if (!BlackjackGames.TryGetValue(key, out BlackjackGame? game))
+            {
+                game = new BlackjackGame(native);
+                BlackjackGames[key] = game;
+            }
+            return game;
+        }
+
+        internal static RideTheBusGame Wrap(S1Casino.RTBGameController native)
+        {
+            EnsureLifecycleHook();
+            int key = native.GetInstanceID();
+            if (!RideTheBusGames.TryGetValue(key, out RideTheBusGame? game))
+            {
+                game = new RideTheBusGame(native);
+                RideTheBusGames[key] = game;
+            }
+            return game;
+        }
+
+        internal static SlotMachine Wrap(S1Casino.SlotMachine native)
+        {
+            EnsureLifecycleHook();
+            int key = native.GetInstanceID();
+            if (!SlotMachines.TryGetValue(key, out SlotMachine? machine))
+            {
+                machine = new SlotMachine(native);
+                SlotMachines[key] = machine;
+            }
+            return machine;
+        }
+
+        internal static void NotifyBlackjackStageChanged(
+            S1Casino.BlackjackGameController native,
+            BlackjackStage previous,
+            BlackjackStage current)
+        {
+            if (previous == current)
+                return;
+
+            BlackjackGame game = Wrap(native);
+            game.NotifyStageChanged(previous, current);
+            InvokeSafely(BlackjackStageChanged, game, previous, current, nameof(BlackjackStageChanged));
+
+            if (current == BlackjackStage.Dealing && previous == BlackjackStage.WaitingForPlayers)
+                InvokeSafely(BlackjackRoundStarted, game, nameof(BlackjackRoundStarted));
+            if (current == BlackjackStage.WaitingForPlayers)
+                InvokeSafely(BlackjackRoundEnded, game, nameof(BlackjackRoundEnded));
+        }
+
+        internal static void NotifyRideTheBusStageChanged(
+            S1Casino.RTBGameController native,
+            RideTheBusStage previous,
+            RideTheBusStage current)
+        {
+            if (previous == current)
+                return;
+
+            RideTheBusGame game = Wrap(native);
+            game.NotifyStageChanged(previous, current);
+            InvokeSafely(RideTheBusStageChanged, game, previous, current, nameof(RideTheBusStageChanged));
+
+            if (current == RideTheBusStage.RedOrBlack && previous == RideTheBusStage.WaitingForPlayers)
+                InvokeSafely(RideTheBusRoundStarted, game, nameof(RideTheBusRoundStarted));
+            if (current == RideTheBusStage.WaitingForPlayers)
+                InvokeSafely(RideTheBusRoundEnded, game, nameof(RideTheBusRoundEnded));
+        }
+
+        internal static void NotifySlotSpinStarted(
+            S1Casino.SlotMachine native,
+            SlotSpinSnapshot snapshot)
+        {
+            int key = native.GetInstanceID();
+            ActiveSpins[key] = snapshot;
+
+            SlotMachine machine = Wrap(native);
+            machine.NotifySpinStarted(snapshot);
+            InvokeSafely(SlotSpinStarted, machine, snapshot, nameof(SlotSpinStarted));
+        }
+
+        internal static void NotifySlotSpinCompleted(
+            S1Casino.SlotMachine native,
+            SlotOutcome outcome,
+            int winAmount)
+        {
+            int key = native.GetInstanceID();
+            if (!ActiveSpins.TryGetValue(key, out SlotSpinSnapshot? started))
+                return;
+
+            ActiveSpins.Remove(key);
+            SlotSpinSnapshot completed = started.Complete(outcome, winAmount);
+            SlotMachine machine = Wrap(native);
+            machine.NotifySpinCompleted(completed);
+            InvokeSafely(SlotSpinCompleted, machine, completed, nameof(SlotSpinCompleted));
+        }
+
+        internal static void LogSubscriberFailure(string eventName, Exception exception) =>
+            Logger.Warning($"A {eventName} subscriber failed: {exception.Message}");
+
+        private static void EnsureLifecycleHook()
+        {
+            if (_lifecycleHooked)
+                return;
+
+            GameLifecycle.OnPreSceneChange += ClearSceneState;
+            _lifecycleHooked = true;
+        }
+
+        private static void ClearSceneState()
+        {
+            BlackjackGames.Clear();
+            RideTheBusGames.Clear();
+            SlotMachines.Clear();
+            ActiveSpins.Clear();
+        }
+
+        private static void InvokeSafely<T>(Action<T>? handlers, T value, string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T> handler in handlers.GetInvocationList())
+            {
+                try { handler(value); }
+                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        private static void InvokeSafely<T1, T2>(
+            Action<T1, T2>? handlers,
+            T1 value1,
+            T2 value2,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T1, T2> handler in handlers.GetInvocationList())
+            {
+                try { handler(value1, value2); }
+                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        private static void InvokeSafely<T1, T2, T3>(
+            Action<T1, T2, T3>? handlers,
+            T1 value1,
+            T2 value2,
+            T3 value3,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T1, T2, T3> handler in handlers.GetInvocationList())
+            {
+                try { handler(value1, value2, value3); }
+                catch (Exception ex) { LogSubscriberFailure(eventName, ex); }
+            }
+        }
+    }
+}

--- a/S1API/Casino/CasinoGames.cs
+++ b/S1API/Casino/CasinoGames.cs
@@ -12,7 +12,9 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using S1API.Entities;
+using S1API.Internal;
 using S1API.Internal.Utils;
+using S1API.Logging;
 using UnityEngine;
 
 namespace S1API.Casino
@@ -24,37 +26,38 @@ namespace S1API.Casino
     {
         private static readonly IReadOnlyList<CasinoPlayerSnapshot> EmptyPlayers =
             new ReadOnlyCollection<CasinoPlayerSnapshot>(Array.Empty<CasinoPlayerSnapshot>());
+        private static readonly Log Logger = new Log("CasinoGameTable");
 
         internal CasinoGameTable(S1Casino.CasinoGameController controller)
         {
-            Controller = controller ?? throw new ArgumentNullException(nameof(controller));
+            S1Controller = controller ?? throw new ArgumentNullException(nameof(controller));
         }
 
-        internal S1Casino.CasinoGameController Controller { get; }
+        internal S1Casino.CasinoGameController S1Controller { get; }
 
         /// <summary>Gets the scene object name.</summary>
-        public string Name => Controller.gameObject?.name ?? string.Empty;
+        public string Name => S1Controller.gameObject?.name ?? string.Empty;
 
         /// <summary>Gets the current world position.</summary>
-        public Vector3 Position => Controller.transform.position;
+        public Vector3 Position => S1Controller.transform.position;
 
         /// <summary>
         /// Gets whether this table's interface is open for the local player.
         /// </summary>
-        public bool IsOpen => Controller.IsOpen;
+        public bool IsOpen => S1Controller.IsOpen;
 
         /// <summary>Gets whether the table is currently accepting ready players.</summary>
-        public bool IsWaitingForPlayers => Controller.IsWaitingForPlayers();
+        public bool IsWaitingForPlayers => S1Controller.IsWaitingForPlayers();
 
         /// <summary>Gets the local player's currently selected bet.</summary>
-        public float LocalBet => Controller.LocalPlayerBet;
+        public float LocalBet => S1Controller.LocalPlayerBet;
 
         /// <summary>Gets the native minimum and maximum bet.</summary>
         public CasinoBetLimits BetLimits
         {
             get
             {
-                Controller.GetBetLimits(out float minimum, out float maximum);
+                S1Controller.GetBetLimits(out float minimum, out float maximum);
                 return new CasinoBetLimits(minimum, maximum);
             }
         }
@@ -66,7 +69,7 @@ namespace S1API.Casino
         {
             get
             {
-                S1Casino.CasinoGamePlayers? players = Controller.Players;
+                S1Casino.CasinoGamePlayers? players = S1Controller.Players;
                 if (players == null)
                     return EmptyPlayers;
 
@@ -83,8 +86,9 @@ namespace S1API.Casino
                         S1Casino.CasinoGamePlayerData? data = players.GetPlayerData(nativePlayer);
                         ready = data != null && data.GetData<bool>("Ready");
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        Logger.Warning($"Failed to read ready state for player '{nativePlayer.PlayerName}': {ex.Message}");
                     }
 
                     snapshots.Add(new CasinoPlayerSnapshot(
@@ -112,14 +116,27 @@ namespace S1API.Casino
     {
         private static readonly IReadOnlyList<CasinoCardSnapshot> EmptyCards =
             new ReadOnlyCollection<CasinoCardSnapshot>(Array.Empty<CasinoCardSnapshot>());
+#if MONOMELON
+        private const BindingFlags NativeMemberFlags =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private static readonly MethodInfo? GetPlayerCardsMethod =
+            typeof(S1Casino.BlackjackGameController).GetMethod(
+                "GetPlayerCards",
+                NativeMemberFlags,
+                binder: null,
+                types: new[] { typeof(int) },
+                modifiers: null);
+        private static readonly FieldInfo? DealerHandField =
+            typeof(S1Casino.BlackjackGameController).GetField("dealerHand", NativeMemberFlags);
+#endif
 
         internal BlackjackGame(S1Casino.BlackjackGameController controller)
             : base(controller)
         {
-            Native = controller;
+            S1Native = controller;
         }
 
-        internal S1Casino.BlackjackGameController Native { get; }
+        internal S1Casino.BlackjackGameController S1Native { get; }
 
         /// <summary>Raised after the native blackjack stage changes.</summary>
         public event Action<BlackjackStage, BlackjackStage>? StageChanged;
@@ -131,25 +148,25 @@ namespace S1API.Casino
         public event Action? RoundEnded;
 
         /// <summary>Gets the current round stage.</summary>
-        public BlackjackStage Stage => (BlackjackStage)(int)Native.CurrentStage;
+        public BlackjackStage Stage => (BlackjackStage)(int)S1Native.CurrentStage;
 
         /// <summary>Gets the current dealer score visible to this peer.</summary>
-        public int DealerScore => Native.DealerScore;
+        public int DealerScore => S1Native.DealerScore;
 
         /// <summary>Gets the current local-player score.</summary>
-        public int LocalPlayerScore => Native.LocalPlayerScore;
+        public int LocalPlayerScore => S1Native.LocalPlayerScore;
 
         /// <summary>Gets whether the local player has a natural blackjack.</summary>
-        public bool IsLocalPlayerBlackjack => Native.IsLocalPlayerBlackjack;
+        public bool IsLocalPlayerBlackjack => S1Native.IsLocalPlayerBlackjack;
 
         /// <summary>Gets whether the local player is bust.</summary>
-        public bool IsLocalPlayerBust => Native.IsLocalPlayerBust;
+        public bool IsLocalPlayerBust => S1Native.IsLocalPlayerBust;
 
         /// <summary>Gets whether the local player belongs to the active round.</summary>
-        public bool IsLocalPlayerInRound => Native.IsLocalPlayerInCurrentRound;
+        public bool IsLocalPlayerInRound => S1Native.IsLocalPlayerInCurrentRound;
 
         /// <summary>Gets the number of seated players currently marked ready.</summary>
-        public int ReadyPlayerCount => Native.GetPlayersReadyCount();
+        public int ReadyPlayerCount => S1Native.GetPlayersReadyCount();
 
         /// <summary>
         /// Gets an immutable snapshot of a seated player's current hand.
@@ -157,16 +174,13 @@ namespace S1API.Casino
         /// <param name="seatIndex">The zero-based seat index.</param>
         public IReadOnlyList<CasinoCardSnapshot> GetPlayerHand(int seatIndex)
         {
-            if (seatIndex < 0 || seatIndex >= Native.Players.PlayerLimit)
+            if (seatIndex < 0 || seatIndex >= S1Native.Players.PlayerLimit)
                 return EmptyCards;
 
 #if IL2CPPMELON
-            var cards = Native.GetPlayerCards(seatIndex);
+            var cards = S1Native.GetPlayerCards(seatIndex);
 #else
-            var method = typeof(S1Casino.BlackjackGameController).GetMethod(
-                "GetPlayerCards",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            var cards = method?.Invoke(Native, new object[] { seatIndex })
+            var cards = GetPlayerCardsMethod?.Invoke(S1Native, new object[] { seatIndex })
                 as List<S1Casino.PlayingCard>;
 #endif
             return FreezeCards(cards);
@@ -178,12 +192,9 @@ namespace S1API.Casino
             get
             {
 #if IL2CPPMELON
-                var cards = Native.dealerHand;
+                var cards = S1Native.dealerHand;
 #else
-                var dealerHandField = typeof(S1Casino.BlackjackGameController).GetField(
-                    "dealerHand",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-                var cards = dealerHandField?.GetValue(Native) as List<S1Casino.PlayingCard>;
+                var cards = DealerHandField?.GetValue(S1Native) as List<S1Casino.PlayingCard>;
 #endif
                 return FreezeCards(cards);
             }
@@ -191,11 +202,11 @@ namespace S1API.Casino
 
         internal void NotifyStageChanged(BlackjackStage previous, BlackjackStage current)
         {
-            InvokeSafely(StageChanged, previous, current, nameof(StageChanged));
+            CasinoEventInvoker.Invoke(StageChanged, previous, current, nameof(StageChanged));
             if (current == BlackjackStage.Dealing && previous == BlackjackStage.WaitingForPlayers)
-                InvokeSafely(RoundStarted, nameof(RoundStarted));
+                CasinoEventInvoker.Invoke(RoundStarted, nameof(RoundStarted));
             if (current == BlackjackStage.WaitingForPlayers && previous != current)
-                InvokeSafely(RoundEnded, nameof(RoundEnded));
+                CasinoEventInvoker.Invoke(RoundEnded, nameof(RoundEnded));
         }
 
         private static IReadOnlyList<CasinoCardSnapshot> FreezeCards(
@@ -227,34 +238,6 @@ namespace S1API.Casino
                 (CasinoCardSuit)(int)card.Suit,
                 (CasinoCardValue)(int)card.Value,
                 card.IsFaceUp);
-
-        private static void InvokeSafely(Action? handlers, string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action handler in handlers.GetInvocationList())
-            {
-                try { handler(); }
-                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
-            }
-        }
-
-        private static void InvokeSafely(
-            Action<BlackjackStage, BlackjackStage>? handlers,
-            BlackjackStage previous,
-            BlackjackStage current,
-            string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<BlackjackStage, BlackjackStage> handler in handlers.GetInvocationList())
-            {
-                try { handler(previous, current); }
-                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
-            }
-        }
     }
 
     /// <summary>
@@ -268,10 +251,10 @@ namespace S1API.Casino
         internal RideTheBusGame(S1Casino.RTBGameController controller)
             : base(controller)
         {
-            Native = controller;
+            S1Native = controller;
         }
 
-        internal S1Casino.RTBGameController Native { get; }
+        internal S1Casino.RTBGameController S1Native { get; }
 
         /// <summary>Raised after the native Ride the Bus stage changes.</summary>
         public event Action<RideTheBusStage, RideTheBusStage>? StageChanged;
@@ -283,41 +266,42 @@ namespace S1API.Casino
         public event Action? RoundEnded;
 
         /// <summary>Gets the current round stage.</summary>
-        public RideTheBusStage Stage => (RideTheBusStage)(int)Native.CurrentStage;
+        public RideTheBusStage Stage => (RideTheBusStage)(int)S1Native.CurrentStage;
 
         /// <summary>Gets whether a question is currently accepting answers.</summary>
-        public bool IsQuestionActive => Native.IsQuestionActive;
+        public bool IsQuestionActive => S1Native.IsQuestionActive;
 
         /// <summary>Gets the local player's current bet multiplier.</summary>
-        public float LocalBetMultiplier => Native.LocalPlayerBetMultiplier;
+        public float LocalBetMultiplier => S1Native.LocalPlayerBetMultiplier;
 
         /// <summary>Gets the local player's multiplied bet.</summary>
-        public float MultipliedLocalBet => Native.MultipliedLocalPlayerBet;
+        public float MultipliedLocalBet => S1Native.MultipliedLocalPlayerBet;
 
         /// <summary>Gets the answer time remaining on the current peer.</summary>
-        public float RemainingAnswerTime => Native.RemainingAnswerTime;
+        public float RemainingAnswerTime => S1Native.RemainingAnswerTime;
 
         /// <summary>Gets whether the local player belongs to the active round.</summary>
-        public bool IsLocalPlayerInRound => Native.IsLocalPlayerInCurrentRound;
+        public bool IsLocalPlayerInRound => S1Native.IsLocalPlayerInCurrentRound;
 
         /// <summary>Gets the number of seated players currently marked ready.</summary>
-        public int ReadyPlayerCount => Native.GetPlayersReadyCount();
+        public int ReadyPlayerCount => S1Native.GetPlayersReadyCount();
 
         /// <summary>Gets the number of active-round players who submitted an answer.</summary>
-        public int AnsweredPlayerCount => Native.GetAnsweredPlayersCount();
+        public int AnsweredPlayerCount => S1Native.GetAnsweredPlayersCount();
 
         /// <summary>Gets immutable snapshots of cards currently assigned by the table.</summary>
         public IReadOnlyList<CasinoCardSnapshot> Cards
         {
             get
             {
-                if (Native.Cards == null || Native.Cards.Length == 0)
+                var nativeCards = S1Native.Cards;
+                if (nativeCards == null || nativeCards.Length == 0)
                     return EmptyCards;
 
                 var cards = new List<CasinoCardSnapshot>();
-                for (int i = 0; i < Native.Cards.Length; i++)
+                for (int i = 0; i < nativeCards.Length; i++)
                 {
-                    S1Casino.PlayingCard? card = Native.Cards[i];
+                    S1Casino.PlayingCard? card = nativeCards[i];
                     if (card != null && (int)card.Value != (int)CasinoCardValue.Blank)
                         cards.Add(BlackjackGame.ToSnapshot(card));
                 }
@@ -330,39 +314,11 @@ namespace S1API.Casino
 
         internal void NotifyStageChanged(RideTheBusStage previous, RideTheBusStage current)
         {
-            InvokeSafely(StageChanged, previous, current, nameof(StageChanged));
+            CasinoEventInvoker.Invoke(StageChanged, previous, current, nameof(StageChanged));
             if (current == RideTheBusStage.RedOrBlack && previous == RideTheBusStage.WaitingForPlayers)
-                InvokeSafely(RoundStarted, nameof(RoundStarted));
+                CasinoEventInvoker.Invoke(RoundStarted, nameof(RoundStarted));
             if (current == RideTheBusStage.WaitingForPlayers && previous != current)
-                InvokeSafely(RoundEnded, nameof(RoundEnded));
-        }
-
-        private static void InvokeSafely(Action? handlers, string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action handler in handlers.GetInvocationList())
-            {
-                try { handler(); }
-                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
-            }
-        }
-
-        private static void InvokeSafely(
-            Action<RideTheBusStage, RideTheBusStage>? handlers,
-            RideTheBusStage previous,
-            RideTheBusStage current,
-            string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<RideTheBusStage, RideTheBusStage> handler in handlers.GetInvocationList())
-            {
-                try { handler(previous, current); }
-                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
-            }
+                CasinoEventInvoker.Invoke(RoundEnded, nameof(RoundEnded));
         }
     }
 
@@ -373,10 +329,10 @@ namespace S1API.Casino
     {
         internal SlotMachine(S1Casino.SlotMachine machine)
         {
-            Native = machine ?? throw new ArgumentNullException(nameof(machine));
+            S1Native = machine ?? throw new ArgumentNullException(nameof(machine));
         }
 
-        internal S1Casino.SlotMachine Native { get; }
+        internal S1Casino.SlotMachine S1Native { get; }
 
         /// <summary>Raised when a synchronized spin begins.</summary>
         public event Action<SlotSpinSnapshot>? SpinStarted;
@@ -385,20 +341,20 @@ namespace S1API.Casino
         public event Action<SlotSpinSnapshot>? SpinCompleted;
 
         /// <summary>Gets the scene object name.</summary>
-        public string Name => Native.gameObject?.name ?? string.Empty;
+        public string Name => S1Native.gameObject?.name ?? string.Empty;
 
         /// <summary>Gets the current world position.</summary>
-        public Vector3 Position => Native.transform.position;
+        public Vector3 Position => S1Native.transform.position;
 
         /// <summary>Gets whether the reels are currently spinning.</summary>
-        public bool IsSpinning => Native.IsSpinning;
+        public bool IsSpinning => S1Native.IsSpinning;
 
         /// <summary>Gets the machine's currently selected bet.</summary>
         public int CurrentBet
         {
             get
             {
-                object? value = ReflectionUtils.TryGetFieldOrProperty(Native, "currentBetAmount");
+                object? value = ReflectionUtils.TryGetFieldOrProperty(S1Native, "currentBetAmount");
                 return value is int bet ? bet : 0;
             }
         }
@@ -417,24 +373,9 @@ namespace S1API.Casino
         }
 
         internal void NotifySpinStarted(SlotSpinSnapshot snapshot) =>
-            InvokeSafely(SpinStarted, snapshot, nameof(SpinStarted));
+            CasinoEventInvoker.Invoke(SpinStarted, snapshot, nameof(SpinStarted));
 
         internal void NotifySpinCompleted(SlotSpinSnapshot snapshot) =>
-            InvokeSafely(SpinCompleted, snapshot, nameof(SpinCompleted));
-
-        private static void InvokeSafely(
-            Action<SlotSpinSnapshot>? handlers,
-            SlotSpinSnapshot snapshot,
-            string eventName)
-        {
-            if (handlers == null)
-                return;
-
-            foreach (Action<SlotSpinSnapshot> handler in handlers.GetInvocationList())
-            {
-                try { handler(snapshot); }
-                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
-            }
-        }
+            CasinoEventInvoker.Invoke(SpinCompleted, snapshot, nameof(SpinCompleted));
     }
 }

--- a/S1API/Casino/CasinoGames.cs
+++ b/S1API/Casino/CasinoGames.cs
@@ -1,0 +1,440 @@
+#if IL2CPPMELON
+using S1Casino = Il2CppScheduleOne.Casino;
+using S1PlayerScripts = Il2CppScheduleOne.PlayerScripts;
+#elif MONOMELON
+using S1Casino = ScheduleOne.Casino;
+using S1PlayerScripts = ScheduleOne.PlayerScripts;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using S1API.Entities;
+using S1API.Internal.Utils;
+using UnityEngine;
+
+namespace S1API.Casino
+{
+    /// <summary>
+    /// Read-only managed view of a native multiplayer casino table.
+    /// </summary>
+    public abstract class CasinoGameTable
+    {
+        private static readonly IReadOnlyList<CasinoPlayerSnapshot> EmptyPlayers =
+            new ReadOnlyCollection<CasinoPlayerSnapshot>(Array.Empty<CasinoPlayerSnapshot>());
+
+        internal CasinoGameTable(S1Casino.CasinoGameController controller)
+        {
+            Controller = controller ?? throw new ArgumentNullException(nameof(controller));
+        }
+
+        internal S1Casino.CasinoGameController Controller { get; }
+
+        /// <summary>Gets the scene object name.</summary>
+        public string Name => Controller.gameObject?.name ?? string.Empty;
+
+        /// <summary>Gets the current world position.</summary>
+        public Vector3 Position => Controller.transform.position;
+
+        /// <summary>
+        /// Gets whether this table's interface is open for the local player.
+        /// </summary>
+        public bool IsOpen => Controller.IsOpen;
+
+        /// <summary>Gets whether the table is currently accepting ready players.</summary>
+        public bool IsWaitingForPlayers => Controller.IsWaitingForPlayers();
+
+        /// <summary>Gets the local player's currently selected bet.</summary>
+        public float LocalBet => Controller.LocalPlayerBet;
+
+        /// <summary>Gets the native minimum and maximum bet.</summary>
+        public CasinoBetLimits BetLimits
+        {
+            get
+            {
+                Controller.GetBetLimits(out float minimum, out float maximum);
+                return new CasinoBetLimits(minimum, maximum);
+            }
+        }
+
+        /// <summary>
+        /// Gets an immutable snapshot of players currently seated at the table.
+        /// </summary>
+        public IReadOnlyList<CasinoPlayerSnapshot> Players
+        {
+            get
+            {
+                S1Casino.CasinoGamePlayers? players = Controller.Players;
+                if (players == null)
+                    return EmptyPlayers;
+
+                var snapshots = new List<CasinoPlayerSnapshot>();
+                for (int seatIndex = 0; seatIndex < players.PlayerLimit; seatIndex++)
+                {
+                    S1PlayerScripts.Player? nativePlayer = players.GetPlayer(seatIndex);
+                    if (nativePlayer == null)
+                        continue;
+
+                    bool ready = false;
+                    try
+                    {
+                        S1Casino.CasinoGamePlayerData? data = players.GetPlayerData(nativePlayer);
+                        ready = data != null && data.GetData<bool>("Ready");
+                    }
+                    catch
+                    {
+                    }
+
+                    snapshots.Add(new CasinoPlayerSnapshot(
+                        ResolvePlayer(nativePlayer),
+                        nativePlayer.PlayerName ?? string.Empty,
+                        seatIndex,
+                        players.GetPlayerScore(nativePlayer),
+                        ready));
+                }
+
+                return snapshots.Count == 0
+                    ? EmptyPlayers
+                    : new ReadOnlyCollection<CasinoPlayerSnapshot>(snapshots);
+            }
+        }
+
+        private static Player? ResolvePlayer(S1PlayerScripts.Player nativePlayer) =>
+            Player.All.FirstOrDefault(player => player.S1Player == nativePlayer);
+    }
+
+    /// <summary>
+    /// Read-only managed view of a native blackjack table.
+    /// </summary>
+    public sealed class BlackjackGame : CasinoGameTable
+    {
+        private static readonly IReadOnlyList<CasinoCardSnapshot> EmptyCards =
+            new ReadOnlyCollection<CasinoCardSnapshot>(Array.Empty<CasinoCardSnapshot>());
+
+        internal BlackjackGame(S1Casino.BlackjackGameController controller)
+            : base(controller)
+        {
+            Native = controller;
+        }
+
+        internal S1Casino.BlackjackGameController Native { get; }
+
+        /// <summary>Raised after the native blackjack stage changes.</summary>
+        public event Action<BlackjackStage, BlackjackStage>? StageChanged;
+
+        /// <summary>Raised when the table enters the dealing stage.</summary>
+        public event Action? RoundStarted;
+
+        /// <summary>Raised when the table returns to its waiting stage.</summary>
+        public event Action? RoundEnded;
+
+        /// <summary>Gets the current round stage.</summary>
+        public BlackjackStage Stage => (BlackjackStage)(int)Native.CurrentStage;
+
+        /// <summary>Gets the current dealer score visible to this peer.</summary>
+        public int DealerScore => Native.DealerScore;
+
+        /// <summary>Gets the current local-player score.</summary>
+        public int LocalPlayerScore => Native.LocalPlayerScore;
+
+        /// <summary>Gets whether the local player has a natural blackjack.</summary>
+        public bool IsLocalPlayerBlackjack => Native.IsLocalPlayerBlackjack;
+
+        /// <summary>Gets whether the local player is bust.</summary>
+        public bool IsLocalPlayerBust => Native.IsLocalPlayerBust;
+
+        /// <summary>Gets whether the local player belongs to the active round.</summary>
+        public bool IsLocalPlayerInRound => Native.IsLocalPlayerInCurrentRound;
+
+        /// <summary>Gets the number of seated players currently marked ready.</summary>
+        public int ReadyPlayerCount => Native.GetPlayersReadyCount();
+
+        /// <summary>
+        /// Gets an immutable snapshot of a seated player's current hand.
+        /// </summary>
+        /// <param name="seatIndex">The zero-based seat index.</param>
+        public IReadOnlyList<CasinoCardSnapshot> GetPlayerHand(int seatIndex)
+        {
+            if (seatIndex < 0 || seatIndex >= Native.Players.PlayerLimit)
+                return EmptyCards;
+
+#if IL2CPPMELON
+            var cards = Native.GetPlayerCards(seatIndex);
+#else
+            var method = typeof(S1Casino.BlackjackGameController).GetMethod(
+                "GetPlayerCards",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var cards = method?.Invoke(Native, new object[] { seatIndex })
+                as List<S1Casino.PlayingCard>;
+#endif
+            return FreezeCards(cards);
+        }
+
+        /// <summary>Gets an immutable snapshot of the dealer's current hand.</summary>
+        public IReadOnlyList<CasinoCardSnapshot> DealerHand
+        {
+            get
+            {
+#if IL2CPPMELON
+                var cards = Native.dealerHand;
+#else
+                var dealerHandField = typeof(S1Casino.BlackjackGameController).GetField(
+                    "dealerHand",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+                var cards = dealerHandField?.GetValue(Native) as List<S1Casino.PlayingCard>;
+#endif
+                return FreezeCards(cards);
+            }
+        }
+
+        internal void NotifyStageChanged(BlackjackStage previous, BlackjackStage current)
+        {
+            InvokeSafely(StageChanged, previous, current, nameof(StageChanged));
+            if (current == BlackjackStage.Dealing && previous == BlackjackStage.WaitingForPlayers)
+                InvokeSafely(RoundStarted, nameof(RoundStarted));
+            if (current == BlackjackStage.WaitingForPlayers && previous != current)
+                InvokeSafely(RoundEnded, nameof(RoundEnded));
+        }
+
+        private static IReadOnlyList<CasinoCardSnapshot> FreezeCards(
+#if IL2CPPMELON
+            Il2CppSystem.Collections.Generic.List<S1Casino.PlayingCard>? cards)
+#else
+            List<S1Casino.PlayingCard>? cards)
+#endif
+        {
+            if (cards == null || cards.Count == 0)
+                return EmptyCards;
+
+            var snapshots = new List<CasinoCardSnapshot>(cards.Count);
+            for (int i = 0; i < cards.Count; i++)
+            {
+                S1Casino.PlayingCard? card = cards[i];
+                if (card != null)
+                    snapshots.Add(ToSnapshot(card));
+            }
+
+            return snapshots.Count == 0
+                ? EmptyCards
+                : new ReadOnlyCollection<CasinoCardSnapshot>(snapshots);
+        }
+
+        internal static CasinoCardSnapshot ToSnapshot(S1Casino.PlayingCard card) =>
+            new CasinoCardSnapshot(
+                card.CardID ?? string.Empty,
+                (CasinoCardSuit)(int)card.Suit,
+                (CasinoCardValue)(int)card.Value,
+                card.IsFaceUp);
+
+        private static void InvokeSafely(Action? handlers, string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action handler in handlers.GetInvocationList())
+            {
+                try { handler(); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        private static void InvokeSafely(
+            Action<BlackjackStage, BlackjackStage>? handlers,
+            BlackjackStage previous,
+            BlackjackStage current,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<BlackjackStage, BlackjackStage> handler in handlers.GetInvocationList())
+            {
+                try { handler(previous, current); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read-only managed view of the native Ride the Bus table.
+    /// </summary>
+    public sealed class RideTheBusGame : CasinoGameTable
+    {
+        private static readonly IReadOnlyList<CasinoCardSnapshot> EmptyCards =
+            new ReadOnlyCollection<CasinoCardSnapshot>(Array.Empty<CasinoCardSnapshot>());
+
+        internal RideTheBusGame(S1Casino.RTBGameController controller)
+            : base(controller)
+        {
+            Native = controller;
+        }
+
+        internal S1Casino.RTBGameController Native { get; }
+
+        /// <summary>Raised after the native Ride the Bus stage changes.</summary>
+        public event Action<RideTheBusStage, RideTheBusStage>? StageChanged;
+
+        /// <summary>Raised when a new Ride the Bus round begins.</summary>
+        public event Action? RoundStarted;
+
+        /// <summary>Raised when the table returns to its waiting stage.</summary>
+        public event Action? RoundEnded;
+
+        /// <summary>Gets the current round stage.</summary>
+        public RideTheBusStage Stage => (RideTheBusStage)(int)Native.CurrentStage;
+
+        /// <summary>Gets whether a question is currently accepting answers.</summary>
+        public bool IsQuestionActive => Native.IsQuestionActive;
+
+        /// <summary>Gets the local player's current bet multiplier.</summary>
+        public float LocalBetMultiplier => Native.LocalPlayerBetMultiplier;
+
+        /// <summary>Gets the local player's multiplied bet.</summary>
+        public float MultipliedLocalBet => Native.MultipliedLocalPlayerBet;
+
+        /// <summary>Gets the answer time remaining on the current peer.</summary>
+        public float RemainingAnswerTime => Native.RemainingAnswerTime;
+
+        /// <summary>Gets whether the local player belongs to the active round.</summary>
+        public bool IsLocalPlayerInRound => Native.IsLocalPlayerInCurrentRound;
+
+        /// <summary>Gets the number of seated players currently marked ready.</summary>
+        public int ReadyPlayerCount => Native.GetPlayersReadyCount();
+
+        /// <summary>Gets the number of active-round players who submitted an answer.</summary>
+        public int AnsweredPlayerCount => Native.GetAnsweredPlayersCount();
+
+        /// <summary>Gets immutable snapshots of cards currently assigned by the table.</summary>
+        public IReadOnlyList<CasinoCardSnapshot> Cards
+        {
+            get
+            {
+                if (Native.Cards == null || Native.Cards.Length == 0)
+                    return EmptyCards;
+
+                var cards = new List<CasinoCardSnapshot>();
+                for (int i = 0; i < Native.Cards.Length; i++)
+                {
+                    S1Casino.PlayingCard? card = Native.Cards[i];
+                    if (card != null && (int)card.Value != (int)CasinoCardValue.Blank)
+                        cards.Add(BlackjackGame.ToSnapshot(card));
+                }
+
+                return cards.Count == 0
+                    ? EmptyCards
+                    : new ReadOnlyCollection<CasinoCardSnapshot>(cards);
+            }
+        }
+
+        internal void NotifyStageChanged(RideTheBusStage previous, RideTheBusStage current)
+        {
+            InvokeSafely(StageChanged, previous, current, nameof(StageChanged));
+            if (current == RideTheBusStage.RedOrBlack && previous == RideTheBusStage.WaitingForPlayers)
+                InvokeSafely(RoundStarted, nameof(RoundStarted));
+            if (current == RideTheBusStage.WaitingForPlayers && previous != current)
+                InvokeSafely(RoundEnded, nameof(RoundEnded));
+        }
+
+        private static void InvokeSafely(Action? handlers, string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action handler in handlers.GetInvocationList())
+            {
+                try { handler(); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        private static void InvokeSafely(
+            Action<RideTheBusStage, RideTheBusStage>? handlers,
+            RideTheBusStage previous,
+            RideTheBusStage current,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<RideTheBusStage, RideTheBusStage> handler in handlers.GetInvocationList())
+            {
+                try { handler(previous, current); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Read-only managed view of a native slot machine.
+    /// </summary>
+    public sealed class SlotMachine
+    {
+        internal SlotMachine(S1Casino.SlotMachine machine)
+        {
+            Native = machine ?? throw new ArgumentNullException(nameof(machine));
+        }
+
+        internal S1Casino.SlotMachine Native { get; }
+
+        /// <summary>Raised when a synchronized spin begins.</summary>
+        public event Action<SlotSpinSnapshot>? SpinStarted;
+
+        /// <summary>Raised when a synchronized spin displays its outcome.</summary>
+        public event Action<SlotSpinSnapshot>? SpinCompleted;
+
+        /// <summary>Gets the scene object name.</summary>
+        public string Name => Native.gameObject?.name ?? string.Empty;
+
+        /// <summary>Gets the current world position.</summary>
+        public Vector3 Position => Native.transform.position;
+
+        /// <summary>Gets whether the reels are currently spinning.</summary>
+        public bool IsSpinning => Native.IsSpinning;
+
+        /// <summary>Gets the machine's currently selected bet.</summary>
+        public int CurrentBet
+        {
+            get
+            {
+                object? value = ReflectionUtils.TryGetFieldOrProperty(Native, "currentBetAmount");
+                return value is int bet ? bet : 0;
+            }
+        }
+
+        /// <summary>Gets the immutable native bet choices.</summary>
+        public IReadOnlyList<int> AvailableBets
+        {
+            get
+            {
+                var nativeAmounts = S1Casino.SlotMachine.BetAmounts;
+                var amounts = new int[nativeAmounts.Length];
+                for (int i = 0; i < nativeAmounts.Length; i++)
+                    amounts[i] = nativeAmounts[i];
+                return new ReadOnlyCollection<int>(amounts);
+            }
+        }
+
+        internal void NotifySpinStarted(SlotSpinSnapshot snapshot) =>
+            InvokeSafely(SpinStarted, snapshot, nameof(SpinStarted));
+
+        internal void NotifySpinCompleted(SlotSpinSnapshot snapshot) =>
+            InvokeSafely(SpinCompleted, snapshot, nameof(SpinCompleted));
+
+        private static void InvokeSafely(
+            Action<SlotSpinSnapshot>? handlers,
+            SlotSpinSnapshot snapshot,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<SlotSpinSnapshot> handler in handlers.GetInvocationList())
+            {
+                try { handler(snapshot); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+    }
+}

--- a/S1API/Casino/CasinoSnapshots.cs
+++ b/S1API/Casino/CasinoSnapshots.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using S1API.Entities;
+
+namespace S1API.Casino
+{
+    /// <summary>
+    /// Represents the native minimum and maximum bet accepted by a casino table.
+    /// </summary>
+    public readonly struct CasinoBetLimits
+    {
+        /// <summary>
+        /// Creates an immutable bet-limit snapshot.
+        /// </summary>
+        public CasinoBetLimits(float minimum, float maximum)
+        {
+            Minimum = minimum;
+            Maximum = maximum;
+        }
+
+        /// <summary>Gets the minimum accepted bet.</summary>
+        public float Minimum { get; }
+
+        /// <summary>Gets the maximum accepted bet.</summary>
+        public float Maximum { get; }
+    }
+
+    /// <summary>
+    /// Card suits used by the native casino games.
+    /// </summary>
+    public enum CasinoCardSuit
+    {
+        /// <summary>Spades.</summary>
+        Spades = 0,
+        /// <summary>Hearts.</summary>
+        Hearts = 1,
+        /// <summary>Diamonds.</summary>
+        Diamonds = 2,
+        /// <summary>Clubs.</summary>
+        Clubs = 3
+    }
+
+    /// <summary>
+    /// Card values used by the native casino games.
+    /// </summary>
+    public enum CasinoCardValue
+    {
+        /// <summary>No card value is assigned.</summary>
+        Blank = 0,
+        /// <summary>Ace.</summary>
+        Ace = 1,
+        /// <summary>Two.</summary>
+        Two = 2,
+        /// <summary>Three.</summary>
+        Three = 3,
+        /// <summary>Four.</summary>
+        Four = 4,
+        /// <summary>Five.</summary>
+        Five = 5,
+        /// <summary>Six.</summary>
+        Six = 6,
+        /// <summary>Seven.</summary>
+        Seven = 7,
+        /// <summary>Eight.</summary>
+        Eight = 8,
+        /// <summary>Nine.</summary>
+        Nine = 9,
+        /// <summary>Ten.</summary>
+        Ten = 10,
+        /// <summary>Jack.</summary>
+        Jack = 11,
+        /// <summary>Queen.</summary>
+        Queen = 12,
+        /// <summary>King.</summary>
+        King = 13
+    }
+
+    /// <summary>
+    /// Immutable public representation of a casino playing card.
+    /// </summary>
+    public readonly struct CasinoCardSnapshot
+    {
+        /// <summary>
+        /// Creates an immutable card snapshot.
+        /// </summary>
+        public CasinoCardSnapshot(string id, CasinoCardSuit suit, CasinoCardValue value, bool isFaceUp)
+        {
+            Id = id ?? string.Empty;
+            Suit = suit;
+            Value = value;
+            IsFaceUp = isFaceUp;
+        }
+
+        /// <summary>Gets the scene-local native card identifier.</summary>
+        public string Id { get; }
+
+        /// <summary>Gets the card suit.</summary>
+        public CasinoCardSuit Suit { get; }
+
+        /// <summary>Gets the card value.</summary>
+        public CasinoCardValue Value { get; }
+
+        /// <summary>Gets whether the card is face up for the current client.</summary>
+        public bool IsFaceUp { get; }
+    }
+
+    /// <summary>
+    /// Immutable player state captured from a casino table.
+    /// </summary>
+    public sealed class CasinoPlayerSnapshot
+    {
+        internal CasinoPlayerSnapshot(Player? player, string name, int seatIndex, int score, bool isReady)
+        {
+            Player = player;
+            Name = name;
+            SeatIndex = seatIndex;
+            Score = score;
+            IsReady = isReady;
+        }
+
+        /// <summary>
+        /// Gets the S1API player wrapper when that player has completed S1API initialization.
+        /// </summary>
+        public Player? Player { get; }
+
+        /// <summary>Gets the current native player name.</summary>
+        public string Name { get; }
+
+        /// <summary>Gets the zero-based table seat index.</summary>
+        public int SeatIndex { get; }
+
+        /// <summary>Gets the synchronized score stored by the table.</summary>
+        public int Score { get; }
+
+        /// <summary>Gets whether the player has marked themselves ready.</summary>
+        public bool IsReady { get; }
+    }
+
+    /// <summary>
+    /// Stages in a native blackjack round.
+    /// </summary>
+    public enum BlackjackStage
+    {
+        /// <summary>The table is accepting players.</summary>
+        WaitingForPlayers = 0,
+        /// <summary>Initial cards are being dealt.</summary>
+        Dealing = 1,
+        /// <summary>A player is taking their turn.</summary>
+        PlayerTurn = 2,
+        /// <summary>The dealer is taking their turn.</summary>
+        DealerTurn = 3,
+        /// <summary>The round is resolving payouts.</summary>
+        Ending = 4
+    }
+
+    /// <summary>
+    /// Native blackjack payout classifications.
+    /// </summary>
+    public enum BlackjackPayout
+    {
+        /// <summary>No payout.</summary>
+        None = 0,
+        /// <summary>Natural blackjack.</summary>
+        Blackjack = 1,
+        /// <summary>Standard win.</summary>
+        Win = 2,
+        /// <summary>Push; the original bet is returned.</summary>
+        Push = 3
+    }
+
+    /// <summary>
+    /// Stages in a native Ride the Bus round.
+    /// </summary>
+    public enum RideTheBusStage
+    {
+        /// <summary>The table is accepting players.</summary>
+        WaitingForPlayers = 0,
+        /// <summary>The player predicts red or black.</summary>
+        RedOrBlack = 1,
+        /// <summary>The player predicts higher or lower.</summary>
+        HigherOrLower = 2,
+        /// <summary>The player predicts inside or outside.</summary>
+        InsideOrOutside = 3,
+        /// <summary>The player predicts the suit.</summary>
+        Suit = 4
+    }
+
+    /// <summary>
+    /// Symbols displayed by a native slot machine.
+    /// </summary>
+    public enum SlotSymbol
+    {
+        /// <summary>Cherry.</summary>
+        Cherry = 0,
+        /// <summary>Lemon.</summary>
+        Lemon = 1,
+        /// <summary>Grape.</summary>
+        Grape = 2,
+        /// <summary>Watermelon.</summary>
+        Watermelon = 3,
+        /// <summary>Bell.</summary>
+        Bell = 4,
+        /// <summary>Seven.</summary>
+        Seven = 5
+    }
+
+    /// <summary>
+    /// Native slot-machine outcome classifications.
+    /// </summary>
+    public enum SlotOutcome
+    {
+        /// <summary>Three sevens.</summary>
+        Jackpot = 0,
+        /// <summary>Three bells.</summary>
+        BigWin = 1,
+        /// <summary>Three matching fruit symbols.</summary>
+        SmallWin = 2,
+        /// <summary>Three fruit symbols.</summary>
+        MiniWin = 3,
+        /// <summary>No winning combination.</summary>
+        NoWin = 4
+    }
+
+    /// <summary>
+    /// Immutable state for a slot spin as observed by the current peer.
+    /// </summary>
+    public sealed class SlotSpinSnapshot
+    {
+        internal SlotSpinSnapshot(
+            int bet,
+            IReadOnlyList<SlotSymbol> symbols,
+            bool wasStartedByLocalPlayer,
+            SlotOutcome? outcome,
+            int? winAmount)
+        {
+            Bet = bet;
+            Symbols = symbols;
+            WasStartedByLocalPlayer = wasStartedByLocalPlayer;
+            Outcome = outcome;
+            WinAmount = winAmount;
+        }
+
+        /// <summary>Gets the bet used for this spin.</summary>
+        public int Bet { get; }
+
+        /// <summary>Gets the immutable ordered reel symbols.</summary>
+        public IReadOnlyList<SlotSymbol> Symbols { get; }
+
+        /// <summary>Gets whether the native spinner connection belongs to this client.</summary>
+        public bool WasStartedByLocalPlayer { get; }
+
+        /// <summary>Gets the outcome after completion, or <c>null</c> while spinning.</summary>
+        public SlotOutcome? Outcome { get; }
+
+        /// <summary>Gets the win amount after completion, or <c>null</c> while spinning.</summary>
+        public int? WinAmount { get; }
+
+        internal SlotSpinSnapshot Complete(SlotOutcome outcome, int winAmount) =>
+            new SlotSpinSnapshot(Bet, Symbols, WasStartedByLocalPlayer, outcome, winAmount);
+
+        internal static IReadOnlyList<SlotSymbol> Freeze(IList<SlotSymbol> symbols)
+        {
+            if (symbols.Count == 0)
+                return new ReadOnlyCollection<SlotSymbol>(Array.Empty<SlotSymbol>());
+
+            var copy = new SlotSymbol[symbols.Count];
+            symbols.CopyTo(copy, 0);
+            return new ReadOnlyCollection<SlotSymbol>(copy);
+        }
+    }
+}

--- a/S1API/Casino/CasinoSnapshots.cs
+++ b/S1API/Casino/CasinoSnapshots.cs
@@ -13,6 +13,8 @@ namespace S1API.Casino
         /// <summary>
         /// Creates an immutable bet-limit snapshot.
         /// </summary>
+        /// <param name="minimum">The minimum bet accepted by the table.</param>
+        /// <param name="maximum">The maximum bet accepted by the table.</param>
         public CasinoBetLimits(float minimum, float maximum)
         {
             Minimum = minimum;
@@ -84,6 +86,10 @@ namespace S1API.Casino
         /// <summary>
         /// Creates an immutable card snapshot.
         /// </summary>
+        /// <param name="id">The scene-local native card identifier.</param>
+        /// <param name="suit">The card suit.</param>
+        /// <param name="value">The card value.</param>
+        /// <param name="isFaceUp">Whether the card is face up for the current client.</param>
         public CasinoCardSnapshot(string id, CasinoCardSuit suit, CasinoCardValue value, bool isFaceUp)
         {
             Id = id ?? string.Empty;

--- a/S1API/Casino/SlotMachineHelper.cs
+++ b/S1API/Casino/SlotMachineHelper.cs
@@ -13,6 +13,7 @@ using S1Items = ScheduleOne.ItemFramework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using S1API.Entities;
 using S1API.Lifecycle;
 using S1API.Logging;
@@ -282,7 +283,7 @@ namespace S1API.Casino
                 if (_isSceneChangeInProgress)
                     return false;
 
-                var machine = FindNearestSlotMachine(machinePosition, maxSearchDistance);
+                var machine = FindNearestNativeSlotMachine(machinePosition, maxSearchDistance);
                 if (machine == null)
                 {
                     Logger.Warning($"No slot machine found near position {machinePosition}");
@@ -325,6 +326,18 @@ namespace S1API.Casino
                     SpinSlotMachineForNPC(npc, machine, symbols, betAmount, activeSpin));
 #endif
 
+                var managedSymbols = new List<SlotSymbol>(symbols.Length);
+                for (int i = 0; i < symbols.Length; i++)
+                    managedSymbols.Add((SlotSymbol)(int)symbols[i]);
+
+                CasinoGameRegistry.NotifySlotSpinStarted(
+                    machine,
+                    new SlotSpinSnapshot(
+                        betAmount,
+                        SlotSpinSnapshot.Freeze(managedSymbols),
+                        wasStartedByLocalPlayer: false,
+                        outcome: null,
+                        winAmount: null));
                 RegisterActiveSpin(activeSpin);
 
                 return true;
@@ -337,12 +350,21 @@ namespace S1API.Casino
         }
 
         /// <summary>
-        /// Finds the nearest slot machine to a given position.
+        /// Finds the nearest native slot machine to a given position.
         /// </summary>
         /// <param name="position">The position to search from.</param>
         /// <param name="maxDistance">Maximum distance to search.</param>
-        /// <returns>The nearest slot machine, or null if none found.</returns>
+        /// <returns>The nearest native slot machine, or null if none found.</returns>
+        /// <remarks>
+        /// This compatibility method exposes a game type. New code should use
+        /// <see cref="CasinoGameRegistry.FindNearestSlotMachine(Vector3, float)"/>.
+        /// </remarks>
+        [Obsolete("Use CasinoGameRegistry.FindNearestSlotMachine to receive an S1API managed wrapper.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static S1Casino.SlotMachine? FindNearestSlotMachine(Vector3 position, float maxDistance)
+            => FindNearestNativeSlotMachine(position, maxDistance);
+
+        internal static S1Casino.SlotMachine? FindNearestNativeSlotMachine(Vector3 position, float maxDistance)
         {
             try
             {

--- a/S1API/Entities/Schedule/ActionSpecs/UseSlotMachineSpec.cs
+++ b/S1API/Entities/Schedule/ActionSpecs/UseSlotMachineSpec.cs
@@ -222,13 +222,13 @@ namespace S1API.Entities.Schedule
             {
                 Logger.Warning($"[{npc.ID}] Initial position not reachable, searching for nearest slot machine");
                 // Try to find the nearest reachable slot machine
-                var machine = SlotMachineHelper.FindNearestSlotMachine(targetPosition, MaxSearchDistance * 2f);
+                var machine = CasinoGameRegistry.FindNearestSlotMachine(targetPosition, MaxSearchDistance * 2f);
                 if (machine != null)
                 {
                     // Check if this machine is reachable
-                    if (npc.Movement.CanGetTo(machine.transform.position))
+                    if (npc.Movement.CanGetTo(machine.Position))
                     {
-                        targetPosition = machine.transform.position;
+                        targetPosition = machine.Position;
                     }
                     else
                     {
@@ -315,10 +315,10 @@ namespace S1API.Entities.Schedule
             {
                 Logger.Warning($"[{npc.ID}] NPC can't pathfind to target, searching for alternative");
                 // NPC can't reach the destination - try to find the nearest slot machine instead
-                var machine = SlotMachineHelper.FindNearestSlotMachine(targetPosition, maxDistance * 2f);
+                var machine = CasinoGameRegistry.FindNearestSlotMachine(targetPosition, maxDistance * 2f);
                 if (machine != null)
                 {
-                    targetPosition = machine.transform.position;
+                    targetPosition = machine.Position;
                 }
                 else
                 {

--- a/S1API/Internal/CasinoEventInvoker.cs
+++ b/S1API/Internal/CasinoEventInvoker.cs
@@ -1,0 +1,65 @@
+using System;
+using S1API.Casino;
+
+namespace S1API.Internal
+{
+    internal static class CasinoEventInvoker
+    {
+        internal static void Invoke(Action? handlers, string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action handler in handlers.GetInvocationList())
+            {
+                try { handler(); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        internal static void Invoke<T>(Action<T>? handlers, T value, string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T> handler in handlers.GetInvocationList())
+            {
+                try { handler(value); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        internal static void Invoke<T1, T2>(
+            Action<T1, T2>? handlers,
+            T1 value1,
+            T2 value2,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T1, T2> handler in handlers.GetInvocationList())
+            {
+                try { handler(value1, value2); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+
+        internal static void Invoke<T1, T2, T3>(
+            Action<T1, T2, T3>? handlers,
+            T1 value1,
+            T2 value2,
+            T3 value3,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T1, T2, T3> handler in handlers.GetInvocationList())
+            {
+                try { handler(value1, value2, value3); }
+                catch (Exception ex) { CasinoGameRegistry.LogSubscriberFailure(eventName, ex); }
+            }
+        }
+    }
+}

--- a/S1API/Internal/Patches/CasinoGamePatches.cs
+++ b/S1API/Internal/Patches/CasinoGamePatches.cs
@@ -7,7 +7,10 @@ using S1Casino = ScheduleOne.Casino;
 using S1NetworkConnection = FishNet.Connection.NetworkConnection;
 #endif
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using HarmonyLib;
 using S1API.Casino;
 
@@ -63,41 +66,68 @@ namespace S1API.Internal.Patches
                 (RideTheBusStage)(int)__0);
         }
 
-        [HarmonyPatch(typeof(S1Casino.SlotMachine), "RpcLogic___StartSpin_2659526290")]
-        [HarmonyPrefix]
-        private static void SlotSpinPrefix(
-            S1Casino.SlotMachine __instance,
-            S1NetworkConnection __0,
-#if IL2CPPMELON
-            Il2CppStructArray<S1Casino.SlotMachine.ESymbol> __1,
-#else
-            S1Casino.SlotMachine.ESymbol[] __1,
-#endif
-            int __2,
-            out SlotStartPatchState __state)
+        internal static MethodBase? FindSlotStartLogicMethod(Type slotMachineType)
         {
-            var symbols = new List<SlotSymbol>(__1.Length);
-            for (int i = 0; i < __1.Length; i++)
-                symbols.Add((SlotSymbol)(int)__1[i]);
+            return slotMachineType
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .FirstOrDefault(method =>
+                {
+                    if (!method.Name.StartsWith("RpcLogic___StartSpin_", StringComparison.Ordinal))
+                        return false;
 
-            __state = new SlotStartPatchState(
-                __instance.IsSpinning,
-                new SlotSpinSnapshot(
-                    __2,
-                    SlotSpinSnapshot.Freeze(symbols),
-                    __0 != null && __0.IsLocalClient,
-                    outcome: null,
-                    winAmount: null));
+                    ParameterInfo[] parameters = method.GetParameters();
+                    return method.ReturnType == typeof(void)
+                        && parameters.Length == 3
+                        && parameters[0].ParameterType == typeof(S1NetworkConnection)
+#if IL2CPPMELON
+                        && parameters[1].ParameterType == typeof(Il2CppStructArray<S1Casino.SlotMachine.ESymbol>)
+#else
+                        && parameters[1].ParameterType == typeof(S1Casino.SlotMachine.ESymbol[])
+#endif
+                        && parameters[2].ParameterType == typeof(int);
+                });
         }
 
-        [HarmonyPatch(typeof(S1Casino.SlotMachine), "RpcLogic___StartSpin_2659526290")]
-        [HarmonyPostfix]
-        private static void SlotSpinPostfix(
-            S1Casino.SlotMachine __instance,
-            SlotStartPatchState __state)
+        [HarmonyPatch]
+        private static class SlotSpinPatch
         {
-            if (!__state.WasSpinning && __instance.IsSpinning)
-                CasinoGameRegistry.NotifySlotSpinStarted(__instance, __state.Snapshot);
+            private static MethodBase? TargetMethod() =>
+                FindSlotStartLogicMethod(typeof(S1Casino.SlotMachine));
+
+            [HarmonyPrefix]
+            private static void Prefix(
+                S1Casino.SlotMachine __instance,
+                S1NetworkConnection __0,
+#if IL2CPPMELON
+                Il2CppStructArray<S1Casino.SlotMachine.ESymbol> __1,
+#else
+                S1Casino.SlotMachine.ESymbol[] __1,
+#endif
+                int __2,
+                out SlotStartPatchState __state)
+            {
+                var symbols = new List<SlotSymbol>(__1.Length);
+                for (int i = 0; i < __1.Length; i++)
+                    symbols.Add((SlotSymbol)(int)__1[i]);
+
+                __state = new SlotStartPatchState(
+                    __instance.IsSpinning,
+                    new SlotSpinSnapshot(
+                        __2,
+                        SlotSpinSnapshot.Freeze(symbols),
+                        __0 != null && __0.IsLocalClient,
+                        outcome: null,
+                        winAmount: null));
+            }
+
+            [HarmonyPostfix]
+            private static void Postfix(
+                S1Casino.SlotMachine __instance,
+                SlotStartPatchState __state)
+            {
+                if (!__state.WasSpinning && __instance.IsSpinning)
+                    CasinoGameRegistry.NotifySlotSpinStarted(__instance, __state.Snapshot);
+            }
         }
 
         [HarmonyPatch(typeof(S1Casino.SlotMachine), "DisplayOutcome")]

--- a/S1API/Internal/Patches/CasinoGamePatches.cs
+++ b/S1API/Internal/Patches/CasinoGamePatches.cs
@@ -1,0 +1,128 @@
+#if IL2CPPMELON
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using S1Casino = Il2CppScheduleOne.Casino;
+using S1NetworkConnection = Il2CppFishNet.Connection.NetworkConnection;
+#elif MONOMELON
+using S1Casino = ScheduleOne.Casino;
+using S1NetworkConnection = FishNet.Connection.NetworkConnection;
+#endif
+
+using System.Collections.Generic;
+using HarmonyLib;
+using S1API.Casino;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// Bridges native casino state transitions to the read-only managed casino API.
+    /// </summary>
+    [HarmonyPatch]
+    internal static class CasinoGamePatches
+    {
+        [HarmonyPatch(typeof(S1Casino.BlackjackGameController), "set_CurrentStage")]
+        [HarmonyPrefix]
+        private static void BlackjackStagePrefix(
+            S1Casino.BlackjackGameController __instance,
+            out BlackjackStage __state)
+        {
+            __state = (BlackjackStage)(int)__instance.CurrentStage;
+        }
+
+        [HarmonyPatch(typeof(S1Casino.BlackjackGameController), "set_CurrentStage")]
+        [HarmonyPostfix]
+        private static void BlackjackStagePostfix(
+            S1Casino.BlackjackGameController __instance,
+            S1Casino.BlackjackGameController.EStage __0,
+            BlackjackStage __state)
+        {
+            CasinoGameRegistry.NotifyBlackjackStageChanged(
+                __instance,
+                __state,
+                (BlackjackStage)(int)__0);
+        }
+
+        [HarmonyPatch(typeof(S1Casino.RTBGameController), "set_CurrentStage")]
+        [HarmonyPrefix]
+        private static void RideTheBusStagePrefix(
+            S1Casino.RTBGameController __instance,
+            out RideTheBusStage __state)
+        {
+            __state = (RideTheBusStage)(int)__instance.CurrentStage;
+        }
+
+        [HarmonyPatch(typeof(S1Casino.RTBGameController), "set_CurrentStage")]
+        [HarmonyPostfix]
+        private static void RideTheBusStagePostfix(
+            S1Casino.RTBGameController __instance,
+            S1Casino.RTBGameController.EStage __0,
+            RideTheBusStage __state)
+        {
+            CasinoGameRegistry.NotifyRideTheBusStageChanged(
+                __instance,
+                __state,
+                (RideTheBusStage)(int)__0);
+        }
+
+        [HarmonyPatch(typeof(S1Casino.SlotMachine), "RpcLogic___StartSpin_2659526290")]
+        [HarmonyPrefix]
+        private static void SlotSpinPrefix(
+            S1Casino.SlotMachine __instance,
+            S1NetworkConnection __0,
+#if IL2CPPMELON
+            Il2CppStructArray<S1Casino.SlotMachine.ESymbol> __1,
+#else
+            S1Casino.SlotMachine.ESymbol[] __1,
+#endif
+            int __2,
+            out SlotStartPatchState __state)
+        {
+            var symbols = new List<SlotSymbol>(__1.Length);
+            for (int i = 0; i < __1.Length; i++)
+                symbols.Add((SlotSymbol)(int)__1[i]);
+
+            __state = new SlotStartPatchState(
+                __instance.IsSpinning,
+                new SlotSpinSnapshot(
+                    __2,
+                    SlotSpinSnapshot.Freeze(symbols),
+                    __0 != null && __0.IsLocalClient,
+                    outcome: null,
+                    winAmount: null));
+        }
+
+        [HarmonyPatch(typeof(S1Casino.SlotMachine), "RpcLogic___StartSpin_2659526290")]
+        [HarmonyPostfix]
+        private static void SlotSpinPostfix(
+            S1Casino.SlotMachine __instance,
+            SlotStartPatchState __state)
+        {
+            if (!__state.WasSpinning && __instance.IsSpinning)
+                CasinoGameRegistry.NotifySlotSpinStarted(__instance, __state.Snapshot);
+        }
+
+        [HarmonyPatch(typeof(S1Casino.SlotMachine), "DisplayOutcome")]
+        [HarmonyPostfix]
+        private static void SlotOutcomePostfix(
+            S1Casino.SlotMachine __instance,
+            S1Casino.SlotMachine.EOutcome __0,
+            int __1)
+        {
+            CasinoGameRegistry.NotifySlotSpinCompleted(
+                __instance,
+                (SlotOutcome)(int)__0,
+                __1);
+        }
+
+        private readonly struct SlotStartPatchState
+        {
+            internal SlotStartPatchState(bool wasSpinning, SlotSpinSnapshot snapshot)
+            {
+                WasSpinning = wasSpinning;
+                Snapshot = snapshot;
+            }
+
+            internal bool WasSpinning { get; }
+            internal SlotSpinSnapshot Snapshot { get; }
+        }
+    }
+}

--- a/S1API/docs/casino-games.md
+++ b/S1API/docs/casino-games.md
@@ -30,7 +30,7 @@ if (nearest != null)
     MelonLogger.Msg($"Nearest slot machine: {nearest.Name} at {nearest.Position}");
 ```
 
-Registry results are immutable snapshots. Calling a discovery method again reflects the objects in the current scene, while wrappers for the same live scene object retain their identity so instance event subscriptions remain attached.
+Registry results are read-only snapshots of the active casino objects at the time of discovery. Their wrapper instances represent live scene objects, so wrapper properties continue to reflect current controller state. Calling a discovery method again reflects the active objects in the current scene, while wrappers for the same live scene object retain their identity within that scene.
 
 ## Shared table state
 
@@ -114,3 +114,5 @@ The same events are available on an individual `SlotMachine` wrapper. S1API's ex
 ## Event lifetime
 
 Static registry subscriptions belong to your mod and remain subscribed across scene changes. Unsubscribe them when your mod no longer needs them. S1API clears scene-object wrapper and active-spin state before scene transitions, so discovery never returns cached objects from a previous gameplay scene.
+
+Subscriptions attached directly to a `BlackjackGame`, `RideTheBusGame`, or `SlotMachine` wrapper last only for that wrapper's scene. Query and subscribe to new wrappers after each gameplay scene load, or use the static `CasinoGameRegistry` events when the subscription should remain active across scene changes.

--- a/S1API/docs/casino-games.md
+++ b/S1API/docs/casino-games.md
@@ -1,0 +1,116 @@
+# Casino game state
+
+S1API exposes read-only managed wrappers for the casino's blackjack table, Ride the Bus table, and slot machines. The wrappers provide discovery, synchronized state snapshots, and round or spin lifecycle events without exposing native casino controllers or RPC methods.
+
+This API observes the game. It does not create custom casino games, replace payouts, submit bets or answers, change readiness, or invoke client/server RPCs.
+
+## Discover games
+
+Casino objects belong to the gameplay scene. Query the registry after the game has loaded, such as from `GameLifecycle.OnLoadComplete`:
+
+```csharp
+using S1API.Casino;
+using S1API.Lifecycle;
+
+GameLifecycle.OnLoadComplete += () =>
+{
+    IReadOnlyList<BlackjackGame> blackjack = CasinoGameRegistry.GetBlackjackGames();
+    IReadOnlyList<RideTheBusGame> rideTheBus = CasinoGameRegistry.GetRideTheBusGames();
+    IReadOnlyList<SlotMachine> slots = CasinoGameRegistry.GetSlotMachines();
+};
+```
+
+`GetTables()` returns blackjack and Ride the Bus through their shared `CasinoGameTable` base. Slot machines are separate because they do not have seated-player or table-bet state.
+
+Use `CasinoGameRegistry.FindNearestSlotMachine(position, maxDistance)` when you need the nearest slot machine without exposing the game's native casino type:
+
+```csharp
+SlotMachine? nearest = CasinoGameRegistry.FindNearestSlotMachine(transform.position, 10f);
+if (nearest != null)
+    MelonLogger.Msg($"Nearest slot machine: {nearest.Name} at {nearest.Position}");
+```
+
+Registry results are immutable snapshots. Calling a discovery method again reflects the objects in the current scene, while wrappers for the same live scene object retain their identity so instance event subscriptions remain attached.
+
+## Shared table state
+
+Every `CasinoGameTable` exposes:
+
+- `Name` and `Position`
+- `IsOpen`, which reports whether this table's interface is open for the local player
+- `IsWaitingForPlayers`
+- `LocalBet`
+- `BetLimits`
+- `Players`, an immutable snapshot containing managed `Player` wrappers when available, seat indices, synchronized scores, and ready state
+
+Local-player properties describe the current client. Stage, player, card, score, and spin data reflect the native state received by that peer.
+
+## Blackjack
+
+```csharp
+BlackjackGame table = CasinoGameRegistry.GetBlackjackGames()[0];
+
+BlackjackStage stage = table.Stage;
+CasinoBetLimits limits = table.BetLimits;
+IReadOnlyList<CasinoCardSnapshot> dealerHand = table.DealerHand;
+
+foreach (CasinoPlayerSnapshot player in table.Players)
+{
+    IReadOnlyList<CasinoCardSnapshot> hand = table.GetPlayerHand(player.SeatIndex);
+    MelonLogger.Msg($"{player.Name}: table score {player.Score}, cards {hand.Count}");
+}
+```
+
+Blackjack also exposes the dealer score, local score, local blackjack/bust flags, ready-player count, and whether the local player belongs to the active round.
+
+Subscribe globally when you want to observe every table:
+
+```csharp
+CasinoGameRegistry.BlackjackStageChanged += (table, previous, current) =>
+    MelonLogger.Msg($"{table.Name}: {previous} -> {current}");
+
+CasinoGameRegistry.BlackjackRoundStarted += table =>
+    MelonLogger.Msg($"Round started at {table.Name}");
+
+CasinoGameRegistry.BlackjackRoundEnded += table =>
+    MelonLogger.Msg($"Round ended at {table.Name}");
+```
+
+The same events are available on an individual `BlackjackGame` wrapper.
+
+## Ride the Bus
+
+`RideTheBusGame` exposes its stage, question-active flag, remaining answer time, local bet multiplier, multiplied local bet, ready and answered player counts, active-round membership, and immutable card snapshots.
+
+```csharp
+RideTheBusGame table = CasinoGameRegistry.GetRideTheBusGames()[0];
+
+CasinoGameRegistry.RideTheBusStageChanged += (game, previous, current) =>
+    MelonLogger.Msg($"Ride the Bus: {previous} -> {current}");
+
+CasinoGameRegistry.RideTheBusRoundStarted += game =>
+    MelonLogger.Msg("Ride the Bus round started");
+
+CasinoGameRegistry.RideTheBusRoundEnded += game =>
+    MelonLogger.Msg("Ride the Bus round ended");
+```
+
+The same events are available on an individual `RideTheBusGame` wrapper.
+
+## Slot machines
+
+Slot wrappers expose their position, current bet, available native bets, and spinning state. Spin events include the bet, ordered reel symbols, whether the native spinner belongs to the current client, and the eventual outcome and win amount.
+
+```csharp
+CasinoGameRegistry.SlotSpinStarted += (machine, spin) =>
+    MelonLogger.Msg($"{machine.Name} started a ${spin.Bet} spin");
+
+CasinoGameRegistry.SlotSpinCompleted += (machine, spin) =>
+    MelonLogger.Msg($"{machine.Name}: {spin.Outcome}, won ${spin.WinAmount}");
+```
+
+The same events are available on an individual `SlotMachine` wrapper. S1API's existing NPC slot-machine helper also publishes through these lifecycle events.
+
+## Event lifetime
+
+Static registry subscriptions belong to your mod and remain subscribed across scene changes. Unsubscribe them when your mod no longer needs them. S1API clears scene-object wrapper and active-spin state before scene transitions, so discovery never returns cached objects from a previous gameplay scene.

--- a/S1API/docs/casino-slot-machines.md
+++ b/S1API/docs/casino-slot-machines.md
@@ -2,6 +2,10 @@
 
 The S1API provides a modder-facing API for making NPCs interact with slot machines in the casino. This system handles cash management, animations, and outcome determination automatically.
 
+For read-only player-facing blackjack, Ride the Bus, and slot-machine state and lifecycle events, see [Casino game state](casino-games.md).
+
+For discovery, including finding the nearest slot machine, use `CasinoGameRegistry`. The legacy `SlotMachineHelper.FindNearestSlotMachine` method remains available for compatibility but exposes a native game type and is obsolete for new mods.
+
 ## Overview
 
 The slot machine system allows NPCs to:

--- a/S1API/docs/toc.yml
+++ b/S1API/docs/toc.yml
@@ -120,7 +120,9 @@
       href: stations.md
     - name: UI
       href: ui.md
-    - name: Casino Slots
+    - name: Casino Games
+      href: casino-games.md
+    - name: NPC Casino Slots
       href: casino-slot-machines.md
     - name: Cartel
       href: cartel-system.md


### PR DESCRIPTION
Closes #239.

## Summary

- add read-only managed wrappers and discovery for blackjack, Ride the Bus, and slot machines
- expose table state, bet limits, local bet state, managed player/card/score snapshots, and round/spin lifecycle events
- bridge verified Mono and IL2CPP stage setters plus the synchronized slot observer/completion paths without exposing native RPCs
- add a managed nearest-slot query and retain `SlotMachineHelper.FindNearestSlotMachine` as an obsolete, hidden compatibility shim for existing mods
- document the API and its local-client versus synchronized-state semantics

## Scope

This first version is observational only. It does not add custom casino game authoring, payout replacement, bet/answer mutation, or direct client/server RPC access.

`CasinoGameRegistry.FindNearestSlotMachine(position, maxDistance)` returns the S1API wrapper. Existing compiled/source consumers of the native-returning helper keep working, while new code is directed to the managed boundary.

## Native research

The implementation was checked against current Mono game assemblies, current IL2CPP interop assemblies, and the serialized casino scene graph. The lifecycle hooks use the blackjack and Ride the Bus `CurrentStage` setters and the slot machine's observer-side spin logic plus outcome display method. No game assemblies, exported assets, saves, logs, or smoke-test probes are included in this branch.

## Validation

- MonoMelon: 635/635 tests passed
- Il2CppMelon: 624/624 tests passed
- focused casino API contracts: 8/8 on each backend
- DocFX: 0 errors; 4 existing optional assembly-reference warnings
- public API documentation coverage: 81.61% (3,221/3,947)
- bounded gameplay-scene smoke on Mono and IL2CPP: discovered 1 blackjack table, 1 Ride the Bus table, and 5 slots; observed 2 blackjack stage events, 2 Ride the Bus stage events, and one paired slot start/completion event

The scene smoke exercised each backend in one process, including the native slot reel coroutine. I did not run a live two-peer GSE/P2P session, so remote propagation is not claimed here; the peer-side observer method and signatures were verified in both runtime assemblies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read-only access to blackjack, Ride the Bus, and slot-machine state.
  - Added casino-game discovery, nearby slot-machine lookup, table access, and lifecycle events.
  - Added immutable snapshots for cards, players, bets, stages, symbols, and spin outcomes.
  - Added slot-spin notifications with bet, result, and winnings details.

- **Documentation**
  - Added casino-game API documentation covering discovery, events, snapshots, and limitations.
  - Updated navigation and slot-machine guidance.

- **Compatibility**
  - Retained the existing slot-machine lookup API for legacy integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->