### PR TITLE
feat(interaction): add native interaction prompt builder

### DIFF
--- a/S1API.Tests/Interaction/InteractionPromptApiCompatibilityTests.cs
+++ b/S1API.Tests/Interaction/InteractionPromptApiCompatibilityTests.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using S1API.Interaction;
+using UnityEngine;
+
+namespace S1API.Tests.Interaction;
+
+public sealed class InteractionPromptApiCompatibilityTests
+{
+    [Fact]
+    public void BuilderFactoriesPreserveSourceAndBinaryShape()
+    {
+        AssertStaticFactory(
+            typeof(InteractionPromptBuilder),
+            nameof(InteractionPromptBuilder.Create));
+        AssertStaticFactory(
+            typeof(InteractionPrompt),
+            nameof(InteractionPrompt.CreateBuilder));
+    }
+
+    [Fact]
+    public void BuilderExposesExpectedFluentShape()
+    {
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithMessage), typeof(string));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithInput), typeof(InteractionPromptInput));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithState), typeof(InteractionPromptState));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithRange), typeof(float));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithPriority), typeof(int));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithAngleLimit), typeof(float));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithoutAngleLimit));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithDisplayLocation), typeof(Transform));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.WithDisplayLocation), typeof(Collider));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.OnHovered), typeof(Action));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.OnInteractionStarted), typeof(Action));
+        AssertBuilderMethod(nameof(InteractionPromptBuilder.OnInteractionEnded), typeof(Action));
+
+        MethodInfo build = typeof(InteractionPromptBuilder).GetMethod(
+            nameof(InteractionPromptBuilder.Build),
+            Type.EmptyTypes)!;
+        Assert.Equal(typeof(InteractionPrompt), build.ReturnType);
+    }
+
+    [Fact]
+    public void HandleExposesExpectedRuntimeShape()
+    {
+        AssertHandleMethod(nameof(InteractionPrompt.SetMessage), typeof(string));
+        AssertHandleMethod(nameof(InteractionPrompt.SetInput), typeof(InteractionPromptInput));
+        AssertHandleMethod(nameof(InteractionPrompt.SetState), typeof(InteractionPromptState));
+        AssertHandleMethod(nameof(InteractionPrompt.SetRange), typeof(float));
+        AssertHandleMethod(nameof(InteractionPrompt.SetPriority), typeof(int));
+        AssertHandleMethod(nameof(InteractionPrompt.SetAngleLimit), typeof(float));
+        AssertHandleMethod(nameof(InteractionPrompt.WithoutAngleLimit));
+        AssertHandleMethod(nameof(InteractionPrompt.SetDisplayLocation), typeof(Transform));
+        AssertHandleMethod(nameof(InteractionPrompt.SetDisplayLocation), typeof(Collider));
+        AssertHandleMethod(nameof(InteractionPrompt.ClearDisplayLocation));
+
+        MethodInfo remove = typeof(InteractionPrompt).GetMethod(
+            nameof(InteractionPrompt.Remove),
+            Type.EmptyTypes)!;
+        Assert.Equal(typeof(bool), remove.ReturnType);
+        Assert.Contains(typeof(IDisposable), typeof(InteractionPrompt).GetInterfaces());
+
+        AssertProperty(nameof(InteractionPrompt.Target), typeof(GameObject));
+        AssertProperty(nameof(InteractionPrompt.Message), typeof(string));
+        AssertProperty(nameof(InteractionPrompt.Input), typeof(InteractionPromptInput));
+        AssertProperty(nameof(InteractionPrompt.State), typeof(InteractionPromptState));
+        AssertProperty(nameof(InteractionPrompt.Range), typeof(float));
+        AssertProperty(nameof(InteractionPrompt.Priority), typeof(int));
+        AssertProperty(nameof(InteractionPrompt.IsAngleLimited), typeof(bool));
+        AssertProperty(nameof(InteractionPrompt.AngleLimit), typeof(float));
+        AssertProperty(nameof(InteractionPrompt.IsRemoved), typeof(bool));
+
+        AssertEvent(nameof(InteractionPrompt.Hovered));
+        AssertEvent(nameof(InteractionPrompt.InteractionStarted));
+        AssertEvent(nameof(InteractionPrompt.InteractionEnded));
+    }
+
+    private static void AssertStaticFactory(Type declaringType, string methodName)
+    {
+        MethodInfo method = declaringType.GetMethod(methodName, new[] { typeof(GameObject) })!;
+        Assert.True(method.IsStatic);
+        Assert.Equal(typeof(InteractionPromptBuilder), method.ReturnType);
+        Assert.Equal("target", Assert.Single(method.GetParameters()).Name);
+    }
+
+    private static void AssertBuilderMethod(string methodName, params Type[] parameterTypes)
+    {
+        MethodInfo method = typeof(InteractionPromptBuilder).GetMethod(methodName, parameterTypes)!;
+        Assert.Equal(typeof(InteractionPromptBuilder), method.ReturnType);
+    }
+
+    private static void AssertHandleMethod(string methodName, params Type[] parameterTypes)
+    {
+        MethodInfo method = typeof(InteractionPrompt).GetMethod(methodName, parameterTypes)!;
+        Assert.Equal(typeof(InteractionPrompt), method.ReturnType);
+    }
+
+    private static void AssertProperty(string propertyName, Type propertyType)
+    {
+        PropertyInfo property = typeof(InteractionPrompt).GetProperty(propertyName)!;
+        Assert.Equal(propertyType, property.PropertyType);
+        Assert.NotNull(property.GetMethod);
+    }
+
+    private static void AssertEvent(string eventName)
+    {
+        EventInfo eventInfo = typeof(InteractionPrompt).GetEvent(eventName)!;
+        Assert.Equal(typeof(Action), eventInfo.EventHandlerType);
+    }
+}

