### PR TITLE
fix(npc): bound custom type discovery

### DIFF
--- a/S1API.Tests/Internal/Utils/ReflectionUtilsTests.cs
+++ b/S1API.Tests/Internal/Utils/ReflectionUtilsTests.cs
@@ -1,4 +1,7 @@
 using S1API.Internal.Utils;
+using S1API.Logging;
+using System.Reflection;
+using System.Reflection.Emit;
 
 namespace S1API.Tests.Internal.Utils;
 
@@ -36,6 +39,58 @@ public sealed class ReflectionUtilsTests
             ReflectionUtils.TryGetStaticFieldOrProperty(typeof(DerivedStaticShape), "RuntimeMember"));
     }
 
+    [Fact]
+    public void DerivedTypeScanIncludesAssembliesThatReferenceTheBaseAssembly()
+    {
+        Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        Assert.True(ReflectionUtils.CanContainTypesDerivedFrom(
+            typeof(ReflectionUtilsTests).Assembly,
+            typeof(ReflectionUtils).Assembly,
+            loadedAssemblies));
+    }
+
+    [Fact]
+    public void GetDerivedClassesFindsTypesInReferencingAssemblies()
+    {
+        Assert.Contains(
+            typeof(DerivedLogShape),
+            ReflectionUtils.GetDerivedClasses<Log>());
+    }
+
+    [Fact]
+    public void DerivedTypeScanExcludesAssembliesWithoutAReferencePathToTheBaseAssembly()
+    {
+        Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        Assert.False(ReflectionUtils.CanContainTypesDerivedFrom(
+            typeof(string).Assembly,
+            typeof(ReflectionUtils).Assembly,
+            loadedAssemblies));
+    }
+
+    [Fact]
+    public void DerivedTypeScanFollowsTransitiveAssemblyReferences()
+    {
+        var assemblyName = new AssemblyName($"S1API.ReflectionUtilsTests.Dynamic.{Guid.NewGuid():N}");
+        AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            assemblyName,
+            AssemblyBuilderAccess.Run);
+        ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name!);
+        moduleBuilder.DefineType(
+                "DynamicReflectionCandidate",
+                TypeAttributes.Public,
+                typeof(ReflectionCandidateBridge))
+            .CreateType();
+
+        Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+        Assert.True(ReflectionUtils.CanContainTypesDerivedFrom(
+            assemblyBuilder,
+            typeof(ReflectionUtils).Assembly,
+            loadedAssemblies));
+    }
+
     private sealed class MonoShape
     {
 #pragma warning disable CS0169
@@ -69,5 +124,17 @@ public sealed class ReflectionUtilsTests
 
     private sealed class DerivedStaticShape : BaseStaticShape
     {
+    }
+
+    public class ReflectionCandidateBridge
+    {
+    }
+
+    private sealed class DerivedLogShape : Log
+    {
+        public DerivedLogShape()
+            : base(nameof(DerivedLogShape))
+        {
+        }
     }
 }

--- a/S1API.Tests/Internal/Utils/ReflectionUtilsTests.cs
+++ b/S1API.Tests/Internal/Utils/ReflectionUtilsTests.cs
@@ -91,6 +91,46 @@ public sealed class ReflectionUtilsTests
             loadedAssemblies));
     }
 
