### PR TITLE
chore(release): prepare 3.2.0

### DIFF
--- a/.github/release-notes/3.2.0.md
+++ b/.github/release-notes/3.2.0.md
@@ -1,0 +1,34 @@
+## New Managed APIs
+
+- Build customizable variants of native grid and surface furniture while preserving placement defaults, isolated materials, stored and ghost visuals, and generated icons ([#264](https://github.com/ifBars/S1API/pull/264)).
+- Inspect an NPC's current building, awareness changes, and vehicle entry or exit events, and read native vehicle color metadata through managed wrappers ([#265](https://github.com/ifBars/S1API/pull/265), [#266](https://github.com/ifBars/S1API/pull/266), [#267](https://github.com/ifBars/S1API/pull/267), [#268](https://github.com/ifBars/S1API/pull/268)).
+- Declare customer, dealer, and supplier roles through NPC properties so prefab configuration follows the selected capabilities ([#280](https://github.com/ifBars/S1API/pull/280)).
+- Discover blackjack, Ride the Bus, and slot-machine games; read immutable state snapshots; and subscribe to round and spin lifecycle events ([#281](https://github.com/ifBars/S1API/pull/281)).
+- Create and query native temperature emitters with cross-runtime managed events, validation, snapshots, and unit helpers ([#283](https://github.com/ifBars/S1API/pull/283)).
+- Inspect native trash containers, subscribe to content and level changes, and invoke the server-authoritative native bagging flow ([#284](https://github.com/ifBars/S1API/pull/284)).
+- Attach configurable native interaction prompts to mod-owned objects with managed lifecycle callbacks, runtime setters, and disposal ([#285](https://github.com/ifBars/S1API/pull/285)).
+- Discover placed jukeboxes, inspect immutable track and playback state, subscribe to changes, and use the native playback, volume, shuffle, repeat, synchronization, and track-selection controls ([#286](https://github.com/ifBars/S1API/pull/286)).
+
+## Fixes and Runtime Compatibility
+
+- Hide dealer conversations until their relationship requirements are met, while keeping conversation hooks idempotent ([#271](https://github.com/ifBars/S1API/pull/271)).
+- Remove the unusable Casino building identifier from the NPC building registry ([#276](https://github.com/ifBars/S1API/pull/276)).
+- Finalize custom NPCs correctly on multiplayer clients, bridge customer contract events on IL2CPP, and tolerate the base game's removed region-unlock member ([#277](https://github.com/ifBars/S1API/pull/277), [#278](https://github.com/ifBars/S1API/pull/278), [#279](https://github.com/ifBars/S1API/pull/279)).
+- Harden cross-wrapper event ownership and cleanup for awareness, vehicle, trash-container, and jukebox APIs, including IL2CPP delegate lifecycles and destroyed native objects ([#266](https://github.com/ifBars/S1API/pull/266), [#267](https://github.com/ifBars/S1API/pull/267), [#284](https://github.com/ifBars/S1API/pull/284), [#286](https://github.com/ifBars/S1API/pull/286)).
+
+## Compatibility and Validation
+
+- The 3.2.0 surface is additive relative to 3.1.15. Existing public contracts, stable identifiers, save schemas, and network payloads remain unchanged.
+- New controls continue to use the game's native authority, replication, synchronization, and persistence paths; consumer mods remain responsible for their own multiplayer authorization where the native API does not provide it.
+- Validated the release candidate with zero-warning Mono and IL2CPP builds, 707 passing Mono tests, 693 passing IL2CPP tests, 82.31% public API documentation coverage, and no ApiCompat breaks against 3.1.15. The hosted coverage analyzer remains a required PR gate.
+- The milestone's furniture, NPC, casino, temperature, trash, interaction-prompt, and jukebox features received targeted Mono and IL2CPP runtime validation during development. No proprietary game assemblies, generated wrappers, saves, logs, or test probes are included in this release.
+
+## Contributors
+
+- @Diffuin: native furniture variants, NPC building and event APIs, vehicle color metadata, temperature emitters, trash containers, jukebox controls, and the Casino building correction in [#264](https://github.com/ifBars/S1API/pull/264), [#265](https://github.com/ifBars/S1API/pull/265), [#266](https://github.com/ifBars/S1API/pull/266), [#267](https://github.com/ifBars/S1API/pull/267), [#268](https://github.com/ifBars/S1API/pull/268), [#276](https://github.com/ifBars/S1API/pull/276), [#283](https://github.com/ifBars/S1API/pull/283), [#284](https://github.com/ifBars/S1API/pull/284), and [#286](https://github.com/ifBars/S1API/pull/286).
+- @ifBars: integration and dual-runtime remediation across the milestone, dealer and custom-NPC compatibility fixes, NPC role properties, casino state APIs, and interaction prompts in [#271](https://github.com/ifBars/S1API/pull/271), [#277](https://github.com/ifBars/S1API/pull/277), [#278](https://github.com/ifBars/S1API/pull/278), [#279](https://github.com/ifBars/S1API/pull/279), [#280](https://github.com/ifBars/S1API/pull/280), [#281](https://github.com/ifBars/S1API/pull/281), and [#285](https://github.com/ifBars/S1API/pull/285).
+
+## Release Links
+
+- [Download S1API-Forked-3.2.0.zip](https://github.com/ifBars/S1API/releases/download/v3.2.0/S1API-Forked-3.2.0.zip)
+- [Full changelog](https://github.com/ifBars/S1API/compare/v3.1.15...v3.2.0)

--- a/S1API/S1API.cs
+++ b/S1API/S1API.cs
@@ -12,7 +12,7 @@ using S1API.Internal.Weather;
 using S1API.Lifecycle;
 using S1API.Map;
 
-[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.1.15", "KaBooMa")]
+[assembly: MelonInfo(typeof(S1API.S1API), "S1API (Forked by Bars)", "3.2.0", "KaBooMa")]
 [assembly: MelonPriority(Int32.MinValue)]
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 namespace S1API

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <LangVersion>latest</LangVersion>
-        <Version>3.1.15</Version>
+        <Version>3.2.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'MonoMelon'">


### PR DESCRIPTION
## Summary

- bump S1API project and Melon metadata to 3.2.0
- add curated milestone release notes with PR-linked contributor attribution
- prepare the immutable releases/3.2.0 branch for tagging after merge

## Validation

- MonoMelon build: 0 warnings, 0 errors
- MonoMelon tests: 707 passed
- Il2CppMelon build: 0 warnings, 0 errors
- Il2CppMelon tests: 693 passed
- DocFX: 0 errors; 4 known optional-reference warnings
- public API documentation coverage: 82.31% (3,439/4,178)
- ApiCompat against published v3.1.15: no breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed APIs for furniture, NPCs, casino games, temperature emitters, trash containers, interaction prompts, and jukeboxes.
  * Added additive API support and validation guarantees.

* **Bug Fixes**
  * Improved compatibility and runtime stability.

* **Documentation**
  * Added release notes, contributor credits, and download/changelog links.
  * Updated the release version to 3.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->