--- a/S1API.Tests/Interaction/InteractionPromptApiCompileFixture.cs
+++ b/S1API.Tests/Interaction/InteractionPromptApiCompileFixture.cs
@@ -1,0 +1,60 @@
+using System;
+using S1API.Interaction;
+using UnityEngine;
+
+namespace S1API.Tests.Interaction;
+
+internal static class InteractionPromptApiCompileFixture
+{
+    internal static InteractionPrompt Configure(
+        GameObject target,
+        Collider displayCollider,
+        Transform displayPoint,
+        Action onHovered,
+        Action onStarted,
+        Action onEnded)
+    {
+        return InteractionPrompt
+            .CreateBuilder(target)
+            .WithMessage("Use machine")
+            .WithInput(InteractionPromptInput.Interact)
+            .WithState(InteractionPromptState.Default)
+            .WithRange(3f)
+            .WithPriority(5)
+            .WithAngleLimit(75f)
+            .WithoutAngleLimit()
+            .WithDisplayLocation(displayPoint)
+            .WithDisplayLocation(displayCollider)
+            .OnHovered(onHovered)
+            .OnInteractionStarted(onStarted)
+            .OnInteractionEnded(onEnded)
+            .Build();
+    }
+
+    internal static void ConfigureRuntime(InteractionPrompt prompt, Collider displayCollider, Transform displayPoint)
+    {
+        prompt
+            .SetMessage("Stop machine")
+            .SetInput(InteractionPromptInput.PrimaryClick)
+            .SetState(InteractionPromptState.Invalid)
+            .SetRange(2f)
+            .SetPriority(10)
+            .SetAngleLimit(45f)
+            .WithoutAngleLimit()
+            .SetDisplayLocation(displayPoint)
+            .SetDisplayLocation(displayCollider)
+            .ClearDisplayLocation();
+
+        _ = prompt.Target;
+        _ = prompt.Message;
+        _ = prompt.Input;
+        _ = prompt.State;
+        _ = prompt.Range;
+        _ = prompt.Priority;
+        _ = prompt.IsAngleLimited;
+        _ = prompt.AngleLimit;
+        _ = prompt.IsRemoved;
+        prompt.Remove();
+        prompt.Dispose();
+    }
+}

--- a/S1API.Tests/Interaction/InteractionPromptContractTests.cs
+++ b/S1API.Tests/Interaction/InteractionPromptContractTests.cs
@@ -1,0 +1,75 @@
+using System;
+using S1API.Interaction;
+
+namespace S1API.Tests.Interaction;
+
+public sealed class InteractionPromptContractTests
+{
+    [Fact]
+    public void NativeRangeIsBoundedByInteractionManagerCast()
+    {
+        Assert.Equal(4f, InteractionPromptContract.NativeMaxInteractionRange);
+        Assert.Equal(0.1f, InteractionPromptContract.NormalizeRange(0.1f));
+        Assert.Equal(4f, InteractionPromptContract.NormalizeRange(4f));
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(4.01f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void RangeRejectsUnsupportedValues(float range)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InteractionPromptContract.NormalizeRange(range));
+    }
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(-1f)]
+    [InlineData(180.01f)]
+    [InlineData(float.NaN)]
+    [InlineData(float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity)]
+    public void AngleLimitRejectsUnsupportedValues(float angleLimit)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InteractionPromptContract.NormalizeAngleLimit(angleLimit));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void MessageRejectsMissingText(string? message)
+    {
+        Assert.ThrowsAny<ArgumentException>(
+            () => InteractionPromptContract.NormalizeMessage(message!));
+    }
+
+    [Fact]
+    public void PublicEnumsRemainStableAndNativeOrdered()
+    {
+        Assert.Equal(0, (int)InteractionPromptInput.Interact);
+        Assert.Equal(1, (int)InteractionPromptInput.PrimaryClick);
+        Assert.Equal(0, (int)InteractionPromptState.Default);
+        Assert.Equal(1, (int)InteractionPromptState.Invalid);
+        Assert.Equal(2, (int)InteractionPromptState.Disabled);
+        Assert.Equal(3, (int)InteractionPromptState.Label);
+    }
+
+    [Fact]
+    public void UndefinedEnumValuesAreRejected()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InteractionPromptContract.ValidateEnum(
+                (InteractionPromptInput)99,
+                "input"));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InteractionPromptContract.ValidateEnum(
+                (InteractionPromptState)99,
+                "state"));
+    }
+}

--- a/S1API.Tests/Interaction/InteractionPromptContractTests.cs
+++ b/S1API.Tests/Interaction/InteractionPromptContractTests.cs
@@ -1,14 +1,101 @@
 using System;
+using System.Reflection;
 using S1API.Interaction;