+    [Fact]
+    public void DerivedTypeScanDoesNotFollowSameNameAssembliesWithDifferentIdentities()
+    {
+        string assemblyName = $"S1API.ReflectionUtilsTests.Duplicate.{Guid.NewGuid():N}";
+        AssemblyBuilder unrelatedAssembly = CreateDynamicAssembly(assemblyName, new Version(1, 0, 0, 0));
+        Type unrelatedType = unrelatedAssembly
+            .DefineDynamicModule(assemblyName)
+            .DefineType("UnrelatedType", TypeAttributes.Public)
+            .CreateType()!;
+
+        AssemblyBuilder relatedAssembly = CreateDynamicAssembly(assemblyName, new Version(2, 0, 0, 0));
+        relatedAssembly
+            .DefineDynamicModule(assemblyName)
+            .DefineType("RelatedType", TypeAttributes.Public, typeof(ReflectionCandidateBridge))
+            .CreateType();
+
+        AssemblyBuilder candidateAssembly = CreateDynamicAssembly(
+            $"S1API.ReflectionUtilsTests.Candidate.{Guid.NewGuid():N}",
+            new Version(1, 0, 0, 0));
+        ModuleBuilder candidateModule = candidateAssembly.DefineDynamicModule(candidateAssembly.GetName().Name!);
+        candidateModule
+            .DefineType("CandidateType", TypeAttributes.Public, unrelatedType)
+            .CreateType();
+
+        Assert.False(ReflectionUtils.CanContainTypesDerivedFrom(
+            candidateAssembly,
+            typeof(ReflectionUtils).Assembly,
+            AppDomain.CurrentDomain.GetAssemblies()));
+    }
+
+    private static AssemblyBuilder CreateDynamicAssembly(string name, Version version)
+    {
+        var assemblyName = new AssemblyName(name)
+        {
+            Version = version
+        };
+
+        return AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+    }
+
     private sealed class MonoShape
     {
 #pragma warning disable CS0169

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -1265,29 +1265,11 @@ namespace S1API.Entities
                     return null;
 
                 // Find the NPC type in loaded assemblies
-                System.Type? npcType = null;
-                var baseType = typeof(NPC);
-                var asms = AppDomain.CurrentDomain.GetAssemblies();
-                for (int ai = 0; ai < asms.Length && npcType == null; ai++)
-                {
-                    var asm = asms[ai];
-                    if (asm == baseType.Assembly)
-                        continue; // Skip S1API assembly (internal wrappers)
-
-                    System.Type[] types;
-                    try { types = asm.GetTypes(); } catch { continue; }
-                    for (int ti = 0; ti < types.Length; ti++)
-                    {
-                        var t = types[ti];
-                        if (t == null || t.IsAbstract || !baseType.IsAssignableFrom(t))
-                            continue;
-                        if (t.Name == typeName)
-                        {
-                            npcType = t;
-                            break;
-                        }
-                    }
-                }
+                var baseAssembly = typeof(NPC).Assembly;
+                System.Type? npcType = ReflectionUtils.GetDerivedClasses<NPC>()
+                    .FirstOrDefault(type =>
+                        type.Assembly != baseAssembly &&
+                        type.Name == typeName);
 
                 if (npcType == null)
                     return null;
@@ -1545,29 +1527,9 @@ namespace S1API.Entities
                 if (spawnables == null)
                     return;
 
-                var baseType = typeof(NPC);
-                var baseAssembly = baseType.Assembly;
-                var candidateTypes = new System.Collections.Generic.List<System.Type>();
-                var asms = AppDomain.CurrentDomain.GetAssemblies();
-                for (int ai = 0; ai < asms.Length; ai++)
-                {
-                    var asm = asms[ai];
-                    Type[] types;
-                    try { types = asm.GetTypes(); } catch { continue; }
-                    for (int ti = 0; ti < types.Length; ti++)
-                    {
-                        var t = types[ti];
-                        if (t == null || t.IsAbstract)
-                            continue;
-                        if (baseType.IsAssignableFrom(t))
-                        {
-                            // Skip internal S1API NPC wrappers; only pre-register mod-defined types
-                            if (t.Assembly == baseAssembly)
-                                continue;
-                            candidateTypes.Add(t);
-                        }
-                    }
-                }
+                var baseAssembly = typeof(NPC).Assembly;
+                var candidateTypes = ReflectionUtils.GetDerivedClasses<NPC>()
+                    .Where(type => type.Assembly != baseAssembly);
 
                 foreach (System.Type type in candidateTypes.OrderBy(
                              candidate => candidate.FullName,

--- a/S1API/Internal/Utils/ReflectionUtils.cs
+++ b/S1API/Internal/Utils/ReflectionUtils.cs
@@ -11,6 +11,8 @@ namespace S1API.Internal.Utils
     /// </summary>
     internal static class ReflectionUtils
     {
+        private static readonly Log Logger = new Log("ReflectionUtils");
+
         private const BindingFlags InstanceMemberFlags = BindingFlags.Public
             | BindingFlags.NonPublic
             | BindingFlags.Instance
@@ -29,9 +31,23 @@ namespace S1API.Internal.Utils
         internal static List<Type> GetDerivedClasses<TBaseClass>()
         {
             List<Type> derivedClasses = new List<Type>();
-            Assembly[] applicableAssemblies = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(assembly => !ShouldSkipAssembly(assembly))
+            Type baseType = typeof(TBaseClass);
+            Assembly baseAssembly = baseType.Assembly;
+            Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            IReadOnlyDictionary<string, Assembly[]> assembliesBySimpleName =
+                IndexAssembliesBySimpleName(loadedAssemblies);
+            Assembly[] applicableAssemblies = loadedAssemblies
+                .Where(assembly => assembly == baseAssembly || !ShouldSkipAssembly(assembly))
+                .Where(assembly => CanContainTypesDerivedFrom(
+                    assembly,
+                    baseAssembly.GetName(),
+                    assembliesBySimpleName))
                 .ToArray();
+
+            Logger.Debug(
+                $"[S1API][Reflection] Scanning {applicableAssemblies.Length} of {loadedAssemblies.Length} " +
+                $"loaded assemblies for types derived from '{baseType.FullName}'.");
+
             foreach (Assembly assembly in applicableAssemblies)
                 foreach (Type type in SafeGetTypes(assembly))
                 {
@@ -39,8 +55,8 @@ namespace S1API.Internal.Utils
                     {
                         if (type == null)
                             continue;
-                        if (typeof(TBaseClass).IsAssignableFrom(type)
-                            && type != typeof(TBaseClass)
+                        if (baseType.IsAssignableFrom(type)
+                            && type != baseType
                             && !type.IsAbstract)
                         {
                             derivedClasses.Add(type);
@@ -56,6 +72,93 @@ namespace S1API.Internal.Utils
                     }
                 }
             return derivedClasses;
+        }
+
+        internal static bool CanContainTypesDerivedFrom(
+            Assembly candidateAssembly,
+            Assembly baseAssembly,
+            IEnumerable<Assembly> loadedAssemblies)
+        {
+            if (candidateAssembly == baseAssembly)
+                return true;
+
+            IReadOnlyDictionary<string, Assembly[]> assembliesBySimpleName =
+                IndexAssembliesBySimpleName(loadedAssemblies);
+
+            return ReferencesAssemblyTransitively(
+                candidateAssembly,
+                baseAssembly.GetName(),
+                assembliesBySimpleName,
+                new HashSet<Assembly>());
+        }
+
+        private static IReadOnlyDictionary<string, Assembly[]> IndexAssembliesBySimpleName(
+            IEnumerable<Assembly> loadedAssemblies)
+        {
+            return loadedAssemblies
+                .Where(assembly => assembly != null)
+                .GroupBy(assembly => assembly.GetName().Name ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.ToArray(), StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static bool CanContainTypesDerivedFrom(
+            Assembly candidateAssembly,
+            AssemblyName baseAssemblyName,
+            IReadOnlyDictionary<string, Assembly[]> assembliesBySimpleName)
+        {
+            if (AssemblyName.ReferenceMatchesDefinition(candidateAssembly.GetName(), baseAssemblyName))
+                return true;
+
+            return ReferencesAssemblyTransitively(
+                candidateAssembly,
+                baseAssemblyName,
+                assembliesBySimpleName,
+                new HashSet<Assembly>());
+        }
+
+        private static bool ReferencesAssemblyTransitively(
+            Assembly candidateAssembly,
+            AssemblyName baseAssemblyName,
+            IReadOnlyDictionary<string, Assembly[]> assembliesBySimpleName,
+            HashSet<Assembly> visitedAssemblies)
+        {
+            if (!visitedAssemblies.Add(candidateAssembly))
+                return false;
+
+            AssemblyName[] referencedAssemblies;
+            try
+            {
+                referencedAssemblies = candidateAssembly.GetReferencedAssemblies();
+            }
+            catch
+            {
+                return false;
+            }
+
+            foreach (AssemblyName referencedAssembly in referencedAssemblies)
+            {
+                if (AssemblyName.ReferenceMatchesDefinition(referencedAssembly, baseAssemblyName))
+                    return true;
+
+                string referencedName = referencedAssembly.Name ?? string.Empty;
+                if (!assembliesBySimpleName.TryGetValue(referencedName, out Assembly[]? loadedReferences)
+                    || loadedReferences == null)
+                    continue;
+
+                foreach (Assembly loadedReference in loadedReferences)
+                {
+                    if (ReferencesAssemblyTransitively(
+                            loadedReference,
+                            baseAssemblyName,
+                            assembliesBySimpleName,
+                            visitedAssemblies))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -137,16 +240,26 @@ namespace S1API.Internal.Utils
         /// <returns>The types that were successfully loaded from the assembly.</returns>
         private static IEnumerable<Type> SafeGetTypes(Assembly asm)
         {
+            string assemblyName = asm.FullName ?? asm.GetName().Name ?? "<unknown>";
+            Logger.Debug($"[S1API][Reflection] About to enumerate types in '{assemblyName}'.");
+
             try
             {
-                return asm.GetTypes();
+                Type[] types = asm.GetTypes();
+                Logger.Debug(
+                    $"[S1API][Reflection] Enumerated {types.Length} types in '{assemblyName}'.");
+                return types;
             }
             catch (ReflectionTypeLoadException ex)
             {
-                return ex.Types.Where(t => t != null)!.Cast<Type>();
+                Type[] loadedTypes = ex.Types.Where(type => type != null).Cast<Type>().ToArray();
+                Logger.Debug(
+                    $"[S1API][Reflection] Partially enumerated {loadedTypes.Length} types in '{assemblyName}'.");
+                return loadedTypes;
             }
             catch
             {
+                Logger.Debug($"[S1API][Reflection] Failed to enumerate types in '{assemblyName}'.");
                 return Array.Empty<Type>();
             }
         }

--- a/S1API/Internal/Utils/ReflectionUtils.cs
+++ b/S1API/Internal/Utils/ReflectionUtils.cs
@@ -106,7 +106,7 @@ namespace S1API.Internal.Utils
             AssemblyName baseAssemblyName,
             IReadOnlyDictionary<string, Assembly[]> assembliesBySimpleName)
         {
-            if (AssemblyName.ReferenceMatchesDefinition(candidateAssembly.GetName(), baseAssemblyName))
+            if (AssemblyIdentityMatches(candidateAssembly.GetName(), baseAssemblyName))
                 return true;
 
             return ReferencesAssemblyTransitively(
@@ -137,7 +137,7 @@ namespace S1API.Internal.Utils
 
             foreach (AssemblyName referencedAssembly in referencedAssemblies)
             {
-                if (AssemblyName.ReferenceMatchesDefinition(referencedAssembly, baseAssemblyName))
+                if (AssemblyIdentityMatches(referencedAssembly, baseAssemblyName))
                     return true;
 
                 string referencedName = referencedAssembly.Name ?? string.Empty;
@@ -147,6 +147,9 @@ namespace S1API.Internal.Utils
 
                 foreach (Assembly loadedReference in loadedReferences)
                 {
+                    if (!AssemblyIdentityMatches(loadedReference.GetName(), referencedAssembly))
+                        continue;
+
                     if (ReferencesAssemblyTransitively(
                             loadedReference,
                             baseAssemblyName,
@@ -160,6 +163,14 @@ namespace S1API.Internal.Utils
 
             return false;
         }
+
+        private static bool AssemblyIdentityMatches(
+            AssemblyName referenceAssemblyName,
+            AssemblyName definitionAssemblyName) =>
+            string.Equals(
+                referenceAssemblyName.FullName,
+                definitionAssemblyName.FullName,
+                StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// INTERNAL: Gets all types by their name.


### PR DESCRIPTION
## Summary

- bound derived-type discovery to loaded assemblies with a reference path to the requested base assembly
- route both NPC discovery paths through the bounded reflection helper instead of calling `Assembly.GetTypes()` across the entire AppDomain
- add verbose before/after assembly enumeration markers for fatal-crash diagnosis
- preserve transitive extension assemblies and ordinary `ReflectionTypeLoadException` recovery

## Root cause

NPC prefab warmup enumerated every loaded assembly with `Assembly.GetTypes()`. On the reported MelonLoader 0.7.3 IL2CPP setup, CoreCLR terminated inside `RuntimeModule.GetTypes()` with `0x80131506`. Because this is a fatal runtime error rather than a managed exception, the surrounding `try/catch` cannot recover.

This change removes generated game assemblies and unrelated mods from the scan before type enumeration. It does not claim that S1API owns the underlying malformed/runtime type state.

## Validation

- `dotnet test S1API.Tests/S1API.Tests.csproj -c MonoMelon --no-restore -p:AutomateLocalDeployment=false` — 711 passed
- `dotnet test S1API.Tests/S1API.Tests.csproj -c Il2CppMelon --no-restore -p:AutomateLocalDeployment=false` — 697 passed
- focused `ReflectionUtilsTests` — 7 passed on each runtime configuration
- `git diff --check` — clean

The exact Discord reporter assembly/mod set is not available locally, so the fatal crash itself has not been directly reproduced. The verbose markers are intended to identify the precise remaining assembly if the bounded candidate set still reaches the fatal CLR condition.

## Upstream assessment

MelonLoader 0.7.3 is currently the latest release and already includes Il2CppInterop `1.5.1-ci.845`. Current `alpha-development` uses the same Il2CppInterop revision. The older MelonLoader type-prefixing fixes predate 0.7.1, and the broken `SystemTypeFromIl2CppType` patch was removed before 0.7.2. An upstream MelonLoader/Il2CppInterop issue should wait for the exact failing assembly and a minimal reproduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery of NPC-derived types across directly and indirectly referenced assemblies.
  * NPC network-spawned wrappers and prefab registration now handle assembly-loading scenarios more reliably.
  * Assemblies that cannot be safely inspected, or whose identities do not match, are excluded without interrupting type discovery.

* **Diagnostics**
  * Added clearer logging for assembly scanning and type enumeration, including successful, partial, and failed inspections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->