### PR TITLE
feat(deliveries): expose loading dock state and vehicle occupancy

### DIFF
--- a/S1API.Tests/Deliveries/LoadingDockApiTests.cs
+++ b/S1API.Tests/Deliveries/LoadingDockApiTests.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using S1API.Deliveries;
+using S1API.Items;
+using S1API.Property;
+using S1API.Vehicles;
+
+#if IL2CPPMELON
+using S1Delivery = Il2CppScheduleOne.Delivery;
+#elif MONOMELON
+using S1Delivery = ScheduleOne.Delivery;
+#endif
+
+namespace S1API.Tests.Deliveries;
+
+public sealed class LoadingDockApiTests
+{
+    [Fact]
+    public void NativeTransitionPatchPointsExistInTargetRuntime()
+    {
+        const BindingFlags flags =
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        Assert.NotNull(typeof(S1Delivery.LoadingDock).GetMethod(
+            "SetOccupant",
+            flags));
+        Assert.NotNull(typeof(S1Delivery.LoadingDock).GetMethod(
+            nameof(S1Delivery.LoadingDock.SetStaticOccupant),
+            flags));
+        Assert.NotNull(typeof(S1Delivery.LoadingDock).GetMethod(
+            "set_IsAcceptingItems",
+            flags));
+    }
+
+    [Fact]
+    public void WrapperSurfaceIsReadOnlyAndManaged()
+    {
+        Assert.Empty(typeof(LoadingDock).GetConstructors(
+            BindingFlags.Public | BindingFlags.Instance));
+        Assert.All(
+            typeof(LoadingDock).GetProperties(BindingFlags.Public | BindingFlags.Instance),
+            property => Assert.Null(property.SetMethod));
+
+        Assert.Equal(typeof(string), GetProperty(nameof(LoadingDock.GUID)).PropertyType);
+        Assert.Equal(typeof(string), GetProperty(nameof(LoadingDock.Name)).PropertyType);
+        Assert.Equal(typeof(PropertyWrapper), GetProperty(nameof(LoadingDock.Property)).PropertyType);
+        Assert.Equal(
+            typeof(IReadOnlyList<ItemSlotInstance>),
+            GetProperty(nameof(LoadingDock.InputSlots)).PropertyType);
+        Assert.Equal(
+            typeof(IReadOnlyList<ItemSlotInstance>),
+            GetProperty(nameof(LoadingDock.OutputSlots)).PropertyType);
+        Assert.Equal(typeof(LandVehicle), GetProperty(nameof(LoadingDock.DynamicOccupant)).PropertyType);
+        Assert.Equal(typeof(LandVehicle), GetProperty(nameof(LoadingDock.StaticOccupant)).PropertyType);
+
+        Assert.DoesNotContain(
+            typeof(LoadingDock).GetMembers(BindingFlags.Public | BindingFlags.Instance),
+            ExposesNativeDeliveryType);
+    }
+
+    [Fact]
+    public void PropertyAndDeliveryExposeLoadingDockNavigation()
+    {
+        Assert.Equal(
+            typeof(IReadOnlyList<LoadingDock>),
+            typeof(PropertyWrapper).GetProperty(nameof(PropertyWrapper.LoadingDocks))!.PropertyType);
+        Assert.Equal(
+            typeof(LoadingDock),
+            typeof(Delivery).GetProperty(nameof(Delivery.LoadingDock))!.PropertyType);
+    }
+
+    [Fact]
+    public void EventsExposeManagedPreviousAndCurrentValues()
+    {
+        Assert.Equal(
+            typeof(Action<LandVehicle?, LandVehicle?>),
+            GetEvent(nameof(LoadingDock.DynamicOccupantChanged)).EventHandlerType);
+        Assert.Equal(
+            typeof(Action<LandVehicle?, LandVehicle?>),
+            GetEvent(nameof(LoadingDock.StaticOccupantChanged)).EventHandlerType);
+        Assert.Equal(
+            typeof(Action<bool, bool>),
+            GetEvent(nameof(LoadingDock.AcceptingItemsChanged)).EventHandlerType);
+    }
+
+    [Fact]
+    public void ManagedNotificationsSuppressNoOpsAndIsolateSubscribers()
+    {
+        var nativeDock = TestObjectFactory.CreateUninitialized<S1Delivery.LoadingDock>();
+        var dock = new LoadingDock(nativeDock);
+        var previous = TestObjectFactory.CreateUninitialized<LandVehicle>();
+        var current = TestObjectFactory.CreateUninitialized<LandVehicle>();
+        int dynamicCalls = 0;
+        int staticCalls = 0;
+        int acceptingCalls = 0;
+
+        dock.DynamicOccupantChanged += (_, _) => throw new InvalidOperationException("expected");
+        dock.DynamicOccupantChanged += (observedPrevious, observedCurrent) =>
+        {
+            Assert.Same(previous, observedPrevious);
+            Assert.Same(current, observedCurrent);
+            dynamicCalls++;
+        };
+        dock.StaticOccupantChanged += (_, _) => staticCalls++;
+        dock.AcceptingItemsChanged += (observedPrevious, observedCurrent) =>
+        {
+            Assert.False(observedPrevious);
+            Assert.True(observedCurrent);
+            acceptingCalls++;
+        };
+
+        dock.NotifyDynamicOccupantChanged(previous, previous);
+        dock.NotifyDynamicOccupantChanged(previous, current);
+        dock.NotifyStaticOccupantChanged(current, current);
+        dock.NotifyStaticOccupantChanged(previous, current);
+        dock.NotifyAcceptingItemsChanged(false, false);
+        dock.NotifyAcceptingItemsChanged(false, true);
+
+        Assert.Equal(1, dynamicCalls);
+        Assert.Equal(1, staticCalls);
+        Assert.Equal(1, acceptingCalls);
+    }
+
+    private static PropertyInfo GetProperty(string name) =>
+        typeof(LoadingDock).GetProperty(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static EventInfo GetEvent(string name) =>
+        typeof(LoadingDock).GetEvent(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static bool ExposesNativeDeliveryType(MemberInfo member)
+    {
+        IEnumerable<Type> types = member switch
+        {
+            PropertyInfo property => new[] { property.PropertyType },
+            EventInfo eventInfo when eventInfo.EventHandlerType != null =>
+                new[] { eventInfo.EventHandlerType },
+            MethodInfo method => new[] { method.ReturnType }
+                .Concat(method.GetParameters().Select(parameter => parameter.ParameterType)),
+            _ => Array.Empty<Type>()
+        };
+
+        return types
+            .SelectMany(ExpandType)
+            .Any(type => type.Namespace?.Contains(
+                "ScheduleOne.Delivery",
+                StringComparison.Ordinal) == true);
+    }
+
+    private static IEnumerable<Type> ExpandType(Type root)
+    {
+        yield return root;
+
+        if (root.HasElementType && root.GetElementType() is Type elementType)
+        {
+            foreach (Type nested in ExpandType(elementType))
+                yield return nested;
+        }
+
+        foreach (Type argument in root.GetGenericArguments())
+        {
+            foreach (Type nested in ExpandType(argument))
+                yield return nested;
+        }
+    }
+}
+
+internal static class LoadingDockApiCompileFixture
+{
+    internal static void Observe(
+        PropertyWrapper property,
+        Delivery delivery,
+        LoadingDock dock)
+    {
+        IReadOnlyList<LoadingDock> propertyDocks = property.LoadingDocks;
+        LoadingDock? selectedDock = delivery.LoadingDock;
+        IReadOnlyList<ItemSlotInstance> inputSlots = dock.InputSlots;
+        IReadOnlyList<ItemSlotInstance> outputSlots = dock.OutputSlots;
+        LandVehicle? dynamicOccupant = dock.DynamicOccupant;
+        LandVehicle? staticOccupant = dock.StaticOccupant;
+
+        Action<LandVehicle?, LandVehicle?> vehicleHandler = (_, _) => { };
+        Action<bool, bool> acceptingHandler = (_, _) => { };
+        dock.DynamicOccupantChanged += vehicleHandler;
+        dock.StaticOccupantChanged += vehicleHandler;
+        dock.AcceptingItemsChanged += acceptingHandler;
+        dock.DynamicOccupantChanged -= vehicleHandler;
+        dock.StaticOccupantChanged -= vehicleHandler;
+        dock.AcceptingItemsChanged -= acceptingHandler;
+
+        _ = propertyDocks;
+        _ = selectedDock;
+        _ = inputSlots;
+        _ = outputSlots;
+        _ = dynamicOccupant;
+        _ = staticOccupant;
+    }
+}

--- a/S1API/Deliveries/Delivery.cs
+++ b/S1API/Deliveries/Delivery.cs
@@ -52,6 +52,27 @@ namespace S1API.Deliveries
         public int LoadingDockIndex => NativeDelivery.LoadingDockIndex;
 
         /// <summary>
+        /// Gets the selected destination loading dock, or <see langword="null"/> while it is unavailable.
+        /// </summary>
+        public LoadingDock? LoadingDock
+        {
+            get
+            {
+                try
+                {
+                    var loadingDock = NativeDelivery.LoadingDock;
+                    return loadingDock == null
+                        ? null
+                        : global::S1API.Deliveries.LoadingDock.Wrap(loadingDock);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the wrapped destination property, or <see langword="null"/> while it is unavailable.
         /// </summary>
         public PropertyWrapper? Destination

--- a/S1API/Deliveries/LoadingDock.cs
+++ b/S1API/Deliveries/LoadingDock.cs
@@ -1,0 +1,245 @@
+#if IL2CPPMELON
+using S1Delivery = Il2CppScheduleOne.Delivery;
+using S1ItemSlotList = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.ItemFramework.ItemSlot>;
+#elif MONOMELON
+using S1Delivery = ScheduleOne.Delivery;
+using S1ItemSlotList = System.Collections.Generic.List<ScheduleOne.ItemFramework.ItemSlot>;
+#endif
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using S1API.Items;
+using S1API.Lifecycle;
+using S1API.Logging;
+using S1API.Property;
+using S1API.Vehicles;
+
+namespace S1API.Deliveries
+{
+    /// <summary>
+    /// Provides read-only access to a property's native loading dock.
+    /// </summary>
+    /// <remarks>
+    /// Scalar properties reflect the live dock state. Slot collections are immutable
+    /// snapshots containing live <see cref="ItemSlotInstance"/> wrappers. Instances are
+    /// cached for the loaded scene so property and delivery lookups share event subscriptions.
+    /// Resolve the dock again after a scene or save transition. Events report state observed
+    /// by the local peer and do not add network replication.
+    /// </remarks>
+    public sealed class LoadingDock
+    {
+        private static readonly Log Logger = new Log("LoadingDock");
+        private static readonly Dictionary<int, LoadingDock> Cache = new Dictionary<int, LoadingDock>();
+        private static readonly IReadOnlyList<ItemSlotInstance> EmptySlots =
+            new ReadOnlyCollection<ItemSlotInstance>(Array.Empty<ItemSlotInstance>());
+        private static bool _lifecycleHooked;
+
+        internal LoadingDock(S1Delivery.LoadingDock loadingDock)
+        {
+            S1LoadingDock = loadingDock ?? throw new ArgumentNullException(nameof(loadingDock));
+        }
+
+        /// <summary>
+        /// INTERNAL: Gets the native loading dock represented by this wrapper.
+        /// </summary>
+        internal S1Delivery.LoadingDock S1LoadingDock { get; }
+
+        /// <summary>
+        /// Gets the stable GUID assigned to this loading dock.
+        /// </summary>
+        public string GUID => S1LoadingDock.GUID.ToString();
+
+        /// <summary>
+        /// Gets the display name assigned by the owning property.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                try
+                {
+                    return S1LoadingDock.Name ?? string.Empty;
+                }
+                catch
+                {
+                    return S1LoadingDock.gameObject?.name ?? string.Empty;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the owning property, or <see langword="null"/> while it is unavailable.
+        /// </summary>
+        public PropertyWrapper? Property
+        {
+            get
+            {
+                try
+                {
+                    var property = S1LoadingDock.ParentProperty;
+                    return property == null ? null : new PropertyWrapper(property);
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets an immutable snapshot of the dock's input slots.
+        /// </summary>
+        /// <remarks>
+        /// The collection cannot be modified, but each contained slot retains the behavior
+        /// of the existing <see cref="ItemSlotInstance"/> API.
+        /// </remarks>
+        public IReadOnlyList<ItemSlotInstance> InputSlots =>
+            SnapshotSlots(S1LoadingDock.InputSlots);
+
+        /// <summary>
+        /// Gets an immutable snapshot of the dock's output slots.
+        /// </summary>
+        /// <remarks>
+        /// The collection cannot be modified, but each contained slot retains the behavior
+        /// of the existing <see cref="ItemSlotInstance"/> API.
+        /// </remarks>
+        public IReadOnlyList<ItemSlotInstance> OutputSlots =>
+            SnapshotSlots(S1LoadingDock.OutputSlots);
+
+        /// <summary>
+        /// Gets whether the dock currently accepts incoming transit items.
+        /// </summary>
+        public bool IsAcceptingItems => S1LoadingDock.IsAcceptingItems;
+
+        /// <summary>
+        /// Gets whether the dock has been removed from transit routing.
+        /// </summary>
+        public bool IsDestroyed => S1LoadingDock.IsDestroyed;
+
+        /// <summary>
+        /// Gets whether a dynamic or static vehicle currently occupies the dock.
+        /// </summary>
+        public bool IsInUse => S1LoadingDock.IsInUse;
+
+        /// <summary>
+        /// Gets the vehicle detected in the dock, or <see langword="null"/> when none is present.
+        /// </summary>
+        public LandVehicle? DynamicOccupant =>
+            VehicleRegistry.Wrap(S1LoadingDock.DynamicOccupant);
+
+        /// <summary>
+        /// Gets the delivery vehicle assigned to the dock, or <see langword="null"/> when none is assigned.
+        /// </summary>
+        public LandVehicle? StaticOccupant =>
+            VehicleRegistry.Wrap(S1LoadingDock.StaticOccupant);
+
+        /// <summary>
+        /// Raised after the dynamically detected vehicle changes.
+        /// </summary>
+        public event Action<LandVehicle?, LandVehicle?>? DynamicOccupantChanged;
+
+        /// <summary>
+        /// Raised after the assigned delivery vehicle changes.
+        /// </summary>
+        public event Action<LandVehicle?, LandVehicle?>? StaticOccupantChanged;
+
+        /// <summary>
+        /// Raised after the accepting-items state changes.
+        /// </summary>
+        public event Action<bool, bool>? AcceptingItemsChanged;
+
+        internal static LoadingDock Wrap(S1Delivery.LoadingDock native)
+        {
+            EnsureLifecycleHook();
+            int key = native.GetInstanceID();
+            if (!Cache.TryGetValue(key, out LoadingDock? loadingDock)
+                || loadingDock.S1LoadingDock != native)
+            {
+                loadingDock = new LoadingDock(native);
+                Cache[key] = loadingDock;
+            }
+
+            return loadingDock;
+        }
+
+        internal void NotifyDynamicOccupantChanged(LandVehicle? previous, LandVehicle? current)
+        {
+            if (ReferenceEquals(previous, current))
+                return;
+
+            Invoke(DynamicOccupantChanged, previous, current, nameof(DynamicOccupantChanged));
+        }
+
+        internal void NotifyStaticOccupantChanged(LandVehicle? previous, LandVehicle? current)
+        {
+            if (ReferenceEquals(previous, current))
+                return;
+
+            Invoke(StaticOccupantChanged, previous, current, nameof(StaticOccupantChanged));
+        }
+
+        internal void NotifyAcceptingItemsChanged(bool previous, bool current)
+        {
+            if (previous == current)
+                return;
+
+            Invoke(AcceptingItemsChanged, previous, current, nameof(AcceptingItemsChanged));
+        }
+
+        private static IReadOnlyList<ItemSlotInstance> SnapshotSlots(S1ItemSlotList? nativeSlots)
+        {
+            if (nativeSlots == null || nativeSlots.Count == 0)
+                return EmptySlots;
+
+            var slots = new List<ItemSlotInstance>(nativeSlots.Count);
+            for (int i = 0; i < nativeSlots.Count; i++)
+            {
+                if (nativeSlots[i] != null)
+                    slots.Add(new ItemSlotInstance(nativeSlots[i]));
+            }
+
+            return slots.Count == 0
+                ? EmptySlots
+                : new ReadOnlyCollection<ItemSlotInstance>(slots);
+        }
+
+        private static void Invoke<T>(
+            Action<T, T>? handlers,
+            T previous,
+            T current,
+            string eventName)
+        {
+            if (handlers == null)
+                return;
+
+            foreach (Action<T, T> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(previous, current);
+                }
+                catch (Exception ex)
+                {
+                    try
+                    {
+                        Logger.Warning($"A {eventName} subscriber failed: {ex.Message}");
+                    }
+                    catch
+                    {
+                        // Logging must not prevent the remaining subscribers from running.
+                    }
+                }
+            }
+        }
+
+        private static void EnsureLifecycleHook()
+        {
+            if (_lifecycleHooked)
+                return;
+
+            GameLifecycle.OnPreSceneChange += Cache.Clear;
+            _lifecycleHooked = true;
+        }
+    }
+}

--- a/S1API/Internal/Deliveries/LoadingDockEventBridge.cs
+++ b/S1API/Internal/Deliveries/LoadingDockEventBridge.cs
@@ -1,0 +1,56 @@
+#if IL2CPPMELON
+using S1Delivery = Il2CppScheduleOne.Delivery;
+using S1Vehicles = Il2CppScheduleOne.Vehicles;
+#elif MONOMELON
+using S1Delivery = ScheduleOne.Delivery;
+using S1Vehicles = ScheduleOne.Vehicles;
+#endif
+
+using S1API.Deliveries;
+using S1API.Vehicles;
+
+namespace S1API.Internal.Deliveries
+{
+    /// <summary>
+    /// Converts native loading-dock state transitions into managed wrapper events.
+    /// </summary>
+    internal static class LoadingDockEventBridge
+    {
+        internal static void NotifyDynamicOccupantChanged(
+            S1Delivery.LoadingDock native,
+            S1Vehicles.LandVehicle? previous,
+            S1Vehicles.LandVehicle? current)
+        {
+            if (previous == current)
+                return;
+
+            LoadingDock.Wrap(native).NotifyDynamicOccupantChanged(
+                VehicleRegistry.Wrap(previous),
+                VehicleRegistry.Wrap(current));
+        }
+
+        internal static void NotifyStaticOccupantChanged(
+            S1Delivery.LoadingDock native,
+            S1Vehicles.LandVehicle? previous,
+            S1Vehicles.LandVehicle? current)
+        {
+            if (previous == current)
+                return;
+
+            LoadingDock.Wrap(native).NotifyStaticOccupantChanged(
+                VehicleRegistry.Wrap(previous),
+                VehicleRegistry.Wrap(current));
+        }
+
+        internal static void NotifyAcceptingItemsChanged(
+            S1Delivery.LoadingDock native,
+            bool previous,
+            bool current)
+        {
+            if (previous == current)
+                return;
+
+            LoadingDock.Wrap(native).NotifyAcceptingItemsChanged(previous, current);
+        }
+    }
+}

--- a/S1API/Internal/Patches/LoadingDockPatches.cs
+++ b/S1API/Internal/Patches/LoadingDockPatches.cs
@@ -1,0 +1,83 @@
+#if IL2CPPMELON
+using S1Delivery = Il2CppScheduleOne.Delivery;
+using S1Vehicles = Il2CppScheduleOne.Vehicles;
+#elif MONOMELON
+using S1Delivery = ScheduleOne.Delivery;
+using S1Vehicles = ScheduleOne.Vehicles;
+#endif
+
+using HarmonyLib;
+using S1API.Internal.Deliveries;
+
+namespace S1API.Internal.Patches
+{
+    /// <summary>
+    /// Observes native loading-dock transitions without replacing their behavior.
+    /// </summary>
+    [HarmonyPatch(typeof(S1Delivery.LoadingDock))]
+    internal static class LoadingDockPatches
+    {
+        [HarmonyPatch("SetOccupant")]
+        [HarmonyPrefix]
+        private static void SetOccupantPrefix(
+            S1Delivery.LoadingDock __instance,
+            out S1Vehicles.LandVehicle? __state)
+        {
+            __state = __instance.DynamicOccupant;
+        }
+
+        [HarmonyPatch("SetOccupant")]
+        [HarmonyPostfix]
+        private static void SetOccupantPostfix(
+            S1Delivery.LoadingDock __instance,
+            S1Vehicles.LandVehicle? __state)
+        {
+            LoadingDockEventBridge.NotifyDynamicOccupantChanged(
+                __instance,
+                __state,
+                __instance.DynamicOccupant);
+        }
+
+        [HarmonyPatch(nameof(S1Delivery.LoadingDock.SetStaticOccupant))]
+        [HarmonyPrefix]
+        private static void SetStaticOccupantPrefix(
+            S1Delivery.LoadingDock __instance,
+            out S1Vehicles.LandVehicle? __state)
+        {
+            __state = __instance.StaticOccupant;
+        }
+
+        [HarmonyPatch(nameof(S1Delivery.LoadingDock.SetStaticOccupant))]
+        [HarmonyPostfix]
+        private static void SetStaticOccupantPostfix(
+            S1Delivery.LoadingDock __instance,
+            S1Vehicles.LandVehicle? __state)
+        {
+            LoadingDockEventBridge.NotifyStaticOccupantChanged(
+                __instance,
+                __state,
+                __instance.StaticOccupant);
+        }
+
+        [HarmonyPatch(nameof(S1Delivery.LoadingDock.IsAcceptingItems), MethodType.Setter)]
+        [HarmonyPrefix]
+        private static void SetAcceptingItemsPrefix(
+            S1Delivery.LoadingDock __instance,
+            out bool __state)
+        {
+            __state = __instance.IsAcceptingItems;
+        }
+
+        [HarmonyPatch(nameof(S1Delivery.LoadingDock.IsAcceptingItems), MethodType.Setter)]
+        [HarmonyPostfix]
+        private static void SetAcceptingItemsPostfix(
+            S1Delivery.LoadingDock __instance,
+            bool __state)
+        {
+            LoadingDockEventBridge.NotifyAcceptingItemsChanged(
+                __instance,
+                __state,
+                __instance.IsAcceptingItems);
+        }
+    }
+}

--- a/S1API/Property/PropertyWrapper.cs
+++ b/S1API/Property/PropertyWrapper.cs
@@ -1,6 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Reflection;
+using S1API.Deliveries;
 using S1API.Logging;
 using UnityEngine;
 using S1API.Internal.Utils;
@@ -20,6 +22,8 @@ namespace S1API.Property
     public class PropertyWrapper : BaseProperty
     {
         private static readonly Log Logger = new Log("PropertyWrapper");
+        private static readonly IReadOnlyList<LoadingDock> EmptyLoadingDocks =
+            new ReadOnlyCollection<LoadingDock>(System.Array.Empty<LoadingDock>());
 
         /// <summary>
         /// A readonly backing field encapsulating the core property instance
@@ -139,6 +143,28 @@ namespace S1API.Property
         /// </summary>
         public int LoadingDockCount =>
             InnerProperty.LoadingDockCount;
+
+        /// <summary>
+        /// Gets an immutable snapshot of the loading docks assigned to this property.
+        /// </summary>
+        public IReadOnlyList<LoadingDock> LoadingDocks
+        {
+            get
+            {
+                var nativeDocks = InnerProperty.LoadingDocks;
+                if (nativeDocks == null || nativeDocks.Length == 0)
+                    return EmptyLoadingDocks;
+
+                var docks = new List<LoadingDock>(nativeDocks.Length);
+                for (int i = 0; i < nativeDocks.Length; i++)
+                {
+                    if (nativeDocks[i] != null)
+                        docks.Add(LoadingDock.Wrap(nativeDocks[i]));
+                }
+
+                return new ReadOnlyCollection<LoadingDock>(docks);
+            }
+        }
 
         /// <summary>
         /// Gets the default rotation value for the property.

--- a/S1API/Vehicles/VehicleRegistry.cs
+++ b/S1API/Vehicles/VehicleRegistry.cs
@@ -205,7 +205,7 @@ namespace S1API.Vehicles
                 _cache.Remove(gameVehicle);
         }
 
-        private static LandVehicle? Wrap(S1Vehicles.LandVehicle? veh)
+        internal static LandVehicle? Wrap(S1Vehicles.LandVehicle? veh)
         {
             if (veh == null)
                 return null;

--- a/S1API/docs/delivery-system.md
+++ b/S1API/docs/delivery-system.md
@@ -1,6 +1,6 @@
 # Deliveries
 
-`S1API.Deliveries` provides read-only, cross-runtime wrappers around supplier deliveries and their order-history receipts. It is intended for mods that need to observe delivery state without depending on Schedule I's native delivery, vehicle, UI, or networking types.
+`S1API.Deliveries` provides read-only, cross-runtime wrappers around supplier deliveries, property loading docks, and order-history receipts. It is intended for mods that need to observe delivery state without depending on Schedule I's native delivery, vehicle, UI, or networking types.
 
 This API describes property/shop deliveries managed by the game's delivery app. Supplier dead-drop orders are a separate flow represented by `NPCSupplier.Status`, `MinutesUntilDeadDropReady`, and `OnDeadDropReady`. Customer drop-off points are another separate system documented in [Delivery Location Registry](delivery-location-registry.md).
 
@@ -57,7 +57,8 @@ Registry results reflect the local peer's loaded state. Query after the world ha
 
 The delivery surface is deliberately split by concern:
 
-- `Delivery`: A read-only live view of an active supplier delivery. It exposes `Id`, `StoreName`, `DestinationCode`, the wrapped `Destination`, `LoadingDockIndex`, `Status`, `MinutesUntilArrival`, `Items`, `Shop`, and `ActiveVehicle`. `Shop` or `Destination` may be unavailable during world setup, while `ActiveVehicle` is normally unavailable until arrival.
+- `Delivery`: A read-only live view of an active supplier delivery. It exposes `Id`, `StoreName`, `DestinationCode`, the wrapped `Destination` and `LoadingDock`, `LoadingDockIndex`, `Status`, `MinutesUntilArrival`, `Items`, `Shop`, and `ActiveVehicle`. `Shop`, `Destination`, or `LoadingDock` may be unavailable during world setup, while `ActiveVehicle` is normally unavailable until arrival.
+- `LoadingDock`: A read-only live view of one property dock, including stable identity, transit slots, accepting/destroyed state, and its dynamic and delivery-vehicle occupants.
 - `DeliveryItem`: An immutable `ItemId` and `Quantity` entry from an order.
 - `DeliveryReceipt`: An immutable delivery order-details snapshot with the delivery identity, destination, loading dock, and ordered items. `GetHistory()` returns receipts that were recorded in order history.
 - `DeliveryStatus`: The public delivery lifecycle state.
@@ -67,6 +68,36 @@ The delivery surface is deliberately split by concern:
 `Delivery.Items` returns an immutable snapshot, while its scalar properties reflect the live delivery. Call `Delivery.ToReceipt()` when you need to retain an immutable snapshot of the current order.
 
 The wrappers do not expose Schedule I's native `DeliveryInstance`, delivery shop, or delivery-vehicle component. Native delivery creation and lifecycle transitions remain hidden so mods cannot bypass server authority. Related `Shop`, `PropertyWrapper`, and `LandVehicle` objects use their existing S1API wrappers and retain the capabilities documented by those APIs.
+
+## Loading Docks
+
+Enumerate all docks owned by a property through `PropertyWrapper.LoadingDocks`, or follow the selected dock directly from an active delivery:
+
+```csharp
+using S1API.Deliveries;
+
+var deliveries = DeliveryRegistry.GetAll();
+Delivery? delivery = deliveries.Count == 0 ? null : deliveries[0];
+LoadingDock? dock = delivery?.LoadingDock;
+if (dock is not null)
+{
+    MelonLoader.MelonLogger.Msg(
+        $"{dock.Name} ({dock.GUID}): {dock.OutputSlots.Count} output slots");
+
+    dock.DynamicOccupantChanged += (previous, current) =>
+        MelonLoader.MelonLogger.Msg(
+            $"Detected vehicle: {previous?.GUID ?? "none"} -> {current?.GUID ?? "none"}");
+    dock.StaticOccupantChanged += (previous, current) =>
+        MelonLoader.MelonLogger.Msg(
+            $"Delivery vehicle: {previous?.GUID ?? "none"} -> {current?.GUID ?? "none"}");
+    dock.AcceptingItemsChanged += (previous, current) =>
+        MelonLoader.MelonLogger.Msg($"Accepting items: {previous} -> {current}");
+}
+```
+
+`InputSlots` and `OutputSlots` are immutable collection snapshots containing live `ItemSlotInstance` wrappers. `DynamicOccupant` represents a nearby stopped vehicle detected by the dock. `StaticOccupant` represents the delivery vehicle assigned during supplier-delivery arrival. `IsInUse` is true when either occupant exists.
+
+Dock wrappers are cached for the loaded scene, so a dock reached through a property and an active delivery shares event subscriptions. Resolve wrappers again after a scene or save transition. Events report native state observed by the local peer and do not add a new replication channel.
 
 ## Lifecycle Events
 
@@ -108,6 +139,8 @@ The initial public API therefore supports observation and lookup only. It does n
 - construct an arbitrary delivery;
 - force a delivery status;
 - assign a native delivery vehicle;
+- create, destroy, or mutate a loading dock or its GUID;
+- force dock occupancy, accepting state, transit routing, or outline UI;
 - invoke native delivery UI or network RPCs.
 
 Use supplier configuration to define what a custom supplier sells, then use `NPCSupplier` and `DeliveryRegistry` to observe the resulting orders.
@@ -118,3 +151,4 @@ Use supplier configuration to define what a custom supplier sells, then use `NPC
 - [Delivery Location Registry](delivery-location-registry.md)
 - <xref:S1API.Deliveries.DeliveryRegistry>
 - <xref:S1API.Deliveries.Delivery>
+- <xref:S1API.Deliveries.LoadingDock>


### PR DESCRIPTION
## Summary

- add a cached, read-only S1API loading-dock wrapper with managed property, slot, state, and vehicle surfaces
- expose docks through PropertyWrapper.LoadingDocks and Delivery.LoadingDock
- publish local-peer dynamic/static occupancy and accepting-state transition events from verified native seams
- document lifecycle, authority, collection, and networking semantics

Implementation follows the plan posted before code changes: https://github.com/ifBars/S1API/issues/293#issuecomment-5460105773

Closes #293

## Compatibility

- Source: additive public members only; no existing signatures changed
- Binary: ApiCompat against the exact stable baseline reported no breaking changes
- Behavior: wrappers are observational; no dock mutation, rerouting, transit insertion, or new replication
- Save data: unchanged; no new serialization or migration
- Network: unchanged; events report native state observed by each local peer

## Local validation

- [x] MonoMelon full solution build: 0 warnings, 0 errors
- [x] MonoMelon full test suite: 721 passed
- [x] Il2CppMelon full solution build: 0 warnings, 0 errors
- [x] Il2CppMelon full test suite: 707 passed
- [x] Focused loading-dock contracts: 5 passed on Mono and 5 passed on IL2CPP
- [x] DocFX build: succeeded with 0 errors (4 pre-existing optional-reference warnings)
- [x] Public documentation coverage: 82.30% (3381 / 4108; minimum 80%)
- [x] ApiCompat against stable: no breaking changes
- [x] git diff --check
- [ ] Loaded-save and two-peer live-game smoke matrix

The live-game matrix remains intentionally unchecked: the existing repository smoke harnesses are feature-specific, and no new disposable loading-dock probe was committed just to manufacture runtime evidence. The native transition seams were inspected separately in current Mono and IL2CPP assemblies, while compile/reflection contracts and the complete dual-runtime suites cover the PR locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading dock access through properties and deliveries.
  * Exposed dock identity, occupancy, accepting status, transit slots, and lifecycle state.
  * Added notifications for occupant and accepting-state changes.
  * Added read-only loading dock collections and delivery navigation.

* **Documentation**
  * Documented loading dock properties, events, snapshots, and access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->