+using UnityEngine;
 
 namespace S1API.Tests.Interaction;
 
 public sealed class InteractionPromptContractTests
 {
     [Fact]
+    public void ExplicitBuilderConfigurationReplacesDefaults()
+    {
+        InteractionPromptBuilder builder = CreateManagedBuilderFixture();
+        Action hovered = () => { };
+        Action started = () => { };
+        Action ended = () => { };
+
+        InteractionPromptBuilder result = builder
+            .WithMessage("Use")
+            .WithInput(InteractionPromptInput.PrimaryClick)
+            .WithState(InteractionPromptState.Label)
+            .WithRange(2.5f)
+            .WithPriority(8)
+            .WithAngleLimit(60f)
+            .OnHovered(hovered)
+            .OnHovered(hovered)
+            .OnInteractionStarted(started)
+            .OnInteractionStarted(started)
+            .OnInteractionEnded(ended)
+            .OnInteractionEnded(ended);
+
+        Assert.Same(builder, result);
+        Assert.Equal("Use", builder.Message);
+        Assert.Equal(InteractionPromptInput.PrimaryClick, builder.Input);
+        Assert.Equal(InteractionPromptState.Label, builder.State);
+        Assert.Equal(2.5f, builder.Range);
+        Assert.Equal(8, builder.Priority);
+        Assert.True(builder.LimitAngle);
+        Assert.Equal(60f, builder.AngleLimit);
+        Assert.Same(hovered, Assert.Single(builder.HoveredCallbacks));
+        Assert.Same(started, Assert.Single(builder.InteractionStartedCallbacks));
+        Assert.Same(ended, Assert.Single(builder.InteractionEndedCallbacks));
+    }
+
+    [Fact]
+    public void FailedMessageValidationLeavesBuilderMutableForImmediateRetry()
+    {
+        InteractionPromptBuilder builder = CreateManagedBuilderFixture();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.Same(builder, builder.WithMessage("Retry"));
+        Assert.Equal("Retry", builder.Message);
+    }
+
+    [Fact]
+    public void BuiltBuilderReturnsCachedHandleAndRejectsFurtherMutation()
+    {
+        InteractionPromptBuilder builder = CreateManagedBuilderFixture();
+        InteractionPrompt prompt = TestObjectFactory.CreateUninitialized<InteractionPrompt>();
+        SetBuiltPrompt(builder, prompt);
+
+        Assert.Same(prompt, builder.Build());
+        Assert.Throws<InvalidOperationException>(() => builder.WithMessage("Changed"));
+        Assert.Throws<InvalidOperationException>(() => builder.WithPriority(1));
+        Assert.Throws<InvalidOperationException>(() => builder.OnHovered(() => { }));
+    }
+
+    [Fact]
+    public void BuilderRejectsNullCallbacksAndUndefinedEnums()
+    {
+        InteractionPromptBuilder builder = CreateManagedBuilderFixture();
+
+        Assert.Throws<ArgumentNullException>(() => builder.OnHovered(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.OnInteractionStarted(null!));
+        Assert.Throws<ArgumentNullException>(() => builder.OnInteractionEnded(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => builder.WithDisplayLocation((Transform)null!));
+        Assert.Throws<ArgumentNullException>(
+            () => builder.WithDisplayLocation((Collider)null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithInput((InteractionPromptInput)99));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => builder.WithState((InteractionPromptState)99));
+    }
+
+    [Fact]
+    public void PublicFactoriesRejectNullTargets()
+    {
+        Assert.Throws<ArgumentNullException>(() => InteractionPromptBuilder.Create(null!));
+        Assert.Throws<ArgumentNullException>(() => InteractionPrompt.CreateBuilder(null!));
+    }
+
+    [Fact]
     public void NativeRangeIsBoundedByInteractionManagerCast()
     {
         Assert.Equal(4f, InteractionPromptContract.NativeMaxInteractionRange);
+        Assert.Equal(90f, InteractionPromptContract.DefaultAngleLimit);
         Assert.Equal(0.1f, InteractionPromptContract.NormalizeRange(0.1f));
         Assert.Equal(4f, InteractionPromptContract.NormalizeRange(4f));
     }
@@ -71,5 +158,28 @@ public sealed class InteractionPromptContractTests
             () => InteractionPromptContract.ValidateEnum(
                 (InteractionPromptState)99,
                 "state"));
+    }
+
+    private static InteractionPromptBuilder CreateManagedBuilderFixture()
+    {
+        InteractionPromptBuilder builder =
+            TestObjectFactory.CreateUninitialized<InteractionPromptBuilder>();
+        SetPrivateField(builder, "_hoveredCallbacks", new List<Action>());
+        SetPrivateField(builder, "_interactionStartedCallbacks", new List<Action>());
+        SetPrivateField(builder, "_interactionEndedCallbacks", new List<Action>());
+        return builder;
+    }
+
+    private static void SetBuiltPrompt(InteractionPromptBuilder builder, InteractionPrompt prompt)
+    {
+        SetPrivateField(builder, "_builtPrompt", prompt);
+    }
+
+    private static void SetPrivateField<TValue>(InteractionPromptBuilder builder, string name, TValue value)
+    {
+        FieldInfo field = typeof(InteractionPromptBuilder).GetField(
+            name,
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        field.SetValue(builder, value);
     }
 }

--- a/S1API.Tests/S1API.Tests.csproj
+++ b/S1API.Tests/S1API.Tests.csproj
@@ -43,6 +43,9 @@
         <Reference Include="UnityEngine.CoreModule">
             <HintPath>$(MonoAssembliesPath)/UnityEngine.CoreModule.dll</HintPath>
         </Reference>
+        <Reference Include="UnityEngine.PhysicsModule">
+            <HintPath>$(MonoAssembliesPath)/UnityEngine.PhysicsModule.dll</HintPath>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Il2CppMelon'">
@@ -55,5 +58,6 @@
         <Reference Include="$(Il2CppAssembliesPath)\Il2Cppmscorlib.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.dll" />
         <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.CoreModule.dll" />
+        <Reference Include="$(Il2CppAssembliesPath)\UnityEngine.PhysicsModule.dll" />
     </ItemGroup>
 </Project>

--- a/S1API/Interaction/InteractionPrompt.cs
+++ b/S1API/Interaction/InteractionPrompt.cs
@@ -1,0 +1,223 @@
+using System;
+using UnityEngine;
+
+namespace S1API.Interaction
+{
+    /// <summary>
+    /// Managed handle for a native Schedule One interaction prompt.
+    /// </summary>
+    public sealed class InteractionPrompt : IDisposable
+    {
+        private readonly Internal.Interaction.InteractionPromptRuntime _runtime;
+        private bool _removed;
+
+        /// <summary>Creates a builder for a mod-owned GameObject.</summary>
+        /// <param name="target">The GameObject whose collider should be interactable.</param>
+        /// <returns>A new interaction prompt builder.</returns>
+        public static InteractionPromptBuilder CreateBuilder(GameObject target) =>
+            InteractionPromptBuilder.Create(target);
+
+        /// <summary>The GameObject containing the native prompt component.</summary>
+        public GameObject Target => _runtime.Target;
+
+        /// <summary>The current prompt message.</summary>
+        public string Message { get; private set; }
+
+        /// <summary>The current native input action.</summary>
+        public InteractionPromptInput Input { get; private set; }
+
+        /// <summary>The current native prompt state.</summary>
+        public InteractionPromptState State { get; private set; }
+
+        /// <summary>The current maximum interaction range.</summary>
+        public float Range { get; private set; }
+
+        /// <summary>The current overlap priority.</summary>
+        public int Priority { get; private set; }
+
+        /// <summary>Whether the prompt currently applies an angle restriction.</summary>
+        public bool IsAngleLimited { get; private set; }
+
+        /// <summary>The current angle restriction in degrees.</summary>
+        public float AngleLimit { get; private set; }
+
+        /// <summary>Whether this handle has been removed or its target destroyed.</summary>
+        public bool IsRemoved => _removed || !_runtime.IsAttached;
+
+        /// <summary>Invoked while the native interaction manager selects this prompt.</summary>
+        public event Action? Hovered;
+
+        /// <summary>Invoked when the native interaction starts.</summary>
+        public event Action? InteractionStarted;
+
+        /// <summary>Invoked when the native interaction ends.</summary>
+        public event Action? InteractionEnded;
+
+        internal InteractionPrompt(InteractionPromptBuilder builder)
+        {
+            Message = builder.Message;
+            Input = builder.Input;
+            State = builder.State;
+            Range = builder.Range;
+            Priority = builder.Priority;
+            IsAngleLimited = builder.LimitAngle;
+            AngleLimit = builder.AngleLimit;
+            _runtime = new Internal.Interaction.InteractionPromptRuntime(
+                this,
+                builder.Target,
+                builder.Input,
+                builder.State,
+                builder.Message,
+                builder.Range,
+                builder.Priority,
+                builder.LimitAngle,
+                builder.AngleLimit,
+                builder.DisplayPoint,
+                builder.DisplayCollider);
+
+            foreach (Action callback in builder.HoveredCallbacks)
+                Hovered += callback;
+            foreach (Action callback in builder.InteractionStartedCallbacks)
+                InteractionStarted += callback;
+            foreach (Action callback in builder.InteractionEndedCallbacks)
+                InteractionEnded += callback;
+        }
+
+        /// <summary>Updates the native prompt message.</summary>
+        /// <param name="message">Non-empty player-facing prompt text.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetMessage(string message)
+        {
+            EnsureUsable();
+            Message = InteractionPromptContract.NormalizeMessage(message);
+            _runtime.SetMessage(Message);
+            return this;
+        }
+
+        /// <summary>Updates the native input action.</summary>
+        /// <param name="input">The interaction input action.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetInput(InteractionPromptInput input)
+        {
+            EnsureUsable();
+            InteractionPromptContract.ValidateEnum(input, nameof(input));
+            Input = input;
+            _runtime.SetInput(input);
+            return this;
+        }
+
+        /// <summary>Updates the native prompt state.</summary>
+        /// <param name="state">The visual and interaction state.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetState(InteractionPromptState state)
+        {
+            EnsureUsable();
+            InteractionPromptContract.ValidateEnum(state, nameof(state));
+            State = state;
+            _runtime.SetState(state);
+            return this;
+        }
+
+        /// <summary>Updates the maximum selection distance.</summary>
+        /// <param name="range">A finite distance between zero and four metres.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetRange(float range)
+        {
+            EnsureUsable();
+            Range = InteractionPromptContract.NormalizeRange(range);
+            _runtime.SetRange(Range);
+            return this;
+        }
+
+        /// <summary>Updates the overlap priority.</summary>
+        /// <param name="priority">A higher value takes precedence.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetPriority(int priority)
+        {
+            EnsureUsable();
+            Priority = priority;
+            _runtime.SetPriority(priority);
+            return this;
+        }
+
+        /// <summary>Applies a horizontal angle restriction.</summary>
+        /// <param name="angleLimit">A finite angle greater than zero and at most 180 degrees.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetAngleLimit(float angleLimit)
+        {
+            EnsureUsable();
+            AngleLimit = InteractionPromptContract.NormalizeAngleLimit(angleLimit);
+            IsAngleLimited = true;
+            _runtime.SetAngleLimit(AngleLimit);
+            return this;
+        }
+
+        /// <summary>Clears the horizontal angle restriction.</summary>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt WithoutAngleLimit()
+        {
+            EnsureUsable();
+            IsAngleLimited = false;
+            _runtime.ClearAngleLimit();
+            return this;
+        }
+
+        /// <summary>Updates the prompt display anchor to a transform.</summary>
+        /// <param name="displayPoint">The transform whose position should be used.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetDisplayLocation(Transform displayPoint)
+        {
+            EnsureUsable();
+            if (ReferenceEquals(displayPoint, null) || displayPoint == null)
+                throw new ArgumentNullException(nameof(displayPoint));
+            _runtime.SetDisplayLocation(displayPoint);
+            return this;
+        }
+
+        /// <summary>Updates the prompt display anchor to a collider.</summary>
+        /// <param name="displayCollider">The collider used for display positioning.</param>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt SetDisplayLocation(Collider displayCollider)
+        {
+            EnsureUsable();
+            if (ReferenceEquals(displayCollider, null) || displayCollider == null)
+                throw new ArgumentNullException(nameof(displayCollider));
+            _runtime.SetDisplayLocation(displayCollider);
+            return this;
+        }
+
+        /// <summary>Resets prompt positioning to the target transform.</summary>
+        /// <returns>This prompt for fluent chaining.</returns>
+        public InteractionPrompt ClearDisplayLocation()
+        {
+            EnsureUsable();
+            _runtime.ClearDisplayLocation();
+            return this;
+        }
+
+        /// <summary>Removes the owned native prompt component.</summary>
+        /// <returns><see langword="true"/> when this call performed the removal.</returns>
+        public bool Remove()
+        {
+            if (IsRemoved)
+                return false;
+
+            _removed = true;
+            _runtime.Dispose();
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => Remove();
+
+        internal void RaiseHovered() => Hovered?.Invoke();
+        internal void RaiseInteractionStarted() => InteractionStarted?.Invoke();
+        internal void RaiseInteractionEnded() => InteractionEnded?.Invoke();
+
+        private void EnsureUsable()
+        {
+            if (IsRemoved)
+                throw new ObjectDisposedException(nameof(InteractionPrompt));
+        }
+    }
+}

--- a/S1API/Interaction/InteractionPromptBuilder.cs
+++ b/S1API/Interaction/InteractionPromptBuilder.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace S1API.Interaction
+{
+    /// <summary>
+    /// Builds a native Schedule One interaction prompt for a mod-owned GameObject.
+    /// </summary>
+    /// <remarks>
+    /// The target must contain a collider on a layer included by the game's interaction
+    /// search mask. The builder does not create colliders or change object layers.
+    /// </remarks>
+    public sealed class InteractionPromptBuilder
+    {
+        private readonly GameObject _target;
+        private readonly List<Action> _hoveredCallbacks = new List<Action>();
+        private readonly List<Action> _interactionStartedCallbacks = new List<Action>();
+        private readonly List<Action> _interactionEndedCallbacks = new List<Action>();
+
+        private string? _message;
+        private InteractionPromptInput _input = InteractionPromptInput.Interact;
+        private InteractionPromptState _state = InteractionPromptState.Default;
+        private float _range = InteractionPromptContract.NativeMaxInteractionRange;
+        private int _priority;
+        private bool _limitAngle;
+        private float _angleLimit = 90f;
+        private Transform? _displayPoint;
+        private Collider? _displayCollider;
+        private InteractionPrompt? _builtPrompt;
+
+        internal GameObject Target => _target;
+        internal string Message => _message!;
+        internal InteractionPromptInput Input => _input;
+        internal InteractionPromptState State => _state;
+        internal float Range => _range;
+        internal int Priority => _priority;
+        internal bool LimitAngle => _limitAngle;
+        internal float AngleLimit => _angleLimit;
+        internal Transform? DisplayPoint => _displayPoint;
+        internal Collider? DisplayCollider => _displayCollider;
+        internal IReadOnlyList<Action> HoveredCallbacks => _hoveredCallbacks;
+        internal IReadOnlyList<Action> InteractionStartedCallbacks => _interactionStartedCallbacks;
+        internal IReadOnlyList<Action> InteractionEndedCallbacks => _interactionEndedCallbacks;
+
+        internal InteractionPromptBuilder(GameObject target)
+        {
+            if (ReferenceEquals(target, null) || target == null)
+                throw new ArgumentNullException(nameof(target));
+
+            _target = target;
+        }
+
+        /// <summary>
+        /// Creates a builder for a mod-owned GameObject.
+        /// </summary>
+        /// <param name="target">The GameObject whose collider should be interactable.</param>
+        /// <returns>A new interaction prompt builder.</returns>
+        public static InteractionPromptBuilder Create(GameObject target) =>
+            new InteractionPromptBuilder(target);
+
+        /// <summary>Sets the text rendered by the native interaction prompt.</summary>
+        /// <param name="message">Non-empty player-facing prompt text.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithMessage(string message)
+        {
+            EnsureMutable();
+            _message = InteractionPromptContract.NormalizeMessage(message);
+            return this;
+        }
+
+        /// <summary>Sets the native input action used to begin the interaction.</summary>
+        /// <param name="input">The interaction input action.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithInput(InteractionPromptInput input)
+        {
+            EnsureMutable();
+            InteractionPromptContract.ValidateEnum(input, nameof(input));
+            _input = input;
+            return this;
+        }
+
+        /// <summary>Sets the native prompt state.</summary>
+        /// <param name="state">The visual and interaction state.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithState(InteractionPromptState state)
+        {
+            EnsureMutable();
+            InteractionPromptContract.ValidateEnum(state, nameof(state));
+            _state = state;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum distance at which the prompt can be selected.
+        /// </summary>
+        /// <param name="range">A finite distance between zero and four metres.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithRange(float range)
+        {
+            EnsureMutable();
+            _range = InteractionPromptContract.NormalizeRange(range);
+            return this;
+        }
+
+        /// <summary>Sets the priority used when native prompts overlap.</summary>
+        /// <param name="priority">A higher value takes precedence.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithPriority(int priority)
+        {
+            EnsureMutable();
+            _priority = priority;
+            return this;
+        }
+
+        /// <summary>
+        /// Limits selection to the specified horizontal angle around the target's forward direction.
+        /// </summary>
+        /// <param name="angleLimit">A finite angle greater than zero and at most 180 degrees.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithAngleLimit(float angleLimit)
+        {
+            EnsureMutable();
+            _angleLimit = InteractionPromptContract.NormalizeAngleLimit(angleLimit);
+            _limitAngle = true;
+            return this;
+        }
+
+        /// <summary>Clears any angle restriction.</summary>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithoutAngleLimit()
+        {
+            EnsureMutable();
+            _limitAngle = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses a transform as the native prompt display anchor.
+        /// </summary>
+        /// <param name="displayPoint">The transform whose position should be used.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithDisplayLocation(Transform displayPoint)
+        {
+            EnsureMutable();
+            if (ReferenceEquals(displayPoint, null) || displayPoint == null)
+                throw new ArgumentNullException(nameof(displayPoint));
+
+            _displayPoint = displayPoint;
+            _displayCollider = null;
+            return this;
+        }
+
+        /// <summary>
+        /// Uses a collider's closest point to the player as the native prompt display anchor.
+        /// </summary>
+        /// <param name="displayCollider">The collider used for display positioning.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder WithDisplayLocation(Collider displayCollider)
+        {
+            EnsureMutable();
+            if (ReferenceEquals(displayCollider, null) || displayCollider == null)
+                throw new ArgumentNullException(nameof(displayCollider));
+
+            _displayCollider = displayCollider;
+            _displayPoint = null;
+            return this;
+        }
+
+        /// <summary>Registers a callback invoked while this prompt is selected.</summary>
+        /// <param name="callback">The callback invoked by the native hover lifecycle.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder OnHovered(Action callback)
+        {
+            EnsureMutable();
+            AddCallback(_hoveredCallbacks, callback, nameof(callback));
+            return this;
+        }
+
+        /// <summary>Registers a callback invoked when the native interaction starts.</summary>
+        /// <param name="callback">The callback invoked by the native interaction lifecycle.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder OnInteractionStarted(Action callback)
+        {
+            EnsureMutable();
+            AddCallback(_interactionStartedCallbacks, callback, nameof(callback));
+            return this;
+        }
+
+        /// <summary>Registers a callback invoked when the native interaction ends.</summary>
+        /// <param name="callback">The callback invoked by the native interaction lifecycle.</param>
+        /// <returns>This builder for fluent chaining.</returns>
+        public InteractionPromptBuilder OnInteractionEnded(Action callback)
+        {
+            EnsureMutable();
+            AddCallback(_interactionEndedCallbacks, callback, nameof(callback));
+            return this;
+        }
+
+        /// <summary>
+        /// Attaches the native interaction component and returns a managed runtime handle.
+        /// </summary>
+        /// <returns>The managed interaction prompt handle.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the message is missing, the target already has an interaction component,
+        /// or no usable collider exists beneath the target.
+        /// </exception>
+        public InteractionPrompt Build()
+        {
+            if (_builtPrompt != null)
+                return _builtPrompt;
+            if (_message == null)
+                throw new InvalidOperationException("WithMessage must be called before Build().");
+
+            _builtPrompt = new InteractionPrompt(this);
+            return _builtPrompt;
+        }
+
+        private void EnsureMutable()
+        {
+            if (_builtPrompt != null)
+                throw new InvalidOperationException("This interaction prompt builder has already been built.");
+        }
+
+        private static void AddCallback(List<Action> callbacks, Action callback, string parameterName)
+        {
+            if (callback == null)
+                throw new ArgumentNullException(parameterName);
+            if (!callbacks.Contains(callback))
+                callbacks.Add(callback);
+        }
+    }
+}

--- a/S1API/Interaction/InteractionPromptBuilder.cs
+++ b/S1API/Interaction/InteractionPromptBuilder.cs
@@ -24,7 +24,7 @@ namespace S1API.Interaction
         private float _range = InteractionPromptContract.NativeMaxInteractionRange;
         private int _priority;
         private bool _limitAngle;
-        private float _angleLimit = 90f;
+        private float _angleLimit = InteractionPromptContract.DefaultAngleLimit;
         private Transform? _displayPoint;
         private Collider? _displayCollider;
         private InteractionPrompt? _builtPrompt;

--- a/S1API/Interaction/InteractionPromptContract.cs
+++ b/S1API/Interaction/InteractionPromptContract.cs
@@ -6,6 +6,7 @@ namespace S1API.Interaction
     internal static class InteractionPromptContract
     {
         internal const float NativeMaxInteractionRange = 4f;
+        internal const float DefaultAngleLimit = 90f;
 
         internal static string NormalizeMessage(string message)
         {

--- a/S1API/Interaction/InteractionPromptContract.cs
+++ b/S1API/Interaction/InteractionPromptContract.cs
@@ -1,0 +1,58 @@
+using System;
+using UnityEngine;
+
+namespace S1API.Interaction
+{
+    internal static class InteractionPromptContract
+    {
+        internal const float NativeMaxInteractionRange = 4f;
+
+        internal static string NormalizeMessage(string message)
+        {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
+            if (string.IsNullOrWhiteSpace(message))
+                throw new ArgumentException("Interaction prompt messages cannot be empty or whitespace.", nameof(message));
+
+            return message;
+        }
+
+        internal static float NormalizeRange(float range)
+        {
+            if (float.IsNaN(range) || float.IsInfinity(range) || range <= 0f || range > NativeMaxInteractionRange)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(range),
+                    "Interaction prompt range must be finite, greater than zero, and at most four metres.");
+            }
+
+            return range;
+        }
+
+        internal static float NormalizeAngleLimit(float angleLimit)
+        {
+            if (float.IsNaN(angleLimit) || float.IsInfinity(angleLimit) || angleLimit <= 0f || angleLimit > 180f)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(angleLimit),
+                    "Interaction prompt angle limits must be finite, greater than zero, and at most 180 degrees.");
+            }
+
+            return angleLimit;
+        }
+
+        internal static void ValidateEnum<TEnum>(TEnum value, string parameterName)
+            where TEnum : struct, Enum
+        {
+            if (!Enum.IsDefined(typeof(TEnum), value))
+                throw new ArgumentOutOfRangeException(parameterName, value, "The interaction prompt value is not defined.");
+        }
+
+        internal static void ValidateTarget(GameObject target)
+        {
+            if (ReferenceEquals(target, null) || target == null)
+                throw new ArgumentNullException(nameof(target));
+        }
+    }
+}

--- a/S1API/Interaction/InteractionPromptInput.cs
+++ b/S1API/Interaction/InteractionPromptInput.cs
@@ -1,0 +1,14 @@
+namespace S1API.Interaction
+{
+    /// <summary>
+    /// Selects the native input action used to start an interaction.
+    /// </summary>
+    public enum InteractionPromptInput
+    {
+        /// <summary>The configured keyboard or controller interaction action.</summary>
+        Interact,
+
+        /// <summary>The configured primary-click action.</summary>
+        PrimaryClick
+    }
+}

--- a/S1API/Interaction/InteractionPromptState.cs
+++ b/S1API/Interaction/InteractionPromptState.cs
@@ -1,0 +1,20 @@
+namespace S1API.Interaction
+{
+    /// <summary>
+    /// Selects the native visual and interaction state shown by an interaction prompt.
+    /// </summary>
+    public enum InteractionPromptState
+    {
+        /// <summary>Shows the normal input prompt.</summary>
+        Default,
+
+        /// <summary>Shows the native invalid prompt and prevents interaction start.</summary>
+        Invalid,
+
+        /// <summary>Hides the prompt and prevents interaction selection.</summary>
+        Disabled,
+
+        /// <summary>Shows the message without an input icon.</summary>
+        Label
+    }
+}

--- a/S1API/Internal/Interaction/InteractionPromptRuntime.cs
+++ b/S1API/Internal/Interaction/InteractionPromptRuntime.cs
@@ -45,6 +45,7 @@ namespace S1API.Internal.Interaction
                 throw new InvalidOperationException(
                     $"GameObject '{target.name}' already contains an InteractableObject component.");
             }
+            ValidateColliderComposition(target);
 
             Target = target;
             _owner = owner;
@@ -64,7 +65,6 @@ namespace S1API.Internal.Interaction
                 _interactable.LimitInteractionAngle = limitAngle;
                 _interactable.AngleLimit = angleLimit;
                 ApplyDisplayLocation(displayPoint, displayCollider);
-                ValidateColliderComposition(interactable);
 
                 EventHelper.AddListener(_hoveredHandler, _interactable.onHovered);
                 EventHelper.AddListener(_interactionStartedHandler, _interactable.onInteractStart);
@@ -165,18 +165,18 @@ namespace S1API.Internal.Interaction
             _interactable.displayLocationPoint = displayPoint;
         }
 
-        private void ValidateColliderComposition(S1Interaction.InteractableObject interactable)
+        private static void ValidateColliderComposition(GameObject target)
         {
-            Collider[] colliders = Target.GetComponentsInChildren<Collider>(true);
+            Collider[] colliders = target.GetComponentsInChildren<Collider>(true);
             for (int i = 0; i < colliders.Length; i++)
             {
                 Collider collider = colliders[i];
-                if (collider != null && collider.GetComponentInParent<S1Interaction.InteractableObject>() == interactable)
+                if (collider != null)
                     return;
             }
 
             throw new InvalidOperationException(
-                $"GameObject '{Target.name}' and its children do not contain a collider usable by the interaction manager.");
+                $"GameObject '{target.name}' and its children do not contain a collider usable by the interaction manager.");
         }
     }
 }

--- a/S1API/Internal/Interaction/InteractionPromptRuntime.cs
+++ b/S1API/Internal/Interaction/InteractionPromptRuntime.cs
@@ -1,0 +1,182 @@
+#if IL2CPPMELON
+using S1Interaction = Il2CppScheduleOne.Interaction;
+#elif MONOMELON
+using S1Interaction = ScheduleOne.Interaction;
+#endif
+
+using System;
+using S1API.Utils;
+using UnityEngine;
+
+namespace S1API.Internal.Interaction
+{
+    internal sealed class InteractionPromptRuntime : IDisposable
+    {
+        private readonly global::S1API.Interaction.InteractionPrompt _owner;
+        private readonly S1Interaction.InteractableObject _interactable;
+        private readonly Action _hoveredHandler;
+        private readonly Action _interactionStartedHandler;
+        private readonly Action _interactionEndedHandler;
+        private bool _disposed;
+
+        internal GameObject Target { get; }
+
+        internal bool IsAttached =>
+            !_disposed && _interactable != null && Target != null;
+
+        internal InteractionPromptRuntime(
+            global::S1API.Interaction.InteractionPrompt owner,
+            GameObject target,
+            global::S1API.Interaction.InteractionPromptInput input,
+            global::S1API.Interaction.InteractionPromptState state,
+            string message,
+            float range,
+            int priority,
+            bool limitAngle,
+            float angleLimit,
+            Transform? displayPoint,
+            Collider? displayCollider)
+        {
+            if (owner == null)
+                throw new ArgumentNullException(nameof(owner));
+            global::S1API.Interaction.InteractionPromptContract.ValidateTarget(target);
+            if (target.GetComponent<S1Interaction.InteractableObject>() != null)
+            {
+                throw new InvalidOperationException(
+                    $"GameObject '{target.name}' already contains an InteractableObject component.");
+            }
+
+            Target = target;
+            _owner = owner;
+            S1Interaction.InteractableObject? interactable = null;
+            try
+            {
+                interactable = target.AddComponent<S1Interaction.InteractableObject>();
+                _interactable = interactable;
+                _hoveredHandler = _owner.RaiseHovered;
+                _interactionStartedHandler = _owner.RaiseInteractionStarted;
+                _interactionEndedHandler = _owner.RaiseInteractionEnded;
+                ApplyInput(input);
+                ApplyState(state);
+                _interactable.SetMessage(message);
+                _interactable.MaxInteractionRange = range;
+                _interactable.Priority = priority;
+                _interactable.LimitInteractionAngle = limitAngle;
+                _interactable.AngleLimit = angleLimit;
+                ApplyDisplayLocation(displayPoint, displayCollider);
+                ValidateColliderComposition(interactable);
+
+                EventHelper.AddListener(_hoveredHandler, _interactable.onHovered);
+                EventHelper.AddListener(_interactionStartedHandler, _interactable.onInteractStart);
+                EventHelper.AddListener(_interactionEndedHandler, _interactable.onInteractEnd);
+            }
+            catch
+            {
+                if (interactable != null)
+                    UnityEngine.Object.Destroy(interactable);
+                throw;
+            }
+        }
+
+        internal void SetMessage(string message) => _interactable.SetMessage(message);
+
+        internal void SetInput(global::S1API.Interaction.InteractionPromptInput input) => ApplyInput(input);
+
+        internal void SetState(global::S1API.Interaction.InteractionPromptState state) => ApplyState(state);
+
+        internal void SetRange(float range) => _interactable.MaxInteractionRange = range;
+
+        internal void SetPriority(int priority) => _interactable.Priority = priority;
+
+        internal void SetAngleLimit(float angleLimit)
+        {
+            _interactable.AngleLimit = angleLimit;
+            _interactable.LimitInteractionAngle = true;
+        }
+
+        internal void ClearAngleLimit() => _interactable.LimitInteractionAngle = false;
+
+        internal void SetDisplayLocation(Transform displayPoint) =>
+            ApplyDisplayLocation(displayPoint, null);
+
+        internal void SetDisplayLocation(Collider displayCollider) =>
+            ApplyDisplayLocation(null, displayCollider);
+
+        internal void ClearDisplayLocation() =>
+            ApplyDisplayLocation(null, null);
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (_interactable != null)
+            {
+                EventHelper.RemoveListener(_hoveredHandler, _interactable.onHovered);
+                EventHelper.RemoveListener(_interactionStartedHandler, _interactable.onInteractStart);
+                EventHelper.RemoveListener(_interactionEndedHandler, _interactable.onInteractEnd);
+                UnityEngine.Object.Destroy(_interactable);
+            }
+        }
+
+        private void ApplyInput(global::S1API.Interaction.InteractionPromptInput input)
+        {
+            S1Interaction.InteractableObject.EInteractionType nativeInput =
+                input == global::S1API.Interaction.InteractionPromptInput.PrimaryClick
+                    ? S1Interaction.InteractableObject.EInteractionType.LeftMouse_Click
+                    : S1Interaction.InteractableObject.EInteractionType.Key_Press;
+            _interactable.SetInteractionType(nativeInput);
+        }
+
+        private void ApplyState(global::S1API.Interaction.InteractionPromptState state)
+        {
+            S1Interaction.InteractableObject.EInteractableState nativeState =
+                (S1Interaction.InteractableObject.EInteractableState)(int)state;
+            _interactable.SetInteractableState(nativeState);
+        }
+
+        private void ApplyDisplayLocation(Transform? displayPoint, Collider? displayCollider)
+        {
+            if (displayCollider != null)
+            {
+                if (!global::S1API.Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(
+                        _interactable,
+                        "displayLocationCollider",
+                        displayCollider))
+                {
+                    throw new InvalidOperationException(
+                        "The native interaction component does not expose displayLocationCollider.");
+                }
+
+                _interactable.displayLocationPoint = null;
+                return;
+            }
+
+            if (!global::S1API.Internal.Utils.ReflectionUtils.TrySetFieldOrProperty(
+                    _interactable,
+                    "displayLocationCollider",
+                    null))
+            {
+                throw new InvalidOperationException(
+                    "The native interaction component does not expose displayLocationCollider.");
+            }
+
+            _interactable.displayLocationPoint = displayPoint;
+        }
+
+        private void ValidateColliderComposition(S1Interaction.InteractableObject interactable)
+        {
+            Collider[] colliders = Target.GetComponentsInChildren<Collider>(true);
+            for (int i = 0; i < colliders.Length; i++)
+            {
+                Collider collider = colliders[i];
+                if (collider != null && collider.GetComponentInParent<S1Interaction.InteractableObject>() == interactable)
+                    return;
+            }
+
+            throw new InvalidOperationException(
+                $"GameObject '{Target.name}' and its children do not contain a collider usable by the interaction manager.");
+        }
+    }
+}

--- a/S1API/docs/interaction-prompts.md
+++ b/S1API/docs/interaction-prompts.md
@@ -1,0 +1,63 @@
+# Native Interaction Prompts
+
+`InteractionPrompt` attaches the game's native interaction prompt to a mod-owned `GameObject`.
+The game remains responsible for raycasts, input-device glyphs, prompt rendering, overlap priority,
+and the interaction lifecycle.
+
+```csharp
+private InteractionPrompt? _prompt;
+
+void ConfigureMachine(GameObject machine, Collider interactionCollider)
+{
+    _prompt = InteractionPrompt
+        .CreateBuilder(machine)
+        .WithMessage("Start mixer")
+        .WithDisplayLocation(interactionCollider)
+        .WithRange(3f)
+        .WithPriority(5)
+        .OnInteractionStarted(StartMixer)
+        .OnInteractionEnded(StopHoldingMixer)
+        .Build();
+}
+```
+
+The target hierarchy must contain a collider on a layer included by the game's interaction search
+mask. S1API does not create a collider or change the target's layer. A collider supplied through
+`WithDisplayLocation(Collider)` controls only where the prompt is rendered; it is not a replacement
+for the target's interaction collider.
+
+## Prompt configuration
+
+The builder supports the native input actions `Interact` and `PrimaryClick`, the native states
+`Default`, `Invalid`, `Disabled`, and `Label`, a maximum range of four metres, overlap priority,
+and an optional horizontal angle limit. The four-metre limit comes from the game's interaction
+raycast, so a larger per-component value would not make the prompt reachable.
+
+If neither display location overload is used, the prompt renders at the target transform. A
+transform uses its position directly. A collider uses the closest point to the player, which is
+useful for large machines and furniture.
+
+## Runtime updates and callbacks
+
+The returned handle can update the message, input, state, range, priority, angle limit, and display
+location:
+
+```csharp
+_prompt
+    ?.SetState(canUse
+        ? InteractionPromptState.Default
+        : InteractionPromptState.Invalid)
+    .SetMessage(canUse ? "Start mixer" : "Mixer is busy");
+```
+
+`OnHovered` follows the native event and may run every frame while the prompt is selected.
+`OnInteractionStarted` and `OnInteractionEnded` follow the game's input-hold lifecycle. These
+callbacks do not provide multiplayer authorization or synchronization. The mod must validate the
+request and use its own network policy before changing shared state.
+
+Call `Remove()` or `Dispose()` when the mod-owned object is retired. Removing the prompt destroys
+only the S1API-owned native component and leaves the target, colliders, and other components intact.
+
+The builder rejects targets that already contain an `InteractableObject`; configure an existing
+native interaction component directly when a prefab already owns one or use a separate child
+target for an additional prompt.

--- a/S1API/docs/toc.yml
+++ b/S1API/docs/toc.yml
@@ -58,6 +58,8 @@
       href: quests-system.md
     - name: Map POIs
       href: map-pois.md
+    - name: Native Interaction Prompts
+      href: interaction-prompts.md
     - name: Cutscenes
       href: cutscenes.md
     - name: Products


### PR DESCRIPTION
## Summary

Closes #238.

Adds an additive `S1API.Interaction` builder and managed handle for attaching the game-native `InteractableObject` to a mod-owned `GameObject`. The public surface covers prompt message, input/state, native-reachable range, priority, angle limits, display anchors, lifecycle callbacks, runtime setters, and disposal. Mono/Il2Cpp field differences stay behind the internal runtime adapter; existing native interaction components are rejected rather than mutated.

## Compatibility

- Public/protected API: adds `InteractionPromptBuilder`, `InteractionPrompt`, `InteractionPromptInput`, and `InteractionPromptState`; no existing symbols changed.
- Existing defaults and behavior: native defaults are preserved where possible; the builder defaults to `Interact`, `Default`, four metres, priority zero, and no angle restriction. The four-metre range contract matches the native interaction manager cast limit.
- Stable IDs, saves, and network payloads: no prefab, asset, save, network, or durable identifier changes. Multiplayer authorization/synchronization remains the consumer mod's responsibility.

## Validation

### Mono

- `dotnet restore S1API.sln -p:Configuration=MonoMelon`
- `dotnet build S1API.sln -c MonoMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore --no-build` — 675 passed
- Disposable live probe in `Schedule I_alternate` — `PASS|NativeAttached=True|Callbacks=True|Setters=True|Removed=True`

### IL2CPP

- `dotnet restore S1API.sln -p:Configuration=Il2CppMelon`
- `dotnet build S1API.sln -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false`
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore --no-build` — 661 passed
- Disposable live probe in `Schedule I_public` — `PASS|NativeAttached=True|Callbacks=True|Setters=True|Removed=True`

### Runtime evidence

The probes used isolated temporary state, backed up/restored the active Mods/UserLibs/log files, and were deleted after validation. No generated game artifacts are included in this PR.

## Documentation

- Added XML documentation for all public builder/handle members.
- Added `docs/interaction-prompts.md` and the documentation TOC entry.
- `docfx docfx.json` completed successfully from `S1API/` with the repository's existing unresolved third-party assembly-reference warnings only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable interaction prompts for Unity objects.
  * Supports custom messages, input methods, visual states, range, priority, angle limits, and display locations.
  * Added callbacks for hover, interaction start, and interaction end events.
  * Prompts can be updated, removed, and disposed at runtime.
* **Documentation**
  * Added usage guidance and API documentation for interaction prompts.
* **Bug Fixes**
  * Added validation for invalid prompt configuration and unